### PR TITLE
React Native lazy imports

### DIFF
--- a/next.md
+++ b/next.md
@@ -20,6 +20,8 @@
 
 - react-native-web-lite proper release
 
+- // TEMP FIX can likely go away
+
 - need a way ton configure the api + server etc during production builds
 
 - style tag to CSS, we could have a mode that takes style tags with precedense/key set and have a mode to optimize that to css

--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -233,6 +233,7 @@ return mod
             `const rn = require_react_native();`,
             `rn.AssetRegistry = require_registry();`,
             `require_ReactNative();`, // This is react-native/Libraries/Renderer/shims/ReactNative.js, we call it here to ensure shims are initialized since we won't lazy load React Native components. See the NOTE below.
+            `if (typeof require_InitializeCore === 'function') { require_InitializeCore(); }`, // Since we're accessing the RefreshRuntime directly via `__cachedModules` directly in the RN bundle, we need to ensure it's loaded in time. Note that calling `require_react_refresh_runtime_development()`, `require_setUpReactRefresh()` or `require_setUpDeveloperTools()` directly won't work.
             `return rn;`,
           ].join('\n')
         )}

--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -240,7 +240,9 @@ return mod
     }
     const RN = run()
 
+    export const REACT_NATIVE_ESM_MANUAL_EXPORTS_START = 'REACT_NATIVE_ESM_MANUAL_EXPORTS_START';${/* NOTE: The `REACT_NATIVE_ESM_MANUAL_EXPORTS_*` vars here are used by other tools to replace exports in this section with a CJS `module.export` which supports dynamic loaded lazy exports, if CJS can be used - such as in a React Native bundle. */ ''}
     ${RNExportNames.map((n) => `export const ${n} = RN.${n}`).join('\n') /* NOTE: React Native exports are designed to be lazy loaded (see: https://github.com/facebook/react-native/blob/v0.77.0-rc.0/packages/react-native/index.js#L106), but while doing so we're calling all the exported getters immediately and executing all the modules at once. */}
+    export const REACT_NATIVE_ESM_MANUAL_EXPORTS_END = 'REACT_NATIVE_ESM_MANUAL_EXPORTS_END';
     `
     await FSExtra.writeFile(options.outfile!, outCode)
   })

--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -11,16 +11,6 @@ const requireResolve =
 
 const external = ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime']
 
-export async function buildAll() {
-  console.info(`Prebuilding React Native (one time cost...)`)
-  await Promise.all([
-    //
-    buildReactJSX(),
-    buildReact(),
-    buildReactNative(),
-  ])
-}
-
 export async function buildReactJSX(options: BuildOptions = {}) {
   return build({
     bundle: true,

--- a/packages/react-native-prebuilt/types/index.d.ts
+++ b/packages/react-native-prebuilt/types/index.d.ts
@@ -1,5 +1,4 @@
 import { type BuildOptions } from 'esbuild';
-export declare function buildAll(): Promise<void>;
 export declare function buildReactJSX(options?: BuildOptions): Promise<void>;
 export declare function buildReact(options?: BuildOptions): Promise<void>;
 export declare function buildReactNative(options: BuildOptions | undefined, { platform }: {

--- a/packages/vxrn/expo-js-native-debugging-plugin.cjs
+++ b/packages/vxrn/expo-js-native-debugging-plugin.cjs
@@ -22,44 +22,13 @@ const plugin = (config, options = {}) => {
       [
         'ios',
         async (config) => {
-          const { rctJsNativeDebuggingHFilePath, rctJsNativeDebuggingMFilePath } =
-            getIosFileNameAndPaths(config)
+          const srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot)
 
-          const rctJsNativeDebuggingHFileContent = `
-//
-//  RCTJsNativeDebugging.h
-//
-
-#import <React/RCTBridgeModule.h>
-@interface RCTJsNativeDebugging : NSObject <RCTBridgeModule>
-@end
-`.trim()
-          const rctJsNativeDebuggingMFileContent = `
-//
-//  RCTJsNativeDebugging.m
-//
-
-#import "RCTJsNativeDebugging.h"
-
-@implementation RCTJsNativeDebugging
-
-RCT_EXPORT_MODULE();
-
-// In JS: globalThis.nativeModuleProxy.JsNativeDebugging.log('message')
-RCT_EXPORT_METHOD(log:(NSString *)message)
-{
-  NSLog(@"%@", message);
-}
-
-@end
-`.trim()
-
-          if (!fs.existsSync(rctJsNativeDebuggingHFilePath)) {
-            fs.writeFileSync(rctJsNativeDebuggingHFilePath, rctJsNativeDebuggingHFileContent)
-          }
-
-          if (!fs.existsSync(rctJsNativeDebuggingMFilePath)) {
-            fs.writeFileSync(rctJsNativeDebuggingMFilePath, rctJsNativeDebuggingMFileContent)
+          for (const [fileName, fileContent] of Object.entries(IOS_FILES)) {
+            const filePath = path.resolve(srcPath, fileName)
+            if (!fs.existsSync(filePath)) {
+              fs.writeFileSync(filePath, fileContent)
+            }
           }
 
           return config
@@ -71,16 +40,16 @@ RCT_EXPORT_METHOD(log:(NSString *)message)
       async (config) => {
         const xcodeProject = config.modResults
 
-        const { rctJsNativeDebuggingHFileName, rctJsNativeDebuggingMFileName } =
-          getIosFileNameAndPaths(config)
-
         const librariesGroupKey = xcodeProject.findPBXGroupKey({ name: 'Libraries' })
 
-        if (!xcodeProject.hasFile(rctJsNativeDebuggingHFileName)) {
-          xcodeProject.addHeaderFile(rctJsNativeDebuggingHFileName, {}, librariesGroupKey)
-        }
-        if (!xcodeProject.hasFile(rctJsNativeDebuggingMFileName)) {
-          xcodeProject.addSourceFile(rctJsNativeDebuggingMFileName, {}, librariesGroupKey)
+        for (const fileName in IOS_FILES) {
+          if (!xcodeProject.hasFile(fileName)) {
+            if (fileName.endsWith('.h')) {
+              xcodeProject.addHeaderFile(fileName, {}, librariesGroupKey)
+            } else {
+              xcodeProject.addSourceFile(fileName, {}, librariesGroupKey)
+            }
+          }
         }
 
         return config
@@ -89,20 +58,177 @@ RCT_EXPORT_METHOD(log:(NSString *)message)
   ])
 }
 
-function getIosFileNameAndPaths(config) {
-  const srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot)
-  const rctJsNativeDebuggingHFileName = 'RCTJsNativeDebugging.h'
-  const rctJsNativeDebuggingMFileName = 'RCTJsNativeDebugging.m'
+const IOS_FILES = {
+  'RCTJsNativeDebugging.h': `
+//
+//  RCTJsNativeDebugging.h
+//
 
