### PR TITLE
chore: update biome to v1.9.4

### DIFF
--- a/apps/devtools/biome.json
+++ b/apps/devtools/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/apps/devtools/biome.json
+++ b/apps/devtools/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/apps/onestack.dev/biome.json
+++ b/apps/onestack.dev/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/examples/bare/biome.json
+++ b/examples/bare/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/examples/bare/biome.json
+++ b/examples/bare/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/examples/one-recommended/biome.json
+++ b/examples/one-recommended/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/examples/one-recommended/biome.json
+++ b/examples/one-recommended/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/examples/one-recommended/package.json
+++ b/examples/one-recommended/package.json
@@ -45,7 +45,7 @@
     "tamagui": "^1.125.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@faker-js/faker": "next",
     "@react-native-community/cli": "15.1.3",
     "@tamagui/vite-plugin": "^1.125.8",

--- a/examples/one-tamagui/biome.json
+++ b/examples/one-tamagui/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/examples/one-tamagui/biome.json
+++ b/examples/one-tamagui/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/examples/one-tamagui/package.json
+++ b/examples/one-tamagui/package.json
@@ -38,7 +38,7 @@
     "tamagui": "^1.125.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@react-native-community/cli": "15.1.3",
     "@tamagui/vite-plugin": "^1.125.8",
     "@types/react": "^18.3.11",

--- a/examples/one-zero/biome.json
+++ b/examples/one-zero/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/examples/testflight/biome.json
+++ b/examples/testflight/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/examples/testflight/biome.json
+++ b/examples/testflight/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/examples/testflight/package.json
+++ b/examples/testflight/package.json
@@ -46,7 +46,7 @@
     "tamagui": "^1.125.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@faker-js/faker": "next",
     "@react-native-community/cli": "15.1.3",
     "@tamagui/vite-plugin": "^1.125.8",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
   "repository": {
     "url": "https://github.com/onejs/one"
   },
-  "workspaces": [
-    "./apps/*",
-    "./packages/*",
-    "./examples/*",
-    "./tests/*"
-  ],
+  "workspaces": ["./apps/*", "./packages/*", "./examples/*", "./tests/*"],
   "scripts": {
     "build": "turbo run build --filter='*' --filter='!example/*'",
     "build:js": "yarn build --no-cache --force -- --skip-types",
@@ -60,7 +55,7 @@
     "watch:ts": "ultra -r --no-pretty --concurrency 400 typecheck -w --preserveWatchOutput"
   },
   "dependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@manypkg/cli": "^0.19.1",
     "@types/react": "^18.3.11",
     "@types/react-native": "^0.73.0",

--- a/packages/lllink/package.json
+++ b/packages/lllink/package.json
@@ -10,9 +10,7 @@
     }
   },
   "bin": "./dist/index.mjs",
-  "files": [
-    "src"
-  ],
+  "files": ["src"],
   "scripts": {
     "build": "tamagui-build --skip-types --skip-native",
     "watch": "yarn build --watch",
@@ -22,7 +20,7 @@
     "lint:fix": "../../node_modules/.bin/biome check --write --unsafe src"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@tamagui/build": "^1.125.8"
   },
   "publishConfig": {

--- a/packages/query-string/package.json
+++ b/packages/query-string/package.json
@@ -18,11 +18,7 @@
       "require": "./dist/cjs/index.cjs"
     }
   },
-  "files": [
-    "src",
-    "types",
-    "dist"
-  ],
+  "files": ["src", "types", "dist"],
   "scripts": {
     "build": "tamagui-build",
     "watch": "tamagui-build --watch",

--- a/packages/safe-area/package.json
+++ b/packages/safe-area/package.json
@@ -29,7 +29,7 @@
     }
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@tamagui/build": "^1.125.8"
   }
 }

