### PR TITLE
fix: prebuilt react not patched correctly

### DIFF
--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -100,8 +100,8 @@ export async function buildReact(options: BuildOptions = {}) {
     const run = () => {
       ${bundled
         .replace(
-          `module.exports = require_react_development();`,
-          `return require_react_development();`
+          /module\.exports = require_react_development(\d*)\(\);/,
+          'return require_react_development$1();'
         )
         .replace(
           `module.exports = require_react_production_min();`,

--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -104,8 +104,8 @@ export async function buildReact(options: BuildOptions = {}) {
           'return require_react_development$1();'
         )
         .replace(
-          `module.exports = require_react_production_min();`,
-          `return require_react_production_min();`
+          /module\.exports = require_react_production_min(\d*)\(\);/,
+          'return require_react_production_min$1();'
         )
         .replace(`process.env.VXRN_REACT_19`, 'false')
         .replace(`Object.assign(exports, eval("require('@vxrn/vendor/react-19')"));`, ``)}


### PR DESCRIPTION
For some reason it becomes `module.exports = require_react_development2();` instead of `module.exports = require_react_development();`. This update ensures both (and any other number) will be correctly patched.