### PR TITLE
test(react-native-prebuilt): ensure we re-export all from react

### DIFF
--- a/packages/react-native-prebuilt/src/index.test.ts
+++ b/packages/react-native-prebuilt/src/index.test.ts
@@ -1,0 +1,24 @@
+import { expect, describe, it } from 'vitest'
+
+import { RExports, RNExportNames } from './index'
+
+describe('RExports', () => {
+  it('should contain all keys that the `react` package exports', async () => {
+    const React = (await import('react')).default
+
+    for (const key in React) {
+      expect(RExports).toContain(key)
+    }
+  })
+})
+
+// describe('RNExportNames', () => {
+//   // RN can't be imported directly so no way to test like this :(
+//   // it('should contain all keys that the `react-native` package exports', async () => {
+//   //   const ReactNative = (await import('react-native')).default
+
+//   //   for (const key in ReactNative) {
+//   //     expect(RNExportNames).toContain(key)
+//   //   }
+//   // })
+// })

--- a/packages/react-native-prebuilt/src/index.ts
+++ b/packages/react-native-prebuilt/src/index.ts
@@ -318,7 +318,7 @@ const esbuildCommonJSFunction = `var __commonJS = (cb, mod) => function __requir
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };`
 
-const RNExportNames = [
+export const RNExportNames = [
   'registerCallableModule',
   'AccessibilityInfo',
   'ActivityIndicator',
@@ -398,7 +398,7 @@ const RNExportNames = [
   'AssetRegistry', // Normally not exported by React Native, but with a hack we make @react-native/assets-registry/registry available here.
 ]
 
-const RExports = [
+export const RExports = [
   'Children',
   'Component',
   'Fragment',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11595,6 +11595,7 @@ __metadata:
     react-dom: "npm:^18.3.1 || ^19.0.0"
     react-native: "npm:^0.76.5"
     tsx: "npm:^4.19.0"
+    vitest: "npm:^2.1.8"
   peerDependencies:
     react: "*"
     react-dom: "*"


### PR DESCRIPTION
Simple test for a simple workaround.