### PR TITLE
fix(react-native-prebuilt): broken react native due to exports not being lazy loaded

### DIFF
--- a/packages/vxrn/react-native-template.js
+++ b/packages/vxrn/react-native-template.js
@@ -123,7 +123,7 @@ function getRequire(importer, importsMap, _mod) {
 
 ${JSON.stringify(importsMap, null, 2)}
 
-${process.env.DEBUG?.startsWith('tamagui') ? debugExtraDetail : ''}
+${/* process.env.DEBUG?.startsWith('tamagui') ? debugExtraDetail : '' // Will break Android: property 'process' doesn't exist */ ''}
 
 ${
   withStack

--- a/packages/vxrn/react-native-template.js
+++ b/packages/vxrn/react-native-template.js
@@ -75,7 +75,7 @@ function __getRequire(absPath, parent) {
 }
 
 const __specialRequireMap = globalThis.__vxrnPrebuildSpecialRequireMap || {
-  'react-native': '.vxrn/react-native.js',
+  'react-native': `.vxrn/react-native.${__VXRN_PLATFORM__.toLowerCase()}.js`,
   react: '.vxrn/react.js',
   'react/jsx-runtime': '.vxrn/react-jsx-runtime.js',
   'react/jsx-dev-runtime': '.vxrn/react-jsx-runtime.js',

--- a/packages/vxrn/react-native-template.js
+++ b/packages/vxrn/react-native-template.js
@@ -14,8 +14,6 @@ global['module'] = {}
 global['__DEV__'] = process.env.__DEV__
 global['___modules___'] = {}
 global['___vxrnAbsoluteToRelative___'] = {}
-// to avoid it looking like browser...
-delete globalThis['window']
 
 global['Event'] =
   global['Event'] ||

--- a/packages/vxrn/src/utils/getReactNativeBundle.ts
+++ b/packages/vxrn/src/utils/getReactNativeBundle.ts
@@ -177,7 +177,10 @@ __require("${id}")
     // TEMP FIX for router tamagui thing since expo router 3 upgrade
     .replaceAll('dist/esm/index.mjs"', 'dist/esm/index.js"')
 
-  const template = await getReactNativeTemplate(internal.mode || 'dev')
+  const template = (await getReactNativeTemplate(internal.mode || 'dev')).replaceAll(
+    '__VXRN_PLATFORM__',
+    `"${platform}"`
+  )
 
   const out = template + appCode
 


### PR DESCRIPTION
React Native [lazy loads exports](https://github.com/facebook/react-native/blob/v0.76.0/packages/react-native/index.js#L102) like this:

```js
module.exports = {
  get Button(): Button {
    return require('./Libraries/Components/Button').default;
  },
  get FlatList(): FlatList {
    return require('./Libraries/Lists/FlatList');
  },
  get Image(): Image {
    return require('./Libraries/Image/Image');
  },
  get Modal(): Modal {
    return require('./Libraries/Modal/Modal');
  },
  // ...
}
```

But we do [this](https://github.com/onejs/one/blob/v1.1.334/packages/react-native-prebuilt/src/index.ts#L233), which produces:

```js
var RN = run();
var Button = RN.Button;
var FlatList = RN.FlatList;
var Image = RN.Image;
var Modal = RN.Modal;
```

Which calls all the getter functions and forces the code to be loaded immediately - and might break things since some RN globals may not be initialized at that time.

Things work [by coincidence](https://github.com/facebook/react-native/blob/v0.74.6/packages/react-native/Libraries/Components/ScrollView/ScrollView.js#L52-L54) on iOS with `react-native` v0.74 and v0.75, but will break with v0.76 or on Android.