### PR TITLE
fix(vercel-deploy): fix API route build failure when react is used and project is not a monorepo

### DIFF
--- a/packages/one/src/vercel/build/generate/createApiServerlessFunction.ts
+++ b/packages/one/src/vercel/build/generate/createApiServerlessFunction.ts
@@ -1,4 +1,6 @@
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import FSExtra from 'fs-extra'
+import { resolvePath } from '@vxrn/resolve'
 
 import fs from 'fs-extra'
 
@@ -23,17 +25,18 @@ export async function createApiServerlessFunction(
       postBuildLogs.push(
         `[one.build][vercel.createSsrServerlessFunction] detected react in depenency tree for ${pageName}`
       )
-      await fs.copy(
-        resolve(join(oneOptionsRoot, '..', '..', 'node_modules', 'react')),
-        resolve(join(funcFolder, 'node_modules', 'react'))
-      )
+      const reactPath = dirname(resolvePath('react/package.json', oneOptionsRoot))
+      await fs.copy(resolve(reactPath), resolve(join(funcFolder, 'node_modules', 'react')))
     }
 
     const distAssetsFolder = resolve(join(funcFolder, 'assets'))
     postBuildLogs.push(
       `[one.build][vercel.createSsrServerlessFunction] copy shared assets to ${distAssetsFolder}`
     )
-    await fs.copy(resolve(join(oneOptionsRoot, 'dist', 'api', 'assets')), distAssetsFolder)
+    const sourceAssetsFolder = resolve(join(oneOptionsRoot, 'dist', 'api', 'assets'))
+    if (await FSExtra.pathExists(sourceAssetsFolder)) {
+      await fs.copy(sourceAssetsFolder, distAssetsFolder)
+    }
 
     await fs.ensureDir(resolve(join(funcFolder, 'entrypoint')))
     const entrypointFilePath = resolve(join(funcFolder, 'entrypoint', 'index.js'))


### PR DESCRIPTION
Resolves #536