--- a/packages/vite-flow/package.json
+++ b/packages/vite-flow/package.json
@@ -13,11 +13,7 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "types": "./types/index.d.ts",
-  "files": [
-    "src",
-    "types",
-    "dist"
-  ],
+  "files": ["src", "types", "dist"],
   "scripts": {
     "build": "tamagui-build",
     "clean": "tamagui-build clean",
@@ -37,7 +33,7 @@
     "vite": "^6.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@tamagui/build": "^1.125.8"
   },
   "publishConfig": {

--- a/packages/vite-native-client/package.json
+++ b/packages/vite-native-client/package.json
@@ -1,9 +1,7 @@
 {
   "name": "@vxrn/vite-native-client",
   "version": "1.1.451",
-  "sideEffects": [
-    "*"
-  ],
+  "sideEffects": ["*"],
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -15,11 +13,7 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "types": "./types/index.d.ts",
-  "files": [
-    "src",
-    "types",
-    "dist"
-  ],
+  "files": ["src", "types", "dist"],
   "scripts": {
     "build": "tamagui-build",
     "clean": "tamagui-build clean",
@@ -27,7 +21,7 @@
     "watch": "tamagui-build --watch"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@tamagui/build": "^1.125.8",
     "react-native": "^0.76.5"
   },

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -93,7 +93,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.3",
+    "@biomejs/biome": "1.9.4",
     "@react-native-community/cli": "^15.1.3",
     "@tamagui/build": "^1.125.8",
     "@types/find-node-modules": "^2.1.2",

--- a/tests/sandbox/biome.json
+++ b/tests/sandbox/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/tests/sandbox/biome.json
+++ b/tests/sandbox/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/tests/test-cloudflare/biome.json
+++ b/tests/test-cloudflare/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/tests/test-cloudflare/biome.json
+++ b/tests/test-cloudflare/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/tests/test-weird-deps/biome.json
+++ b/tests/test-weird-deps/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/tests/test-weird-deps/biome.json
+++ b/tests/test-weird-deps/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/tests/test/biome.json
+++ b/tests/test/biome.json
@@ -69,7 +69,7 @@
   },
   "javascript": {
     "formatter": {
-      "trailingComma": "es5",
+      "trailingCommas": "es5",
       "jsxQuoteStyle": "double",
       "semicolons": "asNeeded",
       "quoteStyle": "single"

--- a/tests/test/biome.json
+++ b/tests/test/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,7 +2100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:^1.8.3":
+"@biomejs/biome@npm:1.9.4":
   version: 1.9.4
   resolution: "@biomejs/biome@npm:1.9.4"
   dependencies:
@@ -11506,7 +11506,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vxrn/safe-area@workspace:packages/safe-area"
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@tamagui/build": "npm:^1.125.8"
   languageName: unknown
   linkType: soft
@@ -11588,7 +11588,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.26.8"
     "@babel/plugin-transform-private-methods": "npm:^7.25.9"
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@react-native/babel-plugin-codegen": "npm:^0.76.5"
     "@tamagui/build": "npm:^1.125.8"
     "@vxrn/resolve": "workspace:*"
@@ -11603,7 +11603,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vxrn/vite-native-client@workspace:packages/vite-native-client"
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@tamagui/build": "npm:^1.125.8"
     react-native: "npm:^0.76.5"
   peerDependencies:
@@ -16045,7 +16045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-recommended@workspace:examples/one-recommended"
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@dotenvx/dotenvx": "npm:^1.12.1"
     "@faker-js/faker": "npm:next"
     "@react-native-community/cli": "npm:15.1.3"
@@ -16104,7 +16104,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-tamagui@workspace:examples/one-tamagui"
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@react-native-community/cli": "npm:15.1.3"
     "@tamagui/animations-css": "npm:^1.125.8"
     "@tamagui/animations-moti": "npm:^1.125.8"
@@ -16137,7 +16137,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-testflight@workspace:examples/testflight"
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@bottom-tabs/react-navigation": "npm:^0.7.8"
     "@dotenvx/dotenvx": "npm:^1.12.1"
     "@faker-js/faker": "npm:next"
@@ -19711,7 +19711,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "lllink@workspace:packages/lllink"
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@tamagui/build": "npm:^1.125.8"
   bin:
     lllink: ./dist/index.mjs
@@ -28799,7 +28799,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vxrn-monorepo@workspace:."
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@manypkg/cli": "npm:^0.19.1"
     "@types/react": "npm:^18.3.11"
     "@types/react-native": "npm:^0.73.0"
@@ -28824,7 +28824,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vxrn@workspace:packages/vxrn"
   dependencies:
-    "@biomejs/biome": "npm:^1.8.3"
+    "@biomejs/biome": "npm:1.9.4"
     "@expo/config-plugins": "npm:^8.0.8"
     "@hono/node-server": "npm:^1.13.7"
     "@react-native-community/cli": "npm:^15.1.3"


### PR DESCRIPTION
This pr updates biome v1.9.4. Since it seems that the format command is not used in the npm scripts, it has not been applied.