### PR TITLE
fix: returning `react-native/package.json` in `resolveId` stops subsequent plugins from resolving

### DIFF
--- a/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
+++ b/packages/vxrn/src/utils/swapPrebuiltReactModules.ts
@@ -162,7 +162,7 @@ export async function swapPrebuiltReactModules(
     async resolveId(id, importer = '') {
       if (id.startsWith('react-native/')) {
         if (id === 'react-native/package.json') {
-          return id
+          return
         }
         return `virtual:rn-internals:${id}`
       }


### PR DESCRIPTION
Resolves https://discord.com/channels/1223009626400751671/1223009626400751676/1315991648404246528.

However, some issues still prevent `react-native-reanimated-carousel` from functioning properly.