### PR TITLE
feat: provide `one run:ios` to avoid confusion

### DIFF
--- a/packages/one/src/cli.ts
+++ b/packages/one/src/cli.ts
@@ -121,6 +121,30 @@ const prebuild = defineCommand({
   },
 })
 
+const runIos = defineCommand({
+  meta: {
+    name: 'run:ios',
+    version: version,
+  },
+  args: {},
+  async run({ args }) {
+    const { run } = await import('./cli/runIos')
+    await run(args)
+  },
+})
+
+const runAndroid = defineCommand({
+  meta: {
+    name: 'run:ios',
+    version: version,
+  },
+  args: {},
+  async run({ args }) {
+    const { run } = await import('./cli/runAndroid')
+    await run(args)
+  },
+})
+
 const clean = defineCommand({
   meta: {
     name: 'clean',
@@ -144,7 +168,7 @@ const main = defineCommand({
   },
   args: {},
   async run({ args }) {
-    if (['clean', 'prebuild'].includes(args._[0])) {
+    if (['clean', 'prebuild', 'run:ios', 'run:android'].includes(args._[0])) {
       // IDK why we're getting into here after a subcommand has been run
       return
     }
@@ -157,6 +181,8 @@ const main = defineCommand({
     clean,
     build: buildCommand,
     prebuild,
+    'run:ios': runIos,
+    'run:android': runAndroid,
     serve: serveCommand,
   },
 })

--- a/packages/one/src/cli/runAndroid.ts
+++ b/packages/one/src/cli/runAndroid.ts
@@ -1,0 +1,6 @@
+export async function run(args: {}) {
+  const { runAndroid } = await import('vxrn')
+  await runAndroid({
+    root: process.cwd(),
+  })
+}

--- a/packages/one/src/cli/runIos.ts
+++ b/packages/one/src/cli/runIos.ts
@@ -1,0 +1,6 @@
+export async function run(args: {}) {
+  const { runIos } = await import('vxrn')
+  await runIos({
+    root: process.cwd(),
+  })
+}

--- a/packages/one/types/cli/runAndroid.d.ts
+++ b/packages/one/types/cli/runAndroid.d.ts
@@ -1,0 +1,2 @@
+export declare function run(args: {}): Promise<void>;
+//# sourceMappingURL=runAndroid.d.ts.map

--- a/packages/one/types/cli/runIos.d.ts
+++ b/packages/one/types/cli/runIos.d.ts
@@ -1,0 +1,2 @@
+export declare function run(args: {}): Promise<void>;
+//# sourceMappingURL=runIos.d.ts.map

--- a/packages/vxrn/src/cli.ts
+++ b/packages/vxrn/src/cli.ts
@@ -1,6 +1,8 @@
 import { defineCommand, runMain } from 'citty'
 import type { dev as devFn } from './exports/dev'
 import type { prebuild as prebuildFn } from './exports/prebuild'
+import type { runIos as runIosFn } from './exports/runIos'
+import type { runAndroid as runAndroidFn } from './exports/runAndroid'
 
 const dev = defineCommand({
   meta: {
@@ -152,6 +154,42 @@ const prebuild = defineCommand({
   },
 })
 
+const runIos = defineCommand({
+  meta: {
+    name: 'run:ios',
+    version: '0.0.0',
+  },
+  args: {},
+  async run() {
+    const imported = await import(
+      // @ts-expect-error
+      './exports/runIos.mjs'
+    )
+    const runIos = imported.runIos as typeof runIosFn
+    const root = process.cwd()
+
+    await runIos({ root })
+  },
+})
+
+const runAndroid = defineCommand({
+  meta: {
+    name: 'run:android',
+    version: '0.0.0',
+  },
+  args: {},
+  async run() {
+    const imported = await import(
+      // @ts-expect-error
+      './exports/runAndroid.mjs'
+    )
+    const runAndroid = imported.runAndroid as typeof runAndroidFn
+    const root = process.cwd()
+
+    await runAndroid({ root })
+  },
+})
+
 const clean = defineCommand({
   meta: {
     name: 'clean',
@@ -181,6 +219,8 @@ const main = defineCommand({
     build,
     serve,
     prebuild,
+    runIos,
+    runAndroid,
     clean,
   },
 })

--- a/packages/vxrn/src/exports/prebuild.ts
+++ b/packages/vxrn/src/exports/prebuild.ts
@@ -24,6 +24,18 @@ export const prebuild = async ({ root }: { root: string }) => {
       'react,react-native,expo',
     ])
 
+    try {
+      const packageJsonPath = path.join(root, 'package.json')
+      let packageJsonContents = await FSExtra.readFile(packageJsonPath, 'utf8')
+
+      packageJsonContents = packageJsonContents.replace(/expo run:ios/g, 'one run:ios')
+      packageJsonContents = packageJsonContents.replace(/expo run:android/g, 'one run:android')
+
+      await FSExtra.writeFile(packageJsonPath, packageJsonContents, 'utf8')
+    } catch (error) {
+      console.error('Error updating package.json', error)
+    }
+
     // Remove the ios/.xcode.env.local file as it's causing problems `node: No such file or directory` during build
     try {
       FSExtra.removeSync(path.join(root, 'ios', '.xcode.env.local'))

--- a/packages/vxrn/src/exports/runAndroid.ts
+++ b/packages/vxrn/src/exports/runAndroid.ts
@@ -1,0 +1,6 @@
+import { expoRun } from '../utils/expoRun'
+
+export const runAndroid = async ({ root }: { root: string }) => {
+  console.info('› one run:android')
+  return await expoRun({ root, platform: 'android' })
+}

--- a/packages/vxrn/src/exports/runIos.ts
+++ b/packages/vxrn/src/exports/runIos.ts
@@ -1,0 +1,6 @@
+import { expoRun } from '../utils/expoRun'
+
+export const runIos = async ({ root }: { root: string }) => {
+  console.info('› one run:ios')
+  return await expoRun({ root, platform: 'ios' })
+}

--- a/packages/vxrn/src/index.ts
+++ b/packages/vxrn/src/index.ts
@@ -2,6 +2,8 @@ export { build } from './exports/build'
 export { dev } from './exports/dev'
 export { serve } from './exports/serve'
 export { prebuild } from './exports/prebuild'
+export { runIos } from './exports/runIos'
+export { runAndroid } from './exports/runAndroid'
 export { clean } from './exports/clean'
 
 export { type VXRNOptionsFilled, getOptionsFilled, fillOptions } from './utils/getOptionsFilled'

--- a/packages/vxrn/src/utils/expoRun.ts
+++ b/packages/vxrn/src/utils/expoRun.ts
@@ -1,0 +1,27 @@
+import module from 'node:module'
+import { fillOptions } from '../utils/getOptionsFilled'
+import { applyBuiltInPatches } from '../utils/patches'
+
+export async function expoRun({ root, platform }: { root: string; platform: 'ios' | 'android' }) {
+  const options = await fillOptions({ root })
+
+  applyBuiltInPatches(options).catch((err) => {
+    console.error(`\n 🥺 error applying built-in patches`, err)
+  })
+
+  try {
+    // Import Expo from the user's project instead of from where vxrn is installed, since vxrn may be installed globally or at the root workspace.
+    const require = module.createRequire(root)
+    const importPath = require.resolve(`@expo/cli/build/src/run/${platform}/index.js`, {
+      paths: [root],
+    })
+    const expoRun = (await import(importPath)).default[
+      `expoRun${platform.charAt(0).toUpperCase() + platform.slice(1)}`
+    ]
+    await expoRun([
+      '--no-bundler', // Do not start the Metro bundler automatically
+    ])
+  } catch (e) {
+    console.error(`Failed to run native project: ${e}\nIs "expo" listed in your dependencies?`)
+  }
+}

--- a/packages/vxrn/types/exports/runAndroid.d.ts
+++ b/packages/vxrn/types/exports/runAndroid.d.ts
@@ -1,0 +1,4 @@
+export declare const runAndroid: ({ root }: {
+    root: string;
+}) => Promise<void>;
+//# sourceMappingURL=runAndroid.d.ts.map

--- a/packages/vxrn/types/exports/runIos.d.ts
+++ b/packages/vxrn/types/exports/runIos.d.ts
@@ -1,0 +1,4 @@
+export declare const runIos: ({ root }: {
+    root: string;
+}) => Promise<void>;
+//# sourceMappingURL=runIos.d.ts.map

--- a/packages/vxrn/types/index.d.ts
+++ b/packages/vxrn/types/index.d.ts
@@ -2,6 +2,8 @@ export { build } from './exports/build';
 export { dev } from './exports/dev';
 export { serve } from './exports/serve';
 export { prebuild } from './exports/prebuild';
+export { runIos } from './exports/runIos';
+export { runAndroid } from './exports/runAndroid';
 export { clean } from './exports/clean';
 export { type VXRNOptionsFilled, getOptionsFilled, fillOptions } from './utils/getOptionsFilled';
 export * from './utils/getOptimizeDeps';

--- a/packages/vxrn/types/utils/expoRun.d.ts
+++ b/packages/vxrn/types/utils/expoRun.d.ts
@@ -1,0 +1,5 @@
+export declare function expoRun({ root, platform }: {
+    root: string;
+    platform: 'ios' | 'android';
+}): Promise<void>;
+//# sourceMappingURL=expoRun.d.ts.map


### PR DESCRIPTION
Can resolve confusing situations such as #124.