### PR TITLE
 fix: search input color

### DIFF
--- a/apps/onestack.dev/features/search/DocSearch.tsx
+++ b/apps/onestack.dev/features/search/DocSearch.tsx
@@ -23,12 +23,12 @@ font-family: sans-serif;
 .DocSearch {
   --docsearch-primary-color: var(--colorPress);
   --docsearch-highlight-color: var(--color);
-  --docsearch-text-color: var(--colorHover);
+  --docsearch-text-color: var(--color);
   --docsearch-modal-background: var(--background);
   --docsearch-searchbox-shadow: none;
   --docsearch-searchbox-background: transparent;
   --docsearch-searchbox-focus-background: transparent;
-  --docsearch-hit-color: var(--colorHover);
+  --docsearch-hit-color: var(--color);
   --docsearch-muted-color: var(--colorFocus);
   --docsearch-logo-color: var(--colorPress);
   --docsearch-footer-background: transparent;


### PR DESCRIPTION
# Why 

When manually change theme, the input color will be invisible.


https://github.com/user-attachments/assets/b67bcf63-938b-4f11-be10-1bfe77b66b3f

# How

seems it's due to `--colorHover` being missing on the docs website's css, not sure which color should be used exactly. I think we could just use `--color` instead. 



## After 

https://github.com/user-attachments/assets/76a1296c-c624-45e0-aaf3-4bcde80d37f5
