### PR TITLE
feat(mdx): export getmdx

### DIFF
--- a/packages/mdx/src/getMDX.ts
+++ b/packages/mdx/src/getMDX.ts
@@ -1,0 +1,35 @@
+import { bundleMDX } from 'mdx-bundler'
+import readingTime from 'reading-time'
+import rehypeAutolinkHeadings from 'rehype-autolink-headings'
+import rehypeSlug from 'rehype-slug'
+import { rehypeHighlightCode } from './rehypeHighlightCode'
+import rehypeMetaAttribute from './rehypeMetaAttribute'
+import { getHeadings } from './getHeadings'
+import type { Frontmatter, UnifiedPlugin } from './types'
+
+export async function getMDX(source: string, extraPlugins?: UnifiedPlugin) {
+    const {frontmatter, code} = await bundleMDX({
+      source,
+      mdxOptions(options) {
+        const plugins = [
+          ...(extraPlugins || []),
+          ...(options.rehypePlugins ?? []),
+          rehypeMetaAttribute,
+          rehypeHighlightCode,
+          rehypeAutolinkHeadings,
+          rehypeSlug,
+        ]
+        options.rehypePlugins = plugins as any
+        return options
+      },
+    })
+
+    return {
+        frontmatter: {
+          ...frontmatter,
+          headings: getHeadings(source),
+          readingTime: readingTime(code),
+        } as Frontmatter,
+        code,
+      }
+  }

--- a/packages/mdx/src/getMDX.ts
+++ b/packages/mdx/src/getMDX.ts
@@ -8,28 +8,28 @@ import { getHeadings } from './getHeadings'
 import type { Frontmatter, UnifiedPlugin } from './types'
 
 export async function getMDX(source: string, extraPlugins?: UnifiedPlugin) {
-    const {frontmatter, code} = await bundleMDX({
-      source,
-      mdxOptions(options) {
-        const plugins = [
-          ...(extraPlugins || []),
-          ...(options.rehypePlugins ?? []),
-          rehypeMetaAttribute,
-          rehypeHighlightCode,
-          rehypeAutolinkHeadings,
-          rehypeSlug,
-        ]
-        options.rehypePlugins = plugins as any
-        return options
-      },
-    })
+  const { frontmatter, code } = await bundleMDX({
+    source,
+    mdxOptions(options) {
+      const plugins = [
+        ...(extraPlugins || []),
+        ...(options.rehypePlugins ?? []),
+        rehypeMetaAttribute,
+        rehypeHighlightCode,
+        rehypeAutolinkHeadings,
+        rehypeSlug,
+      ]
+      options.rehypePlugins = plugins as any
+      return options
+    },
+  })
 
-    return {
-        frontmatter: {
-          ...frontmatter,
-          headings: getHeadings(source),
-          readingTime: readingTime(code),
-        } as Frontmatter,
-        code,
-      }
+  return {
+    frontmatter: {
+      ...frontmatter,
+      headings: getHeadings(source),
+      readingTime: readingTime(code),
+    } as Frontmatter,
+    code,
   }
+}

