### PR TITLE
fix: fail to start if project path contains "js"

### DIFF
--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -169,7 +169,7 @@ export async function buildReactNative(
 
           build.onLoad(
             {
-              filter: /.*.js/,
+              filter: /.*\.js$/,
             },
             async (input) => {
               if (!input.path.includes('react-native') && !input.path.includes(`vite-native-hmr`)) {


### PR DESCRIPTION
Resolves #195.

See https://github.com/onejs/one/issues/195#issuecomment-2531932837 for details.