-  const rctJsNativeDebuggingHFilePath = path.resolve(srcPath, rctJsNativeDebuggingHFileName)
-  const rctJsNativeDebuggingMFilePath = path.resolve(srcPath, rctJsNativeDebuggingMFileName)
+#import <React/RCTBridgeModule.h>
+@interface RCTJsNativeDebugging : NSObject <RCTBridgeModule>
+@end
+  `.trim(),
+  'RCTJsNativeDebugging.m': `
+//
+//  RCTJsNativeDebugging.m
+//
 
-  return {
-    rctJsNativeDebuggingHFileName,
-    rctJsNativeDebuggingMFileName,
-    rctJsNativeDebuggingHFilePath,
-    rctJsNativeDebuggingMFilePath,
-  }
+#import "RCTJsNativeDebugging.h"
+
+@implementation RCTJsNativeDebugging
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(log:(NSString *)message)
+{
+  NSLog(@"%@", message);
+}
+
+@end
+  `.trim(),
+
+  'JSIDebuggingModule.h': `
+//
+//  JSIDebuggingModule.h
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface JSIDebuggingModule : NSObject <RCTBridgeModule>;
+
+@property (nonatomic, assign) BOOL setBridgeOnMainQueue;
+
+@end
+  `.trim(),
+
+  'JSIDebuggingModule.mm': `
+//
+//  JSIDebuggingModule.mm
+//
+
+#import "JSIDebuggingModule.h"
+#import <React/RCTBridge+Private.h>
+#import <React/RCTUtils.h>
+#import <jsi/jsi.h>
+#import "jsi_debugging.h"
+
+@implementation JSIDebuggingModule
+
+@synthesize bridge = _bridge;
+@synthesize methodQueue = _methodQueue;
+
+RCT_EXPORT_MODULE()
+
++ (BOOL)requiresMainQueueSetup {
+
+    return YES;
+}
+
+- (void)setBridge:(RCTBridge *)bridge {
+    _bridge = bridge;
+    _setBridgeOnMainQueue = RCTIsMainQueue();
+    [self installLibrary];
+}
+
+- (void)installLibrary {
+
+    RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
+
+    if (cxxBridge.runtime) {
+      jsi_debugging::install(*(facebook::jsi::Runtime *)cxxBridge.runtime);
+    }
+}
+
+@end
+  `.trim(),
+
+  'jsi_debugging.h': `
+//
+//  jsi_debugging.h
+//
+
+#include <jsi/jsi.h>
+
+using namespace facebook::jsi;
+
+#ifndef JSIDebugging_h
+#define JSIDebugging_h
+
+namespace jsi_debugging {
+  void install(Runtime & jsiRuntime);
+}
+
+#endif /* JSIDebugging_h */
+  `.trim(),
+
+  'jsi_debugging.cpp': `
+//
+//  jsi_debugging.cpp
+//
+
+#include "jsi_debugging.h"
+#include <jsi/jsi.h>
+#include <string>
+#include <iostream>
+#include <sstream>
+
+using namespace facebook::jsi;
+using namespace std;
+
+namespace jsi_debugging {
+    std::string jsiValueToCppString(facebook::jsi::Runtime& runtime, const facebook::jsi::Value& value) {
+        if (value.isString()) {
+            facebook::jsi::String jsiStr = value.asString(runtime);
+            return jsiStr.utf8(runtime);
+        } else if (value.isNumber()) {
+            return std::to_string(value.asNumber());
+        } else if (value.isBool()) {
+            return value.getBool() ? "true" : "false";
+        } else if (value.isObject()) {
+            facebook::jsi::Object obj = value.asObject(runtime);
+            if (obj.isFunction(runtime)) {
+                return "[Function]";
+            } else {
+                return "[Object]";
+            }
+        } else if (value.isNull()) {
+            return "null";
+        } else if (value.isUndefined()) {
+            return "undefined";
+        } else {
+            return "[Unknown Value]";
+        }
+    }
+
+    void install(Runtime & jsiRuntime) {
+        auto nativeLog = Function::createFromHostFunction(
+                                                          jsiRuntime,
+            PropNameID::forAscii(jsiRuntime, "nativeLog"),
+            1,
+            [](
+               facebook::jsi::Runtime& runtime,
+               const facebook::jsi::Value&,
+               const facebook::jsi::Value* args,
+                size_t count
+            ) {
+                std::ostringstream output;
+
+                for (size_t i = 0; i < count; i++) {
+                    if (i > 0) {
+                        output << " "; // Add space between arguments
+                    }
+                    output << jsiValueToCppString(runtime, args[i]);
+                }
+
+                std::cout << output.str() << std::endl;
+
+                return Value::undefined();
+            });
+
+        jsiRuntime.global().setProperty(jsiRuntime, "nativeLog", std::move(nativeLog));
+    }
+}
+  `.trim(),
 }
 
 module.exports = plugin

--- a/packages/vxrn/expo-js-native-debugging-plugin.cjs
+++ b/packages/vxrn/expo-js-native-debugging-plugin.cjs
@@ -3,9 +3,9 @@
  * It'll add files into the native code which provides a starting point for debugging the JavaScript bundle with native code.
  * Please consider this as an incomplete tool only for development purposes.
  *
- * To use this plugin, you need to add it (`vxrn/expo-js-native-debugging-plugin`) to the `plugins` array in your `app.json` file.
+ * To use this plugin, you need to add it (`vxrn/expo-js-native-debugging-plugin`) to the `plugins` array in your `app.json` file, and run prebuild. Then,
  *
- * For iOS, a `JsNativeDebugging` (`RCTJsNativeDebugging`) native module will be added to the project, under the Libraries group.
+ * * For iOS, a `JsNativeDebugging` (`RCTJsNativeDebugging`) native module will be added to the project, under the Libraries group.
  *
  * References:
  * * https://hackmd.io/@z/rn-use-native-modules-without-importing-react-native
@@ -45,6 +45,7 @@ const plugin = (config, options = {}) => {
 
 RCT_EXPORT_MODULE();
 
+// In JS: globalThis.nativeModuleProxy.JsNativeDebugging.log('message')
 RCT_EXPORT_METHOD(log:(NSString *)message)
 {
   NSLog(@"%@", message);

--- a/packages/vxrn/expo-js-native-debugging-plugin.cjs
+++ b/packages/vxrn/expo-js-native-debugging-plugin.cjs
@@ -1,0 +1,107 @@
+/**
+ * This is a internal plugin for the convenience of VxRN developers to debug the JavaScript bundle.
+ * It'll add files into the native code which provides a starting point for debugging the JavaScript bundle with native code.
+ * Please consider this as an incomplete tool only for development purposes.
+ *
+ * To use this plugin, you need to add it (`vxrn/expo-js-native-debugging-plugin`) to the `plugins` array in your `app.json` file.
+ *
+ * For iOS, a `JsNativeDebugging` (`RCTJsNativeDebugging`) native module will be added to the project, under the Libraries group.
+ *
+ * References:
+ * * https://hackmd.io/@z/rn-use-native-modules-without-importing-react-native
+ */
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { withPlugins, withDangerousMod, withXcodeProject } = require('@expo/config-plugins')
+
+const plugin = (config, options = {}) => {
+  return withPlugins(config, [
+    [
+      withDangerousMod,
+      [
+        'ios',
+        async (config) => {
+          const { rctJsNativeDebuggingHFilePath, rctJsNativeDebuggingMFilePath } =
+            getIosFileNameAndPaths(config)
+
+          const rctJsNativeDebuggingHFileContent = `
+//
+//  RCTJsNativeDebugging.h
+//
+
+#import <React/RCTBridgeModule.h>
+@interface RCTJsNativeDebugging : NSObject <RCTBridgeModule>
+@end
+`.trim()
+          const rctJsNativeDebuggingMFileContent = `
+//
+//  RCTJsNativeDebugging.m
+//
+
+#import "RCTJsNativeDebugging.h"
+
+@implementation RCTJsNativeDebugging
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(log:(NSString *)message)
+{
+  NSLog(@"%@", message);
+}
+
+@end
+`.trim()
+
+          if (!fs.existsSync(rctJsNativeDebuggingHFilePath)) {
+            fs.writeFileSync(rctJsNativeDebuggingHFilePath, rctJsNativeDebuggingHFileContent)
+          }
+
+          if (!fs.existsSync(rctJsNativeDebuggingMFilePath)) {
+            fs.writeFileSync(rctJsNativeDebuggingMFilePath, rctJsNativeDebuggingMFileContent)
+          }
+
+          return config
+        },
+      ],
+    ],
+    [
+      withXcodeProject,
+      async (config) => {
+        const xcodeProject = config.modResults
+
+        const { rctJsNativeDebuggingHFileName, rctJsNativeDebuggingMFileName } =
+          getIosFileNameAndPaths(config)
+
+        const librariesGroupKey = xcodeProject.findPBXGroupKey({ name: 'Libraries' })
+
+        if (!xcodeProject.hasFile(rctJsNativeDebuggingHFileName)) {
+          xcodeProject.addHeaderFile(rctJsNativeDebuggingHFileName, {}, librariesGroupKey)
+        }
+        if (!xcodeProject.hasFile(rctJsNativeDebuggingMFileName)) {
+          xcodeProject.addSourceFile(rctJsNativeDebuggingMFileName, {}, librariesGroupKey)
+        }
+
+        return config
+      },
+    ],
+  ])
+}
+
+function getIosFileNameAndPaths(config) {
+  const srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot)
+  const rctJsNativeDebuggingHFileName = 'RCTJsNativeDebugging.h'
+  const rctJsNativeDebuggingMFileName = 'RCTJsNativeDebugging.m'
+
+  const rctJsNativeDebuggingHFilePath = path.resolve(srcPath, rctJsNativeDebuggingHFileName)
+  const rctJsNativeDebuggingMFilePath = path.resolve(srcPath, rctJsNativeDebuggingMFileName)
+
+  return {
+    rctJsNativeDebuggingHFileName,
+    rctJsNativeDebuggingMFileName,
+    rctJsNativeDebuggingHFilePath,
+    rctJsNativeDebuggingMFilePath,
+  }
+}
+
+module.exports = plugin

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -32,6 +32,7 @@
     "./react-native-template.js": "./react-native-template.js",
     "./react-native-commands": "./react-native-commands.cjs",
     "./expo-plugin": "./expo-plugin.cjs",
+    "./expo-js-native-debugging-plugin": "./expo-js-native-debugging-plugin.cjs",
     ".": {
       "types": "./types/index.d.ts",
       "default": "./dist/index.mjs"

--- a/packages/vxrn/react-native-template.js
+++ b/packages/vxrn/react-native-template.js
@@ -30,6 +30,8 @@ globalThis['__cachedModules'] = {
   // },
 }
 
+globalThis['__RN_INTERNAL_MODULE_REQUIRES_MAP__'] = {}
+
 function printError(err) {
   return `${err instanceof Error ? `${err.message}\n${err.stack}` : err}`
 }

--- a/packages/vxrn/src/utils/getReactNativeBundle.ts
+++ b/packages/vxrn/src/utils/getReactNativeBundle.ts
@@ -142,6 +142,19 @@ export async function getReactNativeBundle(
           code = ''
         }
 
+        if (id.startsWith('.vxrn/react-native')) {
+          // Turn eager imports of RN back into dynamic lazy imports.
+          // We needed them eager so rollup won't be unhappy with missing exports, but now we need them lazy again to match the original RN behavior, which may avoid some issues. Such as:
+          // * react-native v0.76 with: Codegen didn't run for RNCSafeAreaView. This will be an error in the future. Make sure you are using @react-native/babel-preset when building your JavaScript code.
+          code = code.replace( // Step 1: Replace the whole `exports` block which contains `exports.REACT_NATIVE_ESM_MANUAL_EXPORTS_` with `module.exports = RN;`
+            /(^exports.+$\s)*(^exports\.REACT_NATIVE_ESM_MANUAL_EXPORTS_.+$\s)(^exports.+$\s)*/m,
+            'module.exports = RN;'
+          )
+          .replace( // Step 2: Remove other unnecessary `var thing = RN.thing;` lines
+            /^.*REACT_NATIVE_ESM_MANUAL_EXPORTS_START[\s\S]*REACT_NATIVE_ESM_MANUAL_EXPORTS_END.*$/m, ''
+          )
+        }
+
         return `
 // id: ${id}
 // name: ${outputModule.name}