--- a/packages/mdx/src/getMDXBySlug.tsx
+++ b/packages/mdx/src/getMDXBySlug.tsx
@@ -1,16 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import compareVersions from 'compare-versions'
-import { bundleMDX } from 'mdx-bundler'
-import readingTime from 'reading-time'
-import type { Frontmatter } from './types'
-import { rehypeHighlightCode } from './rehypeHighlightCode'
-import rehypeMetaAttribute from './rehypeMetaAttribute'
-import rehypeAutolinkHeadings from 'rehype-autolink-headings'
-import rehypeSlug from 'rehype-slug'
-import { getHeadings } from './getHeadings'
-
-export type UnifiedPlugin = import('unified').Plugin[]
+import type { Frontmatter, UnifiedPlugin } from './types'
+import { getMDX } from './getMDX'
 
 export const getMDXBySlug = async (
   basePath: string,
@@ -27,33 +19,8 @@ export const getMDXBySlug = async (
 
   const filePath = path.join(basePath, `${mdxPath}.mdx`)
   const source = fs.readFileSync(filePath, 'utf8')
-  const { frontmatter, code } = await getMDX(source, extraPlugins)
-  return {
-    frontmatter: {
-      ...frontmatter,
-      headings: getHeadings(source),
-      readingTime: readingTime(code),
-    } as Frontmatter,
-    code,
-  }
-}
-
-export async function getMDX(source: string, extraPlugins?: UnifiedPlugin) {
-  return await bundleMDX({
-    source,
-    mdxOptions(options) {
-      const plugins = [
-        ...(extraPlugins || []),
-        ...(options.rehypePlugins ?? []),
-        rehypeMetaAttribute,
-        rehypeHighlightCode,
-        rehypeAutolinkHeadings,
-        rehypeSlug,
-      ]
-      options.rehypePlugins = plugins as any
-      return options
-    },
-  })
+  const bundle = await getMDX(source, extraPlugins)
+  return bundle
 }
 
 export function getAllVersionsFromPath(fromPath: string): string[] {

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -1,4 +1,5 @@
 export { getAllFrontmatter } from './getAllFrontmatter'
+export { getMDX } from './getMDX'
 export { getAllVersionsFromPath, getMDXBySlug } from './getMDXBySlug'
 export { createCodeHighlighter } from './highlightCode'
 export type { Frontmatter } from './types'

--- a/packages/mdx/src/types.ts
+++ b/packages/mdx/src/types.ts
@@ -18,3 +18,5 @@ export type Frontmatter = {
   package?: string
   demoName?: string
 }
+
+export type UnifiedPlugin = import('unified').Plugin[]

--- a/packages/mdx/types/getMDX.d.ts
+++ b/packages/mdx/types/getMDX.d.ts
@@ -1,0 +1,6 @@
+import type { Frontmatter, UnifiedPlugin } from './types';
+export declare function getMDX(source: string, extraPlugins?: UnifiedPlugin): Promise<{
+    frontmatter: Frontmatter;
+    code: string;
+}>;
+//# sourceMappingURL=getMDX.d.ts.map

--- a/packages/mdx/types/getMDXBySlug.d.ts
+++ b/packages/mdx/types/getMDXBySlug.d.ts
@@ -1,20 +1,7 @@
-import type { Frontmatter } from './types';
-export type UnifiedPlugin = import('unified').Plugin[];
+import type { Frontmatter, UnifiedPlugin } from './types';
 export declare const getMDXBySlug: (basePath: string, slug: string, extraPlugins?: UnifiedPlugin) => Promise<{
     frontmatter: Frontmatter;
     code: string;
-}>;
-export declare function getMDX(source: string, extraPlugins?: UnifiedPlugin): Promise<{
-    code: string;
-    frontmatter: {
-        [key: string]: any;
-    };
-    errors: import("esbuild").Message[];
-    matter: Omit<import("gray-matter").GrayMatterFile<string>, "data"> & {
-        data: {
-            [key: string]: any;
-        };
-    };
 }>;
 export declare function getAllVersionsFromPath(fromPath: string): string[];
 //# sourceMappingURL=getMDXBySlug.d.ts.map

--- a/packages/mdx/types/index.d.ts
+++ b/packages/mdx/types/index.d.ts
@@ -1,4 +1,5 @@
 export { getAllFrontmatter } from './getAllFrontmatter';
+export { getMDX } from './getMDX';
 export { getAllVersionsFromPath, getMDXBySlug } from './getMDXBySlug';
 export { createCodeHighlighter } from './highlightCode';
 export type { Frontmatter } from './types';

--- a/packages/mdx/types/types.d.ts
+++ b/packages/mdx/types/types.d.ts
@@ -27,4 +27,5 @@ export type Frontmatter = {
     package?: string;
     demoName?: string;
 };
+export type UnifiedPlugin = import('unified').Plugin[];
 //# sourceMappingURL=types.d.ts.map


### PR DESCRIPTION
I would like to use one to load mdx from a source other than the slug. This PR enables this by exporting `getMDX`.

Changes:
- Move `getMDX` to it's own file
- Move `getHeadings` and `readingTime` calls into `getMDX`
- Move UnifiedPlugin type to types file
- Export `getMDX` in index