### PR TITLE
fix: error in minimal example

### DIFF
--- a/examples/one-basic/package.json
+++ b/examples/one-basic/package.json
@@ -19,6 +19,7 @@
     "one": "1.1.334",
     "react": "^18.3.1",
     "react-native": "0.74.5",
+    "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
     "react-native-web": "^0.19.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11958,6 +11958,7 @@ __metadata:
     one: "npm:1.1.334"
     react: "npm:^18.3.1"
     react-native: "npm:0.74.5"
+    react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.5"
     react-native-screens: "npm:3.31.1"
     react-native-web: "npm:^0.19.12"


### PR DESCRIPTION
# Why 

When I created a minimal example via a CLI locally, it didn't work because it was missing a dependency.  

`@react-navigation/drawer` relies on `reanimated`. it works on onejs locally because reanimated is already exists in its node_modules.

![CleanShot 2024-12-05 at 09 33 16@2x](https://github.com/user-attachments/assets/360f468c-f833-4ea2-8307-900be94e9051)

# How  

Run `npx expo install react-native-reanimated` and add `react-native-reanimated` dependency to `one-basic`.


