### PR TITLE
Fix import.meta.env check

### DIFF
--- a/packages/one/src/createHandleRequest.ts
+++ b/packages/one/src/createHandleRequest.ts
@@ -22,7 +22,7 @@ export function createHandleRequest(
     handleAPI?: (props: RequestHandlerProps) => Promise<any>
   }
 ) {
-  if (import.meta.env) {
+  if (!import.meta.env) {
     throw new Error(`No import.meta.env - Node 22 or greater required.`)
   }
 


### PR DESCRIPTION
This pull request fixes a `import.meta.env` check on startup.

The bug was found and tested with `npx one` using Bun v1.1.30.