### PR TITLE
fix(build): modify build output directory for Vercel deployments

### DIFF
--- a/packages/one/src/vercel/build/buildVercelOutputDirectory.ts
+++ b/packages/one/src/vercel/build/buildVercelOutputDirectory.ts
@@ -61,7 +61,7 @@ export const buildVercelOutputDirectory = async ({
     }
   }
 
-  const vercelOutputFunctionsDir = join(oneOptionsRoot, 'dist', `.vercel/output/functions`)
+  const vercelOutputFunctionsDir = join(oneOptionsRoot, '.vercel/output/functions')
   await ensureDir(vercelOutputFunctionsDir)
 
   for (const route of buildInfoForWriting.manifest.pageRoutes) {
@@ -92,7 +92,7 @@ export const buildVercelOutputDirectory = async ({
   const distMiddlewareDir = resolve(join(oneOptionsRoot, 'dist', 'middlewares'))
   if (existsSync(distMiddlewareDir)) {
     const vercelMiddlewareDir = resolve(
-      join(oneOptionsRoot, 'dist', '.vercel/output/functions/_middleware')
+      join(oneOptionsRoot, '.vercel/output/functions/_middleware')
     )
     await ensureDir(vercelMiddlewareDir)
     postBuildLogs.push(
@@ -114,7 +114,7 @@ export const buildVercelOutputDirectory = async ({
     })
   }
 
-  const vercelOutputStaticDir = resolve(join(oneOptionsRoot, 'dist', '.vercel/output/static'))
+  const vercelOutputStaticDir = resolve(join(oneOptionsRoot, '.vercel/output/static'))
   await ensureDir(vercelOutputStaticDir)
 
   postBuildLogs.push(
@@ -124,9 +124,7 @@ export const buildVercelOutputDirectory = async ({
 
   // Documentation - Vercel Build Output v3 config.json
   //   https://vercel.com/docs/build-output-api/v3/configuration#config.json-supported-properties
-  const vercelConfigFilePath = resolve(
-    join(oneOptionsRoot, 'dist', '.vercel/output', 'config.json')
-  )
+  const vercelConfigFilePath = resolve(join(oneOptionsRoot, '.vercel/output', 'config.json'))
   await writeJSON(vercelConfigFilePath, vercelBuildOutputConfig)
   postBuildLogs.push(`[one.build] wrote vercel config to: ${vercelConfigFilePath}`)
 }

--- a/packages/one/src/vercel/build/generate/createApiServerlessFunction.ts
+++ b/packages/one/src/vercel/build/generate/createApiServerlessFunction.ts
@@ -16,7 +16,7 @@ export async function createApiServerlessFunction(
   try {
     postBuildLogs.push(`[one.build][vercel.createSsrServerlessFunction] pageName: ${pageName}`)
 
-    const funcFolder = join(oneOptionsRoot, 'dist', `.vercel/output/functions/${pageName}.func`)
+    const funcFolder = join(oneOptionsRoot, `.vercel/output/functions/${pageName}.func`)
     await fs.ensureDir(funcFolder)
 
     if (code.includes('react')) {

--- a/packages/one/src/vercel/build/generate/createSsrServerlessFunction.ts
+++ b/packages/one/src/vercel/build/generate/createSsrServerlessFunction.ts
@@ -16,9 +16,7 @@ export async function createSsrServerlessFunction(
     postBuildLogs.push(`[one.build][vercel.createSsrServerlessFunction] pageName: ${pageName}`)
 
     const buildInfoAsString = JSON.stringify(buildInfo)
-    const funcFolder = resolve(
-      join(oneOptionsRoot, 'dist', `.vercel/output/functions/${pageName}.func`)
-    )
+    const funcFolder = resolve(join(oneOptionsRoot, `.vercel/output/functions/${pageName}.func`))
     await fs.ensureDir(funcFolder)
 
     const distServerFrom = resolve(join(oneOptionsRoot, 'dist', 'server'))

--- a/tests/test/vercel.json
+++ b/tests/test/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "yarn build:web",
-  "outputDirectory": "dist/.vercel",
+  "outputDirectory": ".vercel/output",
   "installCommand": "yarn install",
   "cleanUrls": true,
   "public": true,


### PR DESCRIPTION
I met with Brandon at Vercel.

Vercel wants the .vercel/output and we have to point the vercel.json outputDir to the same location

This will build to the root directory and corrects the path for vercel.json outputDirectory.

Once this is merged, I need to run through our starters and make sure the SSR is deploying correctly.
