### PR TITLE
fix: `the symbol "RefreshRuntime" has already been declared`

### DIFF
--- a/packages/vite-native-swc/src/index.ts
+++ b/packages/vite-native-swc/src/index.ts
@@ -380,6 +380,11 @@ function wrapSourceInRefreshRuntime(id: string, code: string, options: Options) 
     `
   }
 
+  if (code.includes('RefreshRuntime = __cachedModules')) {
+    console.warn('[wrapSourceInRefreshRuntime] detected refresh runtime already in code, skipping')
+    return code
+  }
+
   return `const RefreshRuntime = __cachedModules["react-refresh/cjs/react-refresh-runtime.development"];
 const prevRefreshReg = globalThis.$RefreshReg$;
 const prevRefreshSig = globalThis.$RefreshSig$ || (() => {

--- a/packages/vxrn/src/utils/getReactNativeConfig.ts
+++ b/packages/vxrn/src/utils/getReactNativeConfig.ts
@@ -151,6 +151,7 @@ export async function getReactNativeConfig(
 
               const output = await swcTransform(id, code, {
                 mode: mode === 'dev' ? 'serve' : 'build',
+                noHMR: true, // We should not insert HMR runtime code at this stage, as we expect another plugin (e.g. vite:react-swc) to handle that. Inserting it here may cause error: `The symbol "RefreshRuntime" has already been declared`.
               })
 
               if (!output) return null


### PR DESCRIPTION
Context: https://discord.com/channels/1223009626400751671/1307758091533553676/1308884903362039880

Encountered error during dever server building an RN bundle, while using `@stytch/react-native` (`react-native-country-codes-picker` actually):

```
x Build failed in 3.67s
 Error building React Native bundle: Error: [commonjs--resolver] Transform failed with 3 errors:
/Users/matthewwall/Downloads/pygmy/node_modules/react-native-country-codes-picker/index.tsx:21:4: ERROR: The symbol "RefreshRuntime" has already been declared
/Users/matthewwall/Downloads/pygmy/node_modules/react-native-country-codes-picker/index.tsx:22:4: ERROR: The symbol "prevRefreshReg" has already been declared
/Users/matthewwall/Downloads/pygmy/node_modules/react-native-country-codes-picker/index.tsx:23:4: ERROR: The symbol "prevRefreshSig" has already been declared
file: /Users/matthewwall/Downloads/pygmy/node_modules/@stytch/react-native/dist/index.js:21:4

The symbol "RefreshRuntime" has already been declared
19 |  
20 |  var _s = $RefreshSig$(), _s1 = $RefreshSig$();
21 |  var RefreshRuntime = __cachedModules["react-refresh/cjs/react-refresh-runtime.development"];
   |      ^
22 |  var prevRefreshReg = globalThis.$RefreshReg$;
23 |  var prevRefreshSig = globalThis.$RefreshSig$ || function() {

The symbol "prevRefreshReg" has already been declared
20 |  var _s = $RefreshSig$(), _s1 = $RefreshSig$();
21 |  var RefreshRuntime = __cachedModules["react-refresh/cjs/react-refresh-runtime.development"];
22 |  var prevRefreshReg = globalThis.$RefreshReg$;
   |      ^
23 |  var prevRefreshSig = globalThis.$RefreshSig$ || function() {
24 |      console.info("no react refresh setup!");

The symbol "prevRefreshSig" has already been declared
21 |  var RefreshRuntime = __cachedModules["react-refresh/cjs/react-refresh-runtime.development"];
22 |  var prevRefreshReg = globalThis.$RefreshReg$;
23 |  var prevRefreshSig = globalThis.$RefreshSig$ || function() {
   |      ^
24 |      console.info("no react refresh setup!");
25 |      return function(x) {
```

`vite:react-swc` transforms the code using the `swcTransform` function. And `one-node-module-transforms` also transforms the code using the `swcTransform` function, starting from commit `e4e724a`, causing multiple `const RefreshRuntime` stuff being inserted.