### PR TITLE
feat: support user defined global constant replacements in RN

### DIFF
--- a/packages/vxrn/src/utils/getReactNativeConfig.ts
+++ b/packages/vxrn/src/utils/getReactNativeConfig.ts
@@ -276,6 +276,16 @@ export async function getReactNativeConfig(
   // // this fixes my swap-react-native plugin not being called pre 😳
   resolvedConfig = await resolveConfig(nativeBuildConfig, 'build')
 
+  // The `resolveConfig` function will load user's `vite.config.*` (by calling `loadConfigFromFile`).
+  // Here we do this to make user defined global constant replacements (https://vite.dev/config/shared-options#define) to take effect in RN.
+  // TODO: Ultimately, we should make all the user defined config options to take effect in RN.
+  if (resolvedConfig.define) {
+    nativeBuildConfig.define = {
+      ...nativeBuildConfig.define,
+      ...resolvedConfig.define,
+    }
+  }
+
   return nativeBuildConfig satisfies UserConfig
 }
 


### PR DESCRIPTION
This is also part of the work for making a workaround for #252 possible.

Note: the final `define` will be like this, and I think there're no defines that aren't suitable to be defined on native:

```json
{
  "process.env.NODE_ENV": "\"development\"",
  "process.env.ONE_SERVER_URL": "\"http://0.0.0.0:8081\"",
  "process.env.ONE_DEFAULT_RENDER_MODE": "\"ssg\"",
  "import.meta.env.ONE_DEFAULT_RENDER_MODE": "\"ssg\"",
  "import.meta.env.ONE_SERVER_URL": "\"http://0.0.0.0:8081\"",
  "process.env.TAMAGUI_REACT_19": "\"1\"",
  "process.env.ONE_CACHE_KEY": "\"52577802\"",
  "import.meta.env.ONE_CACHE_KEY": "\"52577802\""
}
```