@@ -176,16 +189,6 @@ __require("${id}")
   appCode = appCode
     // TEMP FIX for router tamagui thing since expo router 3 upgrade
     .replaceAll('dist/esm/index.mjs"', 'dist/esm/index.js"')
-    // turn eager imports of RN back into lazy imports
-    // we needed them eager so rollup isnt unhappy with missing exports, now we need them lazy again
-    // so react native doesn't get unhappy on v76 with:
-    // Codegen didn't run for RNCSafeAreaView. This will be an error in the future. Make sure you are using @react-native/babel-preset when building your JavaScript code.
-    .replace(
-      RNEagerImports,
-      `
-module.exports = RN;
-  `
-    )
 
   const template = (await getReactNativeTemplate(internal.mode || 'dev')).replaceAll(
     '__VXRN_PLATFORM__',
@@ -200,162 +203,6 @@ module.exports = RN;
 
   return out
 }
-
-const RNEagerImports = `var registerCallableModule = RN.registerCallableModule;
-var AccessibilityInfo = RN.AccessibilityInfo;
-var ActivityIndicator = RN.ActivityIndicator;
-var Button = RN.Button;
-var DrawerLayoutAndroid = RN.DrawerLayoutAndroid;
-var FlatList = RN.FlatList;
-var Image = RN.Image;
-var ImageBackground = RN.ImageBackground;
-var InputAccessoryView = RN.InputAccessoryView;
-var KeyboardAvoidingView = RN.KeyboardAvoidingView;
-var Modal = RN.Modal;
-var Pressable = RN.Pressable;
-var RefreshControl = RN.RefreshControl;
-var SafeAreaView = RN.SafeAreaView;
-var ScrollView = RN.ScrollView;
-var SectionList = RN.SectionList;
-var StatusBar = RN.StatusBar;
-var Switch = RN.Switch;
-var Text = RN.Text;
-var TextInput = RN.TextInput;
-var Touchable = RN.Touchable;
-var TouchableHighlight = RN.TouchableHighlight;
-var TouchableNativeFeedback = RN.TouchableNativeFeedback;
-var TouchableOpacity = RN.TouchableOpacity;
-var TouchableWithoutFeedback = RN.TouchableWithoutFeedback;
-var View = RN.View;
-var VirtualizedList = RN.VirtualizedList;
-var VirtualizedSectionList = RN.VirtualizedSectionList;
-var ActionSheetIOS = RN.ActionSheetIOS;
-var Alert = RN.Alert;
-var Animated = RN.Animated;
-var Appearance = RN.Appearance;
-var AppRegistry = RN.AppRegistry;
-var AppState = RN.AppState;
-var BackHandler = RN.BackHandler;
-var DeviceInfo = RN.DeviceInfo;
-var DevSettings = RN.DevSettings;
-var Dimensions = RN.Dimensions;
-var Easing = RN.Easing;
-var findNodeHandle = RN.findNodeHandle;
-var I18nManager = RN.I18nManager;
-var InteractionManager = RN.InteractionManager;
-var Keyboard = RN.Keyboard;
-var LayoutAnimation = RN.LayoutAnimation;
-var Linking = RN.Linking;
-var LogBox = RN.LogBox;
-var NativeDialogManagerAndroid = RN.NativeDialogManagerAndroid;
-var NativeEventEmitter = RN.NativeEventEmitter;
-var Networking = RN.Networking;
-var PanResponder = RN.PanResponder;
-var PermissionsAndroid = RN.PermissionsAndroid;
-var PixelRatio = RN.PixelRatio;
-var Settings = RN.Settings;
-var Share = RN.Share;
-var StyleSheet = RN.StyleSheet;
-var Systrace = RN.Systrace;
-var ToastAndroid = RN.ToastAndroid;
-var TurboModuleRegistry = RN.TurboModuleRegistry;
-var UIManager = RN.UIManager;
-var unstable_batchedUpdates = RN.unstable_batchedUpdates;
-var useAnimatedValue = RN.useAnimatedValue;
-var useColorScheme = RN.useColorScheme;
-var useWindowDimensions = RN.useWindowDimensions;
-var UTFSequence = RN.UTFSequence;
-var Vibration = RN.Vibration;
-var YellowBox = RN.YellowBox;
-var DeviceEventEmitter = RN.DeviceEventEmitter;
-var DynamicColorIOS = RN.DynamicColorIOS;
-var NativeAppEventEmitter = RN.NativeAppEventEmitter;
-var NativeModules = RN.NativeModules;
-var Platform = RN.Platform;
-var PlatformColor = RN.PlatformColor;
-var processColor = RN.processColor;
-var requireNativeComponent = RN.requireNativeComponent;
-var RootTagContext = RN.RootTagContext;
-var unstable_enableLogBox = RN.unstable_enableLogBox;
-var AssetRegistry = RN.AssetRegistry;
-
-exports.AccessibilityInfo = AccessibilityInfo;
-exports.ActionSheetIOS = ActionSheetIOS;
-exports.ActivityIndicator = ActivityIndicator;
-exports.Alert = Alert;
-exports.Animated = Animated;
-exports.AppRegistry = AppRegistry;
-exports.AppState = AppState;
-exports.Appearance = Appearance;
-exports.AssetRegistry = AssetRegistry;
-exports.BackHandler = BackHandler;
-exports.Button = Button;
-exports.DevSettings = DevSettings;
-exports.DeviceEventEmitter = DeviceEventEmitter;
-exports.DeviceInfo = DeviceInfo;
-exports.Dimensions = Dimensions;
-exports.DrawerLayoutAndroid = DrawerLayoutAndroid;
-exports.DynamicColorIOS = DynamicColorIOS;
-exports.Easing = Easing;
-exports.FlatList = FlatList;
-exports.I18nManager = I18nManager;
-exports.Image = Image;
-exports.ImageBackground = ImageBackground;
-exports.InputAccessoryView = InputAccessoryView;
-exports.InteractionManager = InteractionManager;
-exports.Keyboard = Keyboard;
-exports.KeyboardAvoidingView = KeyboardAvoidingView;
-exports.LayoutAnimation = LayoutAnimation;
-exports.Linking = Linking;
-exports.LogBox = LogBox;
-exports.Modal = Modal;
-exports.NativeAppEventEmitter = NativeAppEventEmitter;
-exports.NativeDialogManagerAndroid = NativeDialogManagerAndroid;
-exports.NativeEventEmitter = NativeEventEmitter;
-exports.NativeModules = NativeModules;
-exports.Networking = Networking;
-exports.PanResponder = PanResponder;
-exports.PermissionsAndroid = PermissionsAndroid;
-exports.PixelRatio = PixelRatio;
-exports.Platform = Platform;
-exports.PlatformColor = PlatformColor;
-exports.Pressable = Pressable;
-exports.RefreshControl = RefreshControl;
-exports.RootTagContext = RootTagContext;
-exports.SafeAreaView = SafeAreaView;
-exports.ScrollView = ScrollView;
-exports.SectionList = SectionList;
-exports.Settings = Settings;
-exports.Share = Share;
-exports.StatusBar = StatusBar;
-exports.StyleSheet = StyleSheet;
-exports.Switch = Switch;
-exports.Systrace = Systrace;
-exports.Text = Text;
-exports.TextInput = TextInput;
-exports.ToastAndroid = ToastAndroid;
-exports.Touchable = Touchable;
-exports.TouchableHighlight = TouchableHighlight;
-exports.TouchableNativeFeedback = TouchableNativeFeedback;
-exports.TouchableOpacity = TouchableOpacity;
-exports.TouchableWithoutFeedback = TouchableWithoutFeedback;
-exports.TurboModuleRegistry = TurboModuleRegistry;
-exports.UIManager = UIManager;
-exports.UTFSequence = UTFSequence;
-exports.Vibration = Vibration;
-exports.View = View;
-exports.VirtualizedList = VirtualizedList;
-exports.VirtualizedSectionList = VirtualizedSectionList;
-exports.YellowBox = YellowBox;
-exports.findNodeHandle = findNodeHandle;
-exports.processColor = processColor;
-exports.registerCallableModule = registerCallableModule;
-exports.requireNativeComponent = requireNativeComponent;
-exports.unstable_batchedUpdates = unstable_batchedUpdates;
-exports.unstable_enableLogBox = unstable_enableLogBox;
-exports.useAnimatedValue = useAnimatedValue;
-exports.useColorScheme = useColorScheme;
-exports.useWindowDimensions = useWindowDimensions;`
 
 /**
  * Get `react-native-template.js` with some `process.env.*` replaced with static values.

--- a/packages/vxrn/src/utils/getReactNativeBundle.ts
+++ b/packages/vxrn/src/utils/getReactNativeBundle.ts
@@ -176,6 +176,16 @@ __require("${id}")
   appCode = appCode
     // TEMP FIX for router tamagui thing since expo router 3 upgrade
     .replaceAll('dist/esm/index.mjs"', 'dist/esm/index.js"')
+    // turn eager imports of RN back into lazy imports
+    // we needed them eager so rollup isnt unhappy with missing exports, now we need them lazy again
+    // so react native doesn't get unhappy on v76 with:
+    // Codegen didn't run for RNCSafeAreaView. This will be an error in the future. Make sure you are using @react-native/babel-preset when building your JavaScript code.
+    .replace(
+      RNEagerImports,
+      `
+module.exports = RN;
+  `
+    )
 
   const template = (await getReactNativeTemplate(internal.mode || 'dev')).replaceAll(
     '__VXRN_PLATFORM__',
@@ -190,6 +200,162 @@ __require("${id}")
 
   return out
 }
+
+const RNEagerImports = `var registerCallableModule = RN.registerCallableModule;
+var AccessibilityInfo = RN.AccessibilityInfo;
+var ActivityIndicator = RN.ActivityIndicator;
+var Button = RN.Button;
+var DrawerLayoutAndroid = RN.DrawerLayoutAndroid;
+var FlatList = RN.FlatList;
+var Image = RN.Image;
+var ImageBackground = RN.ImageBackground;
+var InputAccessoryView = RN.InputAccessoryView;
+var KeyboardAvoidingView = RN.KeyboardAvoidingView;
+var Modal = RN.Modal;
+var Pressable = RN.Pressable;
+var RefreshControl = RN.RefreshControl;
+var SafeAreaView = RN.SafeAreaView;
+var ScrollView = RN.ScrollView;
+var SectionList = RN.SectionList;
+var StatusBar = RN.StatusBar;
+var Switch = RN.Switch;
+var Text = RN.Text;
+var TextInput = RN.TextInput;
+var Touchable = RN.Touchable;
+var TouchableHighlight = RN.TouchableHighlight;
+var TouchableNativeFeedback = RN.TouchableNativeFeedback;
+var TouchableOpacity = RN.TouchableOpacity;
+var TouchableWithoutFeedback = RN.TouchableWithoutFeedback;
+var View = RN.View;
+var VirtualizedList = RN.VirtualizedList;
+var VirtualizedSectionList = RN.VirtualizedSectionList;
+var ActionSheetIOS = RN.ActionSheetIOS;
+var Alert = RN.Alert;
+var Animated = RN.Animated;
+var Appearance = RN.Appearance;
+var AppRegistry = RN.AppRegistry;
+var AppState = RN.AppState;
+var BackHandler = RN.BackHandler;
+var DeviceInfo = RN.DeviceInfo;
+var DevSettings = RN.DevSettings;
+var Dimensions = RN.Dimensions;
+var Easing = RN.Easing;
+var findNodeHandle = RN.findNodeHandle;
+var I18nManager = RN.I18nManager;
+var InteractionManager = RN.InteractionManager;
+var Keyboard = RN.Keyboard;
+var LayoutAnimation = RN.LayoutAnimation;
+var Linking = RN.Linking;
+var LogBox = RN.LogBox;
+var NativeDialogManagerAndroid = RN.NativeDialogManagerAndroid;
+var NativeEventEmitter = RN.NativeEventEmitter;
+var Networking = RN.Networking;
+var PanResponder = RN.PanResponder;
+var PermissionsAndroid = RN.PermissionsAndroid;
+var PixelRatio = RN.PixelRatio;
+var Settings = RN.Settings;
+var Share = RN.Share;
+var StyleSheet = RN.StyleSheet;
+var Systrace = RN.Systrace;
+var ToastAndroid = RN.ToastAndroid;
+var TurboModuleRegistry = RN.TurboModuleRegistry;
+var UIManager = RN.UIManager;
+var unstable_batchedUpdates = RN.unstable_batchedUpdates;
+var useAnimatedValue = RN.useAnimatedValue;
+var useColorScheme = RN.useColorScheme;
+var useWindowDimensions = RN.useWindowDimensions;
+var UTFSequence = RN.UTFSequence;
+var Vibration = RN.Vibration;
+var YellowBox = RN.YellowBox;
+var DeviceEventEmitter = RN.DeviceEventEmitter;
+var DynamicColorIOS = RN.DynamicColorIOS;
+var NativeAppEventEmitter = RN.NativeAppEventEmitter;
+var NativeModules = RN.NativeModules;
+var Platform = RN.Platform;
+var PlatformColor = RN.PlatformColor;
+var processColor = RN.processColor;
+var requireNativeComponent = RN.requireNativeComponent;
+var RootTagContext = RN.RootTagContext;
+var unstable_enableLogBox = RN.unstable_enableLogBox;
+var AssetRegistry = RN.AssetRegistry;
+
+exports.AccessibilityInfo = AccessibilityInfo;
+exports.ActionSheetIOS = ActionSheetIOS;
+exports.ActivityIndicator = ActivityIndicator;
+exports.Alert = Alert;
+exports.Animated = Animated;
+exports.AppRegistry = AppRegistry;
+exports.AppState = AppState;
+exports.Appearance = Appearance;
+exports.AssetRegistry = AssetRegistry;
+exports.BackHandler = BackHandler;
+exports.Button = Button;
+exports.DevSettings = DevSettings;
+exports.DeviceEventEmitter = DeviceEventEmitter;
+exports.DeviceInfo = DeviceInfo;
+exports.Dimensions = Dimensions;
+exports.DrawerLayoutAndroid = DrawerLayoutAndroid;
+exports.DynamicColorIOS = DynamicColorIOS;
+exports.Easing = Easing;
+exports.FlatList = FlatList;
+exports.I18nManager = I18nManager;
+exports.Image = Image;
+exports.ImageBackground = ImageBackground;
+exports.InputAccessoryView = InputAccessoryView;
+exports.InteractionManager = InteractionManager;
+exports.Keyboard = Keyboard;
+exports.KeyboardAvoidingView = KeyboardAvoidingView;
+exports.LayoutAnimation = LayoutAnimation;
+exports.Linking = Linking;
+exports.LogBox = LogBox;
+exports.Modal = Modal;
+exports.NativeAppEventEmitter = NativeAppEventEmitter;
+exports.NativeDialogManagerAndroid = NativeDialogManagerAndroid;
+exports.NativeEventEmitter = NativeEventEmitter;
+exports.NativeModules = NativeModules;
+exports.Networking = Networking;
+exports.PanResponder = PanResponder;
+exports.PermissionsAndroid = PermissionsAndroid;
+exports.PixelRatio = PixelRatio;
+exports.Platform = Platform;
+exports.PlatformColor = PlatformColor;
+exports.Pressable = Pressable;
+exports.RefreshControl = RefreshControl;
+exports.RootTagContext = RootTagContext;
+exports.SafeAreaView = SafeAreaView;
+exports.ScrollView = ScrollView;
+exports.SectionList = SectionList;
+exports.Settings = Settings;
+exports.Share = Share;
+exports.StatusBar = StatusBar;
+exports.StyleSheet = StyleSheet;
+exports.Switch = Switch;
+exports.Systrace = Systrace;
+exports.Text = Text;
+exports.TextInput = TextInput;
+exports.ToastAndroid = ToastAndroid;
+exports.Touchable = Touchable;
+exports.TouchableHighlight = TouchableHighlight;
+exports.TouchableNativeFeedback = TouchableNativeFeedback;
+exports.TouchableOpacity = TouchableOpacity;
+exports.TouchableWithoutFeedback = TouchableWithoutFeedback;
+exports.TurboModuleRegistry = TurboModuleRegistry;
+exports.UIManager = UIManager;
+exports.UTFSequence = UTFSequence;
+exports.Vibration = Vibration;
+exports.View = View;
+exports.VirtualizedList = VirtualizedList;
+exports.VirtualizedSectionList = VirtualizedSectionList;
+exports.YellowBox = YellowBox;
+exports.findNodeHandle = findNodeHandle;
+exports.processColor = processColor;
+exports.registerCallableModule = registerCallableModule;
+exports.requireNativeComponent = requireNativeComponent;
+exports.unstable_batchedUpdates = unstable_batchedUpdates;
+exports.unstable_enableLogBox = unstable_enableLogBox;
+exports.useAnimatedValue = useAnimatedValue;
+exports.useColorScheme = useColorScheme;
+exports.useWindowDimensions = useWindowDimensions;`
 
 /**
  * Get `react-native-template.js` with some `process.env.*` replaced with static values.

--- a/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
+++ b/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
@@ -231,7 +231,7 @@ export async function swapPrebuiltReactModules(
     async load(id) {
       if (id.startsWith('virtual:rn-internals')) {
         const idOut = id.replace('virtual:rn-internals:', '')
-        let out = `const ___val = __cachedModules["${idOut}"]
+        let out = `const ___val = __RN_INTERNAL_MODULE_REQUIRES_MAP__["${idOut}"]()
         const ___defaultVal = ___val ? ___val.default || ___val : ___val
         export default ___defaultVal
 

--- a/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
+++ b/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
@@ -231,7 +231,7 @@ export async function swapPrebuiltReactModules(
     async load(id) {
       if (id.startsWith('virtual:rn-internals')) {
         const idOut = id.replace('virtual:rn-internals:', '')
-        let out = `const ___val = __RN_INTERNAL_MODULE_REQUIRES_MAP__["${idOut}"]()
+        let out = (id.includes('codegenNativeComponent') ? `const ___val = __RN_INTERNAL_MODULE_REQUIRES_MAP__["${idOut}"]()` : `const ___val = __cachedModules["${idOut}"]`) /* IDK why we can't use __RN_INTERNAL_MODULE_REQUIRES_MAP__ for all modules, if we do so the app will hang with a white screen (but won't crash) */ + `
         const ___defaultVal = ___val ? ___val.default || ___val : ___val
         export default ___defaultVal
 


### PR DESCRIPTION
Based on #208.

The original implementation actually works, but by lazy loading, React `RefreshRuntime` won't get loaded in time, while in the RN bundle, it'll be used like this at the top level:

```js
var RefreshRuntime = __cachedModules["react-refresh/cjs/react-refresh-runtime.development"];
```

Which leads to errors:

```
Cannot read property 'createSignatureFunctionForTransform' of undefined
```

where that `undefined` is `RefreshRuntime`.