### PR TITLE
feat(site): scroll to hash element on page load

### DIFF
--- a/apps/onestack.dev/app/docs/[slug].tsx
+++ b/apps/onestack.dev/app/docs/[slug].tsx
@@ -1,7 +1,7 @@
 import { getMDXComponent } from 'mdx-bundler/client'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { H1 } from 'tamagui'
-import { useLoader } from 'one'
+import { useLoader, useParams } from 'one'
 import { DocsRightSidebar } from '~/features/docs/DocsRightSidebar'
 import { components } from '~/features/docs/MDXComponents'
 import { HeadInfo } from '~/features/site/HeadInfo'
@@ -28,6 +28,23 @@ export async function loader({ params }) {
 export function DocCorePage() {
   const { code, frontmatter } = useLoader(loader)
   const Component = useMemo(() => getMDXComponent(code), [code])
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const hash = window.location.hash
+      if (!hash || !hash.startsWith('#')) return
+
+      const id = hash.slice(1)
+      const el = document.getElementById(id)
+      if (!el) return
+
+      el.scrollIntoView({ behavior: 'instant' })
+    }, 50)
+
+    return () => {
+      clearTimeout(timeout)
+    }
+  })
 
   return (
     <>


### PR DESCRIPTION
Trying to implement this on the website first, and if it works well, we can consider moving it into the framework.

Tried to make One support accessing the hash from `useParams`, but still no luck yet.

If we read from `window.location`, there'll be a time gap since the page component will be loaded before the URL has been updated. Thus, `setTimeout` is used here.