### PR TITLE
should always optimize `react/jsx-dev-runtime` if it’s there

### DIFF
--- a/packages/one/src/vite/one.ts
+++ b/packages/one/src/vite/one.ts
@@ -324,6 +324,26 @@ export function one(options: One.PluginOptions = {}): PluginOption {
         })
       },
     } satisfies Plugin,
+
+    // Plugins may transform the source code and add imports of `react/jsx-dev-runtime`, which won't be discovered by Vite's initial `scanImports` since the implementation is using ESbuild where such plugins are not executed.
+    // Thus, if the project has a valid `react/jsx-dev-runtime` import, we tell Vite to optimize it, so Vite won't only discover it on the next page load and trigger a full reload.
+    {
+      name: 'one:optimize-react-dev-runtime',
+
+      config() {
+        try {
+          resolvePath('react/jsx-dev-runtime', root)
+
+          return {
+            optimizeDeps: {
+              include: ['react/jsx-dev-runtime'],
+            },
+          }
+        } catch {
+          return {}
+        }
+      },
+    } satisfies Plugin
   ] satisfies Plugin[]
 
   // react scan


### PR DESCRIPTION
Context: https://discord.com/channels/909986013848412191/1330712751739375708/1331662439581876306