### PR TITLE
docs: update react-native-bottom-tabs integration

### DIFF
--- a/apps/onestack.dev/data/docs/exports-withLayoutContext.mdx
+++ b/apps/onestack.dev/data/docs/exports-withLayoutContext.mdx
@@ -10,7 +10,7 @@ A good example of this is the new [`react-native-bottom-tabs`](https://github.co
 To make any React Navigation navigator work inside a One layout, use `withLayoutContext`:
 
 ```tsx
-import { createNativeBottomTabNavigator } from 'react-native-bottom-tabs/react-navigation'
+import { createNativeBottomTabNavigator } from '@bottom-tabs/react-navigation'
 import { withLayoutContext } from 'one'
 
 const NativeTabsNavigator = createNativeBottomTabNavigator().Navigator


### PR DESCRIPTION
Hey!

Since a few releases, I've been keeping the React Navigation integration in a separate package. This PR reflects this change in the docs.