### PR TITLE
fix(resolve): resolve correctly if the path to resolve is not reachable from the source code file where the resolve package lives

### DIFF
--- a/packages/one/test/_setup.ts
+++ b/packages/one/test/_setup.ts
@@ -73,6 +73,13 @@ export default async () => {
           ONE_SERVER_URL: `http://localhost:${prodPort}`,
         },
       })
+      let buildProcessOutput = ''
+      buildProcess.stdout?.on('data', (data) => {
+        buildProcessOutput += data.toString()
+      })
+      buildProcess.stderr?.on('data', (data) => {
+        buildProcessOutput += data.toString()
+      })
 
       // Wait for build process to complete
       await new Promise<void>((resolve, reject) => {
@@ -85,7 +92,7 @@ export default async () => {
           } else {
             reject(
               new Error(
-                `Build process exited with code ${code} after ${Math.round(performance.now() - prodBuildStartedAt)}ms`
+                `Build process exited with code ${code} after ${Math.round(performance.now() - prodBuildStartedAt)}ms.\nLogs:\n${buildProcessOutput}`
               )
             )
           }

--- a/packages/resolve/src/index.tsx
+++ b/packages/resolve/src/index.tsx
@@ -1,3 +1,4 @@
+import module from 'node:module'
 import { fileURLToPath } from 'node:url'
 
 const resolver =
@@ -7,6 +8,17 @@ const resolver =
       ? (path: string, from?: string) => new URL(path, import.meta.url).pathname
       : require.resolve
 
+const resolverV2 = (path, from) => {
+  const require = module.createRequire(from)
+  const importPath = require.resolve(path, { paths: [from] })
+  return importPath
+}
+
 export const resolvePath = (path: string, from?: string): string => {
-  return resolver(path, from)
+  // We might be able to use resolverV2 directly, but here we'll still try to use the original implementation first in case there're any issues with the new one.
+  try {
+    return resolver(path, from)
+  } catch (e) {
+    return resolverV2(path, from)
+  }
 }


### PR DESCRIPTION
The original implementaion of `@vxrn/resolve` will throw a `ERR_MODULE_NOT_FOUND` error in this case, for example:

```js
resolvePath('react-native-web', '/.../apps/my-app')
```

```
├── apps
│   └── my-app
│       └── node_modules
│           └── react-native-web
└── node_modules
    └── @vxrn
        └── resolve
            └── index.mjs
```

It will only work if the path to resolve is also importable from the source location where `@vxrn/resolve` lives, for example:

```
└── apps
    └── my-app
        └── node_modules
            ├── @vxrn
            │   └── resolve
            │       └── index.mjs
            └── react-native-web
```