### PR TITLE
Fix: Improve theme toggle button accessibility

### DIFF
--- a/apps/onestack.dev/components/TopNav.tsx
+++ b/apps/onestack.dev/components/TopNav.tsx
@@ -10,6 +10,8 @@ import { SocialLinksRow } from '~/features/site/SocialLinksRow'
 import { ToggleThemeButton } from '~/features/theme/ThemeToggleButton'
 
 const SimpleButton = styled(View, {
+  role: 'button',
+  cursor: 'pointer',
   pe: 'auto',
   w: 42,
   h: 42,

--- a/apps/onestack.dev/features/theme/ThemeToggleButton.tsx
+++ b/apps/onestack.dev/features/theme/ThemeToggleButton.tsx
@@ -23,6 +23,8 @@ export function ToggleThemeButton() {
         pointerEvents="auto"
         cur="pointer"
         onPress={onPress}
+        role="button"
+        aria-label="Toggle theme"
       >
         <Icon size={22} color="$color13" />
       </View>


### PR DESCRIPTION
- Added `role="button"` to theme toggle buttons to make them keyboard accessible
- Ensures buttons can be reached via tab navigation