### PR TITLE
add NATIVE_PROD_MODE env for simulating production bundle on development server

### DIFF
--- a/packages/vxrn/src/exports/dev.ts
+++ b/packages/vxrn/src/exports/dev.ts
@@ -131,7 +131,13 @@ export const dev = async (optionsIn: DevOptions) => {
           return cachedReactNativeBundle
         }
 
-        const builtBundle = await getReactNativeBundle(options)
+        let mode: 'dev' | 'prod' = 'dev' as const
+        if (process.env.NATIVE_PROD_MODE) {
+          console.info('`NATIVE_PROD_MODE` env is set, serving production bundle')
+          mode = 'prod'
+        }
+
+        const builtBundle = await getReactNativeBundle(options, { mode })
         cachedReactNativeBundle = builtBundle
         if (process.env.UNSTABLE_BUNDLE_CACHE && !!process.env.VXRN_DISABLE_CACHE) {
           // do not await cache write


### PR DESCRIPTION
```bash
NATIVE_PROD_MODE=true yarn dev
```

Note: this is not 100% the same as the release app since we can't simulate the JS runtime in release this way.