### PR TITLE
Fix `one-recommended` example broken on web due to `useLoader` behavior changes

### DIFF
--- a/packages/one/src/cli/build.ts
+++ b/packages/one/src/cli/build.ts
@@ -465,22 +465,22 @@ export async function build(args: {
         if (exported.loader) {
           loaderData = (await exported.loader?.({ path, params })) ?? null
           const code = await readFile(clientJsPath, 'utf-8')
-          const withLoader = 
-          // super dirty to quickly make ssr loaders work until we have better
-          `
+          const withLoader =
+            // super dirty to quickly make ssr loaders work until we have better
+            `
 if (typeof document === 'undefined') globalThis.document = {}
-` + replaceLoader({
-            code,
-            loaderData,
-          })          
+` +
+            replaceLoader({
+              code,
+              loaderData,
+            })
           const loaderPartialPath = join(clientDir, getLoaderPath(path))
           await outputFile(loaderPartialPath, withLoader)
         }
-        
+
         // ssr, we basically skip at build-time and just compile it the js we need
         if (foundRoute.type !== 'ssr') {
           const loaderProps: LoaderProps = { path, params }
-          globalThis['__vxrnLoaderProps__'] = loaderProps
           // importing resetState causes issues :/
           globalThis['__vxrnresetState']?.()
 
@@ -501,7 +501,7 @@ if (typeof document === 'undefined') globalThis.document = {}
             await outputFile(
               htmlOutPath,
               `<html><head>
-              ${constants.SPA_HEADER_ELEMENTS}
+              ${constants.getSpaHeaderElements({ serverContext: { loaderProps, loaderData } })}
               ${preloads
                 .map((preload) => `   <script type="module" src="${preload}"></script>`)
                 .join('\n')}
@@ -519,10 +519,10 @@ if (typeof document === 'undefined') globalThis.document = {}
 ${errMsg}
 
   loaderData:
-  
+
 ${JSON.stringify(loaderData || null, null, 2)}
   params:
-  
+
 ${JSON.stringify(params || null, null, 2)}`
         )
         console.error(err)
@@ -655,8 +655,8 @@ function getPathnameFromFilePath(path: string, params = {}, strict = false) {
   function paramsError(part: string) {
     throw new Error(
       `[one] Params doesn't fit route:
-      
-      - path: ${path} 
+
+      - path: ${path}
       - part: ${part}
       - fileName: ${fileName}
       - params:

--- a/packages/one/src/constants.ts
+++ b/packages/one/src/constants.ts
@@ -1,3 +1,5 @@
+import type { ServerContext } from './utils/serverContext'
+
 export const isWebClient = process.env.TAMAGUI_TARGET !== 'native' && typeof window !== 'undefined'
 export const isWebServer = process.env.TAMAGUI_TARGET !== 'native' && typeof window === 'undefined'
 export const isNative = process.env.TAMAGUI_TARGET === 'native'
@@ -17,8 +19,10 @@ export const VIRTUAL_SSR_CSS_HREF = `/@id/__x00__${VIRTUAL_SSR_CSS_ENTRY}`
 
 export const SERVER_CONTEXT_KEY = '__one_server_context__'
 
-export const SPA_HEADER_ELEMENTS = `
+export const getSpaHeaderElements = ({
+  serverContext = {},
+}: { serverContext?: ServerContext } = {}) => `
   <script>globalThis['global'] = globalThis</script>
   <script>globalThis['__vxrnIsSPA'] = true</script>
-  <script>globalThis["${SERVER_CONTEXT_KEY}"] = {}</script>
+  <script>globalThis["${SERVER_CONTEXT_KEY}"] = ${JSON.stringify(serverContext)}</script>
 `

--- a/packages/one/src/createHandleRequest.ts
+++ b/packages/one/src/createHandleRequest.ts
@@ -109,7 +109,7 @@ export async function resolveAPIRoute(
       console.error(`\n [one] Error importing API route at ${pathname}:
 
         ${err}
-      
+
         If this is an import error, you can likely fix this by adding this dependency to
         the "optimizeDeps.include" array in your vite.config.ts.
       `)
@@ -253,6 +253,7 @@ export function createHandleRequest(handlers: RequestHandlers) {
             }
 
             const finalUrl = new URL(originalUrl, url.origin)
+            finalUrl.search = url.search
 
             if (!route.compiledRegex.test(finalUrl.pathname)) {
               continue

--- a/packages/one/src/useLoader.ts
+++ b/packages/one/src/useLoader.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useEffect, useRef } from 'react'
 import { getLoaderPath } from './utils/cleanUrl'
-import { useActiveParams, useParams } from './hooks'
+import { useActiveParams, useParams, usePathname } from './hooks'
 import { resolveHref } from './link/href'
 import { useRouteNode } from './router/Route'
 import { preloadingLoader } from './router/router'
@@ -24,6 +24,7 @@ export function useLoader<
     return useAsyncFn(
       loader,
       preloadedProps || {
+        path: usePathname(),
         params: useActiveParams(),
       }
     )

--- a/packages/one/src/utils/serverContext.tsx
+++ b/packages/one/src/utils/serverContext.tsx
@@ -1,6 +1,6 @@
 import { SERVER_CONTEXT_KEY } from '../constants'
 
-type ServerContext = {
+export type ServerContext = {
   css?: string[]
   postRenderData?: any
   loaderData?: any
@@ -8,7 +8,7 @@ type ServerContext = {
   mode?: 'spa' | 'ssg' | 'ssr'
 }
 
-type MaybeServerContext = null | ServerContext
+export type MaybeServerContext = null | ServerContext
 
 export const SERVER_CONTEXT_POST_RENDER_STRING = `_one_post_render_data_`
 

--- a/packages/one/src/vite/plugins/fileSystemRouterPlugin.tsx
+++ b/packages/one/src/vite/plugins/fileSystemRouterPlugin.tsx
@@ -3,7 +3,7 @@ import { debounce } from 'perfect-debounce'
 import type { Connect, Plugin, ViteDevServer } from 'vite'
 import { createServerModuleRunner } from 'vite'
 import type { ModuleRunner } from 'vite/module-runner'
-import { SPA_HEADER_ELEMENTS } from '../../constants'
+import { getSpaHeaderElements } from '../../constants'
 import { createHandleRequest } from '../../createHandleRequest'
 import type { RenderAppProps } from '../../types'
 import { isResponse } from '../../utils/isResponse'
@@ -38,7 +38,7 @@ export function createFileSystemRouterPlugin(options: One.PluginOptions): Plugin
         if (route.type === 'spa') {
           // render just the layouts? route.layouts
           return `<html><head>
-            ${SPA_HEADER_ELEMENTS}
+            ${getSpaHeaderElements({ serverContext: { mode: 'spa' } })}
             <script type="module">
               import { injectIntoGlobalHook } from "/@react-refresh";
               injectIntoGlobalHook(window);

--- a/packages/one/types/constants.d.ts
+++ b/packages/one/types/constants.d.ts
@@ -1,3 +1,4 @@
+import type { ServerContext } from './utils/serverContext';
 export declare const isWebClient: boolean;
 export declare const isWebServer: boolean;
 export declare const isNative: boolean;
@@ -10,5 +11,7 @@ export declare const PRELOAD_JS_POSTFIX: string;
 export declare const VIRTUAL_SSR_CSS_ENTRY = "virtual:ssr-css.css";
 export declare const VIRTUAL_SSR_CSS_HREF = "/@id/__x00__virtual:ssr-css.css";
 export declare const SERVER_CONTEXT_KEY = "__one_server_context__";
-export declare const SPA_HEADER_ELEMENTS = "\n  <script>globalThis['global'] = globalThis</script>\n  <script>globalThis['__vxrnIsSPA'] = true</script>\n  <script>globalThis[\"__one_server_context__\"] = {}</script>\n";
+export declare const getSpaHeaderElements: ({ serverContext, }?: {
+    serverContext?: ServerContext;
+}) => string;
 //# sourceMappingURL=constants.d.ts.map

--- a/packages/one/types/utils/serverContext.d.ts
+++ b/packages/one/types/utils/serverContext.d.ts
@@ -1,14 +1,13 @@
-type ServerContext = {
+export type ServerContext = {
     css?: string[];
     postRenderData?: any;
     loaderData?: any;
     loaderProps?: any;
     mode?: 'spa' | 'ssg' | 'ssr';
 };
-type MaybeServerContext = null | ServerContext;
+export type MaybeServerContext = null | ServerContext;
 export declare const SERVER_CONTEXT_POST_RENDER_STRING = "_one_post_render_data_";
 export declare function setServerContext(c: ServerContext): void;
 export declare function getServerContext(): MaybeServerContext;
 export declare function ServerContextScript(): import("react/jsx-runtime").JSX.Element;
-export {};
 //# sourceMappingURL=serverContext.d.ts.map


### PR DESCRIPTION
It seems that the global `__vxrnLoaderProps__` and `__vxrnLoaderData__` is now replaced with server context in #378.

The first commit made things work, while the second and third commit is a further proper fix.