### PR TITLE
[examples] dependencies with native code should be explicitly listed in package.json for native to work properly

### DIFF
--- a/examples/one-basic/package.json
+++ b/examples/one-basic/package.json
@@ -19,6 +19,8 @@
     "one": "1.1.299",
     "react": "^18.3.1",
     "react-native": "0.74.1",
+    "react-native-safe-area-context": "^4.10.1",
+    "react-native-screens": "3.31.1",
     "react-native-web": "^0.19.12"
   },
   "devDependencies": {

--- a/examples/one-tamagui/package.json
+++ b/examples/one-tamagui/package.json
@@ -30,6 +30,7 @@
     "react": "^18.3.1",
     "react-native": "0.74.1",
     "react-native-reanimated": "~3.10.1",
+    "react-native-safe-area-context": "^4.10.1",
     "react-native-screens": "3.31.1",
     "react-native-svg": "15.2.0",
     "react-native-web": "^0.19.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12360,6 +12360,8 @@ __metadata:
     one: "npm:1.1.299"
     react: "npm:^18.3.1"
     react-native: "npm:0.74.1"
+    react-native-safe-area-context: "npm:^4.10.1"
+    react-native-screens: "npm:3.31.1"
     react-native-web: "npm:^0.19.12"
     vite: "npm:6.0.0-beta.1"
   languageName: unknown
@@ -12444,6 +12446,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-native: "npm:0.74.1"
     react-native-reanimated: "npm:~3.10.1"
+    react-native-safe-area-context: "npm:^4.10.1"
     react-native-screens: "npm:3.31.1"
     react-native-svg: "npm:15.2.0"
     react-native-web: "npm:^0.19.12"


### PR DESCRIPTION
Since `one` is depending on `@react-navigation/native` and `@react-navigation/native` is depending on `react-native-screens` and `react-native-safe-area-context` which have native dependencies. See: https://reactnavigation.org/docs/7.x/getting-started#installing-dependencies-into-a-bare-react-native-project.

Can fix #133.