### PR TITLE
use yarn for packing and npm for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ docs/.vitepress/cache
 !.yarn/sdks
 !.yarn/versions
 
+# temporary packed packages for release, created by scripts/release.ts
+package.tmp.tgz
+
 .turbo
 
 .ultra.cache.json

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -208,34 +208,34 @@ async function run() {
       }
     }
 
-    // if (!skipVersion && !finish) {
-    //   await Promise.all(
-    //     allPackageJsons.map(async ({ json, path }) => {
-    //       const next = { ...json }
+    if (!skipVersion && !finish) {
+      await Promise.all(
+        allPackageJsons.map(async ({ json, path }) => {
+          const next = { ...json }
 
-    //       next.version = version
+          next.version = version
 
-    //       for (const field of [
-    //         'dependencies',
-    //         'devDependencies',
-    //         'optionalDependencies',
-    //         'peerDependencies',
-    //       ]) {
-    //         const nextDeps = next[field]
-    //         if (!nextDeps) continue
-    //         for (const depName in nextDeps) {
-    //           if (nextDeps[depName].startsWith('workspace:')) {
-    //             if (allPackageJsons.some((p) => p.name === depName)) {
-    //               nextDeps[depName] = version
-    //             }
-    //           }
-    //         }
-    //       }
+          for (const field of [
+            'dependencies',
+            'devDependencies',
+            'optionalDependencies',
+            'peerDependencies',
+          ]) {
+            const nextDeps = next[field]
+            if (!nextDeps) continue
+            for (const depName in nextDeps) {
+              if (nextDeps[depName].startsWith('workspace:')) {
+                if (allPackageJsons.some((p) => p.name === depName)) {
+                  nextDeps[depName] = version
+                }
+              }
+            }
+          }
 
-    //       await writeJSON(path, next, { spaces: 2 })
-    //     })
-    //   )
-    // }
+          await writeJSON(path, next, { spaces: 2 })
+        })
+      )
+    }
 
     if (!finish && dryRun) {
       console.info(`Dry run, exiting before publish`)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -224,7 +224,7 @@ async function run() {
             const nextDeps = next[field]
             if (!nextDeps) continue
             for (const depName in nextDeps) {
-              if (nextDeps[depName].startsWith('workspace:')) {
+              if (!nextDeps[depName].startsWith('workspace:')) {
                 if (allPackageJsons.some((p) => p.name === depName)) {
                   nextDeps[depName] = version
                 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -295,7 +295,18 @@ async function run() {
           }
 
           try {
-            await spawnify(`yarn npm publish --tag prepub`, {
+            await spawnify(`yarn pack --out package.tmp.tgz`, {
+              cwd,
+              avoidLog: true,
+            })
+
+            const publishCommand = [
+              'npm publish',
+              'package.tmp.tgz', // produced by `yarn pack`
+              '--tag prepub --access public',
+            ].filter(Boolean).join(' ')
+
+            await spawnify(publishCommand, {
               cwd,
               avoidLog: true,
             })
@@ -337,11 +348,22 @@ async function run() {
         await pMap(
           packageJsons,
           async ({ name, cwd }) => {
-            const tag = canary ? ` --tag canary` : ''
+            const publishOptions = [canary && `--tag canary`].filter(Boolean).join(' ')
 
-            console.info(`Publishing ${name}${tag}`)
+            await spawnify(`yarn pack --out package.tmp.tgz`, {
+              cwd,
+              avoidLog: true,
+            })
 
-            await spawnify(`npm publish${tag}`, {
+            const publishCommand = [
+              'npm publish',
+              'package.tmp.tgz', // produced by `yarn pack`
+              publishOptions,
+            ].filter(Boolean).join(' ')
+
+            console.info(`Publishing ${name}: ${publishCommand}`)
+
+            await spawnify(publishCommand, {
               cwd,
             }).catch((err) => console.error(err))
           },


### PR DESCRIPTION
Since yarn will handle workspace version cross-references (https://yarnpkg.com/features/workspaces#cross-references), and with npm we can have less trouble publishing.