### PR TITLE
Add version to cli tool

### DIFF
--- a/examples/test/app/(blog)/blog/my-first-post.tsx
+++ b/examples/test/app/(blog)/blog/my-first-post.tsx
@@ -1,0 +1,5 @@
+import { Text } from 'react-native'
+
+export default function MyFirstPost() {
+  return <Text>My First Post</Text>
+}

--- a/examples/test/app/(marketing)/about.tsx
+++ b/examples/test/app/(marketing)/about.tsx
@@ -1,0 +1,5 @@
+import { Text } from 'react-native'
+
+export default function About() {
+  return <Text>About Our Company</Text>
+}

--- a/examples/test/routes.d.ts
+++ b/examples/test/routes.d.ts
@@ -3,7 +3,7 @@ import type { OneRouter } from 'one'
 declare module 'one' {
   export namespace OneRouter {
     export interface __routes<T extends string = string> extends Record<string, unknown> {
-      StaticRoutes: `/` | `/_sitemap` | `/not-found/test` | `/ssr/basic` | `/sub-page` | `/sub-page/sub` | `/sub-page/sub2`
+      StaticRoutes: `/` | `/(blog)/blog/my-first-post` | `/(marketing)/about` | `/_sitemap` | `/about` | `/blog/my-first-post` | `/not-found/test` | `/ssr/basic` | `/sub-page` | `/sub-page/sub` | `/sub-page/sub2`
       DynamicRoutes: `/not-found/+not-found`
       DynamicRouteTemplate: `/not-found/+not-found`
       IsTyped: true

--- a/packages/create-vxrn/src/create.ts
+++ b/packages/create-vxrn/src/create.ts
@@ -82,7 +82,7 @@ export async function create(args: { template?: string }) {
   await FSExtra.mkdir(resolvedProjectPath)
 
   try {
-    await cloneStarter(template, resolvedProjectPath, projectName)
+    await cloneStarter(template, resolvedProjectPath)
     process.chdir(resolvedProjectPath)
   } catch (e) {
     console.error(`[vxrn] Failed to copy example into ${resolvedProjectPath}\n\n`, e)

--- a/packages/create-vxrn/src/index.ts
+++ b/packages/create-vxrn/src/index.ts
@@ -7,6 +7,8 @@ import path from 'node:path'
 import { cwd } from 'node:process'
 import { getTemplateInfo } from './helpers/getTemplateInfo'
 import { create } from './create'
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
 
 let projectPath = ''
 
@@ -67,8 +69,21 @@ const main = defineCommand({
 
 runMain(main)
 
+function getPackageVersion() {
+  let dirname
+  if (typeof __dirname !== 'undefined') {
+    // CommonJS
+    dirname = __dirname
+  } else {
+    // ESM
+    dirname = path.dirname(fileURLToPath(import.meta.url))
+  }
+  const packagePath = path.join(dirname, '..', '..', 'package.json')
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf-8'))
+  return packageJson.version
+}
+
 if (process.argv.includes('--version')) {
-  // TODO
-  // console.info(packageJson.version)
+  console.info(getPackageVersion())
   process.exit(0)
 }

--- a/packages/create-vxrn/src/steps/one.ts
+++ b/packages/create-vxrn/src/steps/one.ts
@@ -25,4 +25,8 @@ export const preInstall: ExtraSteps = async ({ projectName, packageManager, proj
   if (packageManager === 'pnpm') {
     await FSExtra.writeFile(join(projectPath, `.npmrc`), `node-linker=hoisted\n`)
   }
+  if (packageManager === 'yarn') {
+    await FSExtra.writeFile(join(projectPath, 'yarn.lock'), '')
+    console.info(`Created empty yarn.lock file`)
+  }
 }

--- a/packages/one/src/cli.ts
+++ b/packages/one/src/cli.ts
@@ -1,13 +1,31 @@
 import { defineCommand, runMain } from 'citty'
 import { loadEnv } from './vite/loadEnv'
-// import packageJson from 'one/package.json' with { type: 'json' }
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function getPackageVersion() {
+  let dirname
+  if (typeof __dirname !== 'undefined') {
+    // CommonJS
+    dirname = __dirname
+  } else {
+    // ESM
+    dirname = path.dirname(fileURLToPath(import.meta.url))
+  }
+  const packagePath = path.join(dirname, '..', '..', 'package.json')
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf-8'))
+  return packageJson.version
+}
+
+const version = getPackageVersion()
 
 void loadEnv(process.cwd())
 
 const dev = defineCommand({
   meta: {
     name: 'dev',
-    // version: packageJson.version,
+    version: version,
     description: 'Start the dev server',
   },
   args: {
@@ -33,7 +51,7 @@ const dev = defineCommand({
 const buildCommand = defineCommand({
   meta: {
     name: 'build',
-    version: '0.0.0',
+    version: version,
     description: 'Build your app',
   },
   args: {
@@ -58,7 +76,7 @@ const buildCommand = defineCommand({
 const serveCommand = defineCommand({
   meta: {
     name: 'serve',
-    version: '0.0.0',
+    version: version,
     description: 'Serve a built app for production',
   },
   args: {
@@ -93,7 +111,7 @@ const serveCommand = defineCommand({
 const prebuild = defineCommand({
   meta: {
     name: 'prebuild',
-    version: '0.0.0',
+    version: version,
     description: 'Prebuild native iOS project', // TODO: Android
   },
   args: {},
@@ -121,8 +139,8 @@ const clean = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'main',
-    version: '0.0.0',
-    description: 'Welcome to vxrn',
+    version: version,
+    description: 'Welcome to One',
   },
   args: {},
   async run({ args }) {

--- a/packages/one/test/routing.test.ts
+++ b/packages/one/test/routing.test.ts
@@ -46,6 +46,18 @@ const runTests = (environment: 'dev' | 'prod') => {
         const response = await fetch(`${serverUrl}/not-found/non-existent-route`)
         expect(response.status).toBe(404)
       })
+
+      it('should render page from inside a group', async () => {
+        const response = await fetch(`${serverUrl}/about`)
+        const html = await response.text()
+        expect(html).toContain('About Our Company')
+      })
+
+      it('should render page from subdir when parent group name is the same', async () => {
+        const response = await fetch(`${serverUrl}/blog/my-first-post`)
+        const html = await response.text()
+        expect(html).toContain('My First Post')
+      })
     })
   })
 }


### PR DESCRIPTION
- adds version output
- adds blank yarn.lock for yarn users on pre-install
- bonus: adds a test for (group) file-system routing, as I briefly saw an error there, but tests pass.