### PR TITLE
fix: wait until patches are applied before starting other stuff

### DIFF
--- a/packages/vxrn/src/exports/dev.ts
+++ b/packages/vxrn/src/exports/dev.ts
@@ -25,7 +25,7 @@ export const dev = async (optionsIn: DevOptions) => {
     await clean(optionsIn)
   }
 
-  applyBuiltInPatches(options).catch((err) => {
+  await applyBuiltInPatches(options).catch((err) => {
     console.error(`\n 🥺 error applying built-in patches`, err)
   })
 

--- a/packages/vxrn/src/exports/patch.ts
+++ b/packages/vxrn/src/exports/patch.ts
@@ -7,7 +7,7 @@ export type DevOptions = VXRNOptions & { clean?: boolean }
 export const patch = async (optionsIn: DevOptions) => {
   const options = await fillOptions(optionsIn)
 
-  applyBuiltInPatches(options).catch((err) => {
+  await applyBuiltInPatches(options).catch((err) => {
     console.error(`\n 🥺 error applying built-in patches`, err)
   })
 }


### PR DESCRIPTION
Might be slower? But it can avoid Vite dep optimizing errors while Vite starts to pre-bundle things before all patches are applied. Such as:

![](https://github.com/user-attachments/assets/a82fe81f-e16d-4892-9e10-3932aee4b6ba)