### PR TITLE
showing new hotUpdate

### DIFF
--- a/examples/one-tamagui/app/_layout.tsx
+++ b/examples/one-tamagui/app/_layout.tsx
@@ -9,7 +9,7 @@ import { TamaguiRootProvider } from '../src/tamagui/TamaguiRootProvider'
  * The root _layout.tsx filters <html /> and <body /> out on native
  */
 
-export default function Layout() {
+export function Layout() {
   return (
     <html lang="en-US">
       <head>

--- a/examples/one-tamagui/app/index.tsx
+++ b/examples/one-tamagui/app/index.tsx
@@ -1,15 +1,15 @@
 import { Image } from '@tamagui/image-next'
-import { Text, YStack } from 'tamagui'
 import { Link } from 'one'
-import { ToggleThemeButton } from '~/interface/ToggleThemeButton'
-import oneBall from '~/app-icon.png'
 import { version } from 'react'
+import { Text, YStack } from 'tamagui'
+import oneBall from '~/app-icon.png'
+import { ToggleThemeButton } from '~/interface/ToggleThemeButton'
 
 export function HomePage() {
   return (
     <YStack bg="$color1" minH="100%" gap="$4" px="$4" items="center" justify="center" flex={1}>
       <Text fontSize="$8" text="center">
-        Hello, One
+        Hello, One2222222222222222222
       </Text>
 
       <Image src={oneBall} width={128} height={128} />

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@tamagui/build": "^1.124.1",
+    "@types/react-refresh": "^0",
     "depcheck": "^1.4.7",
     "react-native": "^0.76.5",
     "rollup": "^4.29.1"

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { resolvePath } from '@vxrn/utils'
+import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { extname, join, sep } from 'node:path'
@@ -15,7 +16,6 @@ import { debug, runtimePublicPath, validParsers } from './constants'
 import { getBabelOptions, transformBabel } from './transformBabel'
 import { transformSWC } from './transformSWC'
 import type { Environment, GetTransformProps, Options } from './types'
-import { createHash } from 'node:crypto'
 
 export * from './configure'
 export * from './transformBabel'

--- a/packages/compiler/src/transformSWC.ts
+++ b/packages/compiler/src/transformSWC.ts
@@ -294,7 +294,6 @@ ${result.code}
 if (module.hot) {
   globalThis.$RefreshReg$ = prevRefreshReg;
   globalThis.$RefreshSig$ = prevRefreshSig;
-  globalThis['lastHmrExports'] = JSON.stringify(Object.keys(exports))
 }
 
 ${postfixCode}

--- a/packages/one/src/router/useScreens.tsx
+++ b/packages/one/src/router/useScreens.tsx
@@ -178,16 +178,15 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       console.groupEnd()
     }
 
-    if (props.segment === '') {
+    if (value.contextKey === './_layout.tsx') {
+      // this is breaking root layout hmr
       // @ts-expect-error
       const out = Component(props, ref)
-
       const { children, bodyProps, head, htmlProps } = filterRootHTML(out)
       const { children: headChildren, ...headProps } = head?.props || {}
       const serverContext = useServerContext()
 
-      // let finalChildren = <Suspense fallback={null}>{children}</Suspense>
-      let finalChildren = children
+      let finalChildren = <SafeAreaProviderCompat>{children}</SafeAreaProviderCompat>
 
       if (process.env.TAMAGUI_TARGET === 'native') {
         // on native we just ignore all html/body/head
@@ -210,7 +209,7 @@ export function getQualifiedRouteComponent(value: RouteNode) {
             {headChildren}
           </head>
           <body key="body" suppressHydrationWarning {...bodyProps}>
-            <SafeAreaProviderCompat>{finalChildren}</SafeAreaProviderCompat>
+            {finalChildren}
           </body>
         </>
       )

--- a/packages/vite-native-client/src/client.ts
+++ b/packages/vite-native-client/src/client.ts
@@ -167,6 +167,8 @@ const debounceReload = (time: number) => {
 const pageReload = debounceReload(50)
 
 async function handleMessage(payload: HMRPayload) {
+  console.log('MESSAGE', JSON.stringify(payload, null, 2))
+
   switch (payload.type) {
     case 'connected':
       console.info(`[vite] connected.`)

--- a/packages/vite-native-hmr/src/hmr-client.ts
+++ b/packages/vite-native-hmr/src/hmr-client.ts
@@ -1,6 +1,17 @@
 import { getDevServerLocation } from './getDevServerLocation'
 
 /**
+ * 🚨🚨🚨🚨🚨🚨🚨
+ *
+ *
+ * It seems we're doing HMR from `@vxrn/vite-native-client`
+ *
+ *
+ * Can we remove this?
+ *
+ */
+
+/**
  * Represent Hot Module Replacement Update body.
  *
  * @internal

--- a/packages/vite-native-hmr/types/hmr-client.d.ts
+++ b/packages/vite-native-hmr/types/hmr-client.d.ts
@@ -1,4 +1,14 @@
 /**
+ * 🚨🚨🚨🚨🚨🚨🚨
+ *
+ *
+ * It seems we're doing HMR from `@vxrn/vite-native-client`
+ *
+ *
+ * Can we remove this?
+ *
+ */
+/**
  * Represent Hot Module Replacement Update body.
  *
  * @internal

--- a/packages/vxrn/src/plugins/reactNativeDevServer.ts
+++ b/packages/vxrn/src/plugins/reactNativeDevServer.ts
@@ -5,7 +5,11 @@ import {
   removeConnectedNativeClient,
 } from '../utils/connectedNativeClients'
 import type { VXRNOptionsFilled } from '../utils/getOptionsFilled'
-import { clearCachedBundle, getReactNativeBundle } from '../utils/getReactNativeBundle'
+import {
+  clearCachedBundle,
+  getReactNativeBundle,
+  lastRequestedBundlePlatform,
+} from '../utils/getReactNativeBundle'
 import { hotUpdateCache } from '../utils/hotUpdateCache'
 import { URL } from 'node:url'
 import { existsSync } from 'node:fs'
@@ -117,7 +121,10 @@ export function createReactNativeDevServerPlugin(options: VXRNOptionsFilled): Pl
       })
 
       hmrWSS.on('connection', (socket) => {
-        addConnectedNativeClient()
+        const platform = lastRequestedBundlePlatform
+        if (!platform) return
+
+        addConnectedNativeClient(platform)
 
         socket.on('message', (message) => {
           if (message.toString().includes('ping')) {
@@ -126,7 +133,7 @@ export function createReactNativeDevServerPlugin(options: VXRNOptionsFilled): Pl
         })
 
         socket.on('close', () => {
-          removeConnectedNativeClient()
+          removeConnectedNativeClient(platform)
         })
 
         socket.on('error', (error) => {

--- a/packages/vxrn/src/plugins/reactNativeHMRPlugin.ts
+++ b/packages/vxrn/src/plugins/reactNativeHMRPlugin.ts
@@ -16,7 +16,7 @@ export function reactNativeHMRPlugin({
   root,
   assetExts,
   mode,
-}: VXRNOptionsFilled & { assetExts: string[] }) {
+}: VXRNOptionsFilled & { assetExts: string[] }): Plugin {
   let idResolver: ReturnType<typeof createIdResolver>
 
   const assetExtsRegExp = new RegExp(`\\.(${assetExts.join('|')})$`)
@@ -27,8 +27,14 @@ export function reactNativeHMRPlugin({
 
     // TODO see about moving to hotUpdate
     // https://deploy-preview-16089--vite-docs-main.netlify.app/guide/api-vite-environment.html#the-hotupdate-hook
-    async handleHotUpdate({ read, modules, file, server }) {
-      const environment = server.environments.ios // TODO: android? How can we get the current environment here?
+    async hotUpdate({ read, modules, file, server }) {
+      if (!connectedNativeClients.get(this.environment.name)) {
+        return
+      }
+
+      console.log('no modules?', modules)
+
+      const environment = server.environments[this.environment.name]
 
       if (!idResolver) {
         const rnConfig = getReactNativeResolvedConfig()
@@ -48,9 +54,6 @@ export function reactNativeHMRPlugin({
 
       try {
         if (!isWithin(root, file)) {
-          return
-        }
-        if (!connectedNativeClients) {
           return
         }
 

--- a/packages/vxrn/src/utils/connectedNativeClients.ts
+++ b/packages/vxrn/src/utils/connectedNativeClients.ts
@@ -1,9 +1,11 @@
-export let connectedNativeClients = 0
+type Env = string
 
-export function addConnectedNativeClient() {
-  connectedNativeClients++
+export const connectedNativeClients = new Map<Env, number>()
+
+export function addConnectedNativeClient(env: Env) {
+  connectedNativeClients.set(env, (connectedNativeClients.get(env) || 0) + 1)
 }
 
-export function removeConnectedNativeClient() {
-  connectedNativeClients--
+export function removeConnectedNativeClient(env: Env) {
+  connectedNativeClients.set(env, (connectedNativeClients.get(env) || 0) - 1)
 }

--- a/packages/vxrn/src/utils/getReactNativeBundle.ts
+++ b/packages/vxrn/src/utils/getReactNativeBundle.ts
@@ -18,6 +18,9 @@ export function clearCachedBundle() {
   cachedReactNativeBundles = {}
 }
 
+// TODO figure out better
+export let lastRequestedBundlePlatform: 'ios' | 'android' | null = null
+
 export async function getReactNativeBundle(
   options: VXRNOptionsFilled,
   platform: 'ios' | 'android',
@@ -27,6 +30,7 @@ export async function getReactNativeBundle(
   }
 ) {
   entryRoot = options.root
+  lastRequestedBundlePlatform = platform
 
   const cached = cachedReactNativeBundles[platform]
   if (cached && !process.env.VXRN_DISABLE_CACHE) {

--- a/packages/vxrn/types/plugins/reactNativeHMRPlugin.d.ts
+++ b/packages/vxrn/types/plugins/reactNativeHMRPlugin.d.ts
@@ -1,8 +1,6 @@
+import { type Plugin } from 'vite';
 import type { VXRNOptionsFilled } from '../utils/getOptionsFilled';
 export declare function reactNativeHMRPlugin({ root, assetExts, mode, }: VXRNOptionsFilled & {
     assetExts: string[];
-}): {
-    name: string;
-    handleHotUpdate(this: void, { read, modules, file, server }: import("vite").HmrContext): Promise<void>;
-};
+}): Plugin;
 //# sourceMappingURL=reactNativeHMRPlugin.d.ts.map

--- a/packages/vxrn/types/utils/connectedNativeClients.d.ts
+++ b/packages/vxrn/types/utils/connectedNativeClients.d.ts
@@ -1,4 +1,6 @@
-export declare let connectedNativeClients: number;
-export declare function addConnectedNativeClient(): void;
-export declare function removeConnectedNativeClient(): void;
+type Env = string;
+export declare const connectedNativeClients: Map<string, number>;
+export declare function addConnectedNativeClient(env: Env): void;
+export declare function removeConnectedNativeClient(env: Env): void;
+export {};
 //# sourceMappingURL=connectedNativeClients.d.ts.map

--- a/packages/vxrn/types/utils/getReactNativeBundle.d.ts
+++ b/packages/vxrn/types/utils/getReactNativeBundle.d.ts
@@ -1,6 +1,7 @@
 import type { VXRNOptionsFilled } from './getOptionsFilled';
 export declare let entryRoot: string;
 export declare function clearCachedBundle(): void;
+export declare let lastRequestedBundlePlatform: 'ios' | 'android' | null;
 export declare function getReactNativeBundle(options: VXRNOptionsFilled, platform: 'ios' | 'android', internal?: {
     mode?: 'dev' | 'prod';
     assetsDest?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10383,7 +10383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.1.14":
+"@types/babel__core@npm:*, @types/babel__core@npm:^7.1.14":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
   dependencies:
@@ -10775,6 +10775,16 @@ __metadata:
   dependencies:
     react-native: "npm:*"
   checksum: 10/a764ca5d876dae3c109da449f736c44271b3b236d0d6e836c078247af1419f6d851600c56bb0c26f3e0d1b4be6eaac56b65c1f74ad0f0d05baf8b65dd1d5c597
+  languageName: node
+  linkType: hard
+
+"@types/react-refresh@npm:^0":
+  version: 0.14.6
+  resolution: "@types/react-refresh@npm:0.14.6"
+  dependencies:
+    "@types/babel__core": "npm:*"
+    csstype: "npm:^3.0.2"
+  checksum: 10/352331d47915913151e6895abebf73461e42baab0377ded19d57b9ea1c33be74019d57fd70b7dc974b1049de430077d00e581eba29d10c9fbbb374bae447ed70
   languageName: node
   linkType: hard
 
@@ -11386,6 +11396,7 @@ __metadata:
     "@babel/plugin-transform-regenerator": "npm:^7.25.9"
     "@swc/core": "npm:^1.10.4"
     "@tamagui/build": "npm:^1.124.1"
+    "@types/react-refresh": "npm:^0"
     "@vxrn/utils": "workspace:*"
     "@vxrn/vite-native-client": "workspace:*"
     babel-plugin-react-compiler: "npm:^19.0.0-beta-201e55d-20241215"


### PR DESCRIPTION
I was experimenting with fixing hot reload on root layout, that is tricky due to our wrapping and filtering of HTML. probably we need to fall back to a compiler method to inject the helper for the root layout.

This shows some other improvements for hmr @zetavg but problem is `modules` is empty for ios env, its only filled out for web. I think because we have two separate vite things going and only web is actually being used. We'd need a bigger refactor.