### PR TITLE
basic debug log setup + debug logging for vxrn:auto-pre-bundle-deps-for-ssr

### DIFF
--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -58,6 +58,7 @@
     "@vxrn/vite-native-swc": "1.1.325",
     "citty": "^0.1.6",
     "crossws": "^0.2.4",
+    "debug": "^4.3.7",
     "env-editor": "^1.1.0",
     "es-module-lexer": "^1.3.0",
     "esbuild": "^0.24.0",
@@ -84,6 +85,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@tamagui/build": "^1.116.7",
+    "@types/debug": "^4",
     "@types/find-node-modules": "^2.1.2",
     "@types/node": "^22.1.0",
     "@types/qrcode-terminal": "^0",

--- a/packages/vxrn/src/utils/createDebugger.ts
+++ b/packages/vxrn/src/utils/createDebugger.ts
@@ -1,0 +1,44 @@
+import debug from 'debug'
+
+interface DebuggerOptions {
+  onlyWhenFocused?: boolean | string
+}
+
+export type VxrnDebugScope = `vxrn:${string}`
+
+const DEBUG = process.env.DEBUG
+
+/**
+ * This is like `createDebugger()` in the Vite source code ([see](https://github.com/vitejs/vite/blob/v6.0.0-beta.5/packages/vite/src/node/utils.ts#L163)),
+ * but some of its features are not supported yet to keeps things simple.
+ */
+export function createDebugger(
+  namespace: VxrnDebugScope | undefined,
+  options: DebuggerOptions = {}
+): (debug.Debugger['log'] & { namespace: VxrnDebugScope }) | undefined {
+  if (!namespace) return
+
+  const log = debug(namespace)
+  const { onlyWhenFocused } = options
+
+  let enabled = log.enabled
+  if (enabled && onlyWhenFocused) {
+    const ns = typeof onlyWhenFocused === 'string' ? onlyWhenFocused : namespace
+    enabled = !!DEBUG?.includes(ns)
+  }
+
+  // Not supported for now
+  const filter = undefined
+
+  if (enabled) {
+    const fn = (...args: [string, ...any[]]) => {
+      if (!filter || args.some((a) => a?.includes?.(filter))) {
+        log(...args)
+      }
+    }
+
+    fn.namespace = namespace
+
+    return fn
+  }
+}

--- a/packages/vxrn/types/utils/createDebugger.d.ts
+++ b/packages/vxrn/types/utils/createDebugger.d.ts
@@ -1,0 +1,14 @@
+import debug from 'debug';
+interface DebuggerOptions {
+    onlyWhenFocused?: boolean | string;
+}
+export type VxrnDebugScope = `vxrn:${string}`;
+/**
+ * This is like `createDebugger()` in the Vite source code ([see](https://github.com/vitejs/vite/blob/v6.0.0-beta.5/packages/vite/src/node/utils.ts#L163)),
+ * but some of its features are not supported yet to keeps things simple.
+ */
+export declare function createDebugger(namespace: VxrnDebugScope | undefined, options?: DebuggerOptions): (debug.Debugger['log'] & {
+    namespace: VxrnDebugScope;
+}) | undefined;
+export {};
+//# sourceMappingURL=createDebugger.d.ts.map

--- a/yarn.lock
+++ b/yarn.lock
@@ -7657,7 +7657,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0":
+"@types/debug@npm:^4, @types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
   dependencies:
@@ -10545,7 +10545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6, debug@npm:^4.3.7":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
   dependencies:
@@ -21967,6 +21967,7 @@ __metadata:
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
     "@tamagui/build": "npm:^1.116.7"
     "@tamagui/react-native-svg": "npm:^1.116.7"
+    "@types/debug": "npm:^4"
     "@types/find-node-modules": "npm:^2.1.2"
     "@types/node": "npm:^22.1.0"
     "@types/qrcode-terminal": "npm:^0"
@@ -21982,6 +21983,7 @@ __metadata:
     "@vxrn/vite-native-swc": "npm:1.1.325"
     citty: "npm:^0.1.6"
     crossws: "npm:^0.2.4"
+    debug: "npm:^4.3.7"
     depcheck: "npm:^1.4.7"
     env-editor: "npm:^1.1.0"
     es-module-lexer: "npm:^1.3.0"


### PR DESCRIPTION
(Inspired by the Vite source code, powered by the [`debug`](https://www.npmjs.com/package/debug) package which is also used by Vite.)

## Example Usage

```bash
DEBUG=vxrn:* yarn dev --clean
```

![](https://github.com/user-attachments/assets/7d1a8340-dfed-41c1-83cd-2a703a2d2d50)

```bash
DEBUG=vxrn:auto-pre-bundle-deps-for-ssr yarn dev --clean
```

![](https://github.com/user-attachments/assets/2277735f-4399-46f0-8fbb-27df5978bd63)

> [!NOTE]  
> Other debug logs are printed since old code are not migrated and they will print debug messages just if the keyword `"vxrn"` is included in `DEBUG`.