### PR TITLE
Use isPending for better-auth loading state

### DIFF
--- a/packages/better-auth/src/index.ts
+++ b/packages/better-auth/src/index.ts
@@ -86,7 +86,8 @@ export function createBetterAuthClient<Opts extends ClientOptions>(
   let disposeSessionSub: Function | null = null
   function subscribeToAuthClientSession() {
     disposeSessionSub?.()
-    disposeSessionSub = authClient.useSession.subscribe(async ({ data, error }) => {
+    disposeSessionSub = authClient.useSession.subscribe(async ({ data, error, isPending }) => {
+      loading = isPending;
       if (error) {
         console.error(`Auth error`, error)
       }
@@ -140,7 +141,6 @@ export function createBetterAuthClient<Opts extends ClientOptions>(
 
   function setState(next: Partial<State>) {
     const current = authState.value!
-    loading = false
     authState.emit({ ...current, ...next })
   }
 


### PR DESCRIPTION
`loading` was getting set to `false` immediately by the `else { setState(empty); }` block. `useSession.subscribe` exposes `isPending`. Not sure if having a mutable `loading` variable is the right approach, but it seems to be working as expected now.