### PR TITLE
fix(compiler): should recognize production mode when used to build RN bundle

### DIFF
--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -149,13 +149,17 @@ ${rootJS.code}
           let code = codeIn
           const environment = getEnvName(this.environment.name)
           const isNative = environment === 'ios' || environment === 'android'
+          const production =
+            process.env.NODE_ENV === 'production' ||
+            JSON.parse(this.environment.config?.define?.['process.env.NODE_ENV'] || '""') ===
+              'production'
 
           // it has a hidden special character
           // TODO: use === special char this is in sensitive perf path
           const isEntry = _id.includes('one-entry-native')
 
           if (isEntry) {
-            if (isNative && process.env.NODE_ENV === 'development') {
+            if (isNative && !production) {
               code = `import '@vxrn/vite-native-client'\n${code}`
             }
             if (isNative && configuration.enableNativewind) {
@@ -185,8 +189,6 @@ ${rootJS.code}
           if (!validParsers.has(extension)) {
             return
           }
-
-          const production = process.env.NODE_ENV === 'production'
 
           let id = _id.split('?')[0]
 


### PR DESCRIPTION
Fixes broken RN native builds.

Since when Xcode calls the bundle script, it won't be using `NODE_ENV`.

It would have been broken already, but luckily there's `forceJSX` which prevents this from happening, until [this change](https://github.com/onejs/one/pull/406/files#diff-99afc6baff732daa1f90f304742f5bddbd93b04441d389f4ec7b37e55914a79fL41).