### PR TITLE
fix: redirect homepage hyperlinks correctly

### DIFF
--- a/apps/onestack.dev/app/index.tsx
+++ b/apps/onestack.dev/app/index.tsx
@@ -149,11 +149,11 @@ export default function HomePage() {
               loaders
             </Link>
             ,{' '}
-            <Link style={{ color: 'var(--color11)' }} href="/docs/routing-middleware">
+            <Link style={{ color: 'var(--color11)' }} href="/docs/routing-middlewares">
               middleware
             </Link>
             , a{' '}
-            <Link style={{ color: 'var(--color11)' }} href="/docs/">
+            <Link style={{ color: 'var(--color11)' }} href="/docs/one-dev">
               CLI
             </Link>
             ,{' '}


### PR DESCRIPTION
Closes [#501](https://github.com/onejs/one/issues/501)

Fixed the broken hyperlinks on the homepage that were leading to a white page when clicking "CLI" and "Middleware." The links now navigate to the correct sections of the page. Let me know if anything else needs adjustment!