### PR TITLE
Add missing @tamagui/config to the tamagui example

### DIFF
--- a/examples/one-tamagui/package.json
+++ b/examples/one-tamagui/package.json
@@ -18,6 +18,7 @@
     "@tamagui/animations-css": "^1.122.7",
     "@tamagui/animations-moti": "^1.122.7",
     "@tamagui/colors": "^1.122.7",
+    "@tamagui/config": "^1.122.7",
     "@tamagui/image-next": "^1.122.7",
     "@tamagui/lucide-icons": "^1.122.7",
     "@tamagui/react-native-media-driver": "^1.122.7",


### PR DESCRIPTION
I have created a project with tamagui template and noticed the `@tamagui/config` package was missing

```
✘ [ERROR] Could not resolve "@tamagui/config/v4"

    src/tamagui/tamagui.config.ts:1:30:
      1 │ import { defaultConfig } from '@tamagui/config/v4'
        ╵                               ~~~~~~~~~~~~~~~~~~~~
```