### PR TITLE
fix: generate `routes.d.ts` besides the app dir when it's customized

### DIFF
--- a/packages/one/src/vite/plugins/generateFileSystemRouteTypesPlugin.tsx
+++ b/packages/one/src/vite/plugins/generateFileSystemRouteTypesPlugin.tsx
@@ -1,4 +1,4 @@
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { debounce } from 'perfect-debounce'
 import type { Plugin } from 'vite'
 import type { One } from '../types'
@@ -13,7 +13,14 @@ export function generateFileSystemRouteTypesPlugin(options: One.PluginOptions): 
 
     configureServer(server) {
       const appDir = join(process.cwd(), getRouterRootFromOneOptions(options))
-      const outFile = join(process.cwd(), 'routes.d.ts')
+      const outFile = (() => {
+        if (dirname(appDir) !== process.cwd()) {
+          console.warn('Seems that the router root has been customized and is in a nested folder. For now we will generate the routes.d.ts file beside the app folder. This behavior might be changed in the future.')
+          return join(dirname(appDir), 'routes.d.ts')
+        }
+
+        return join(process.cwd(), 'routes.d.ts')
+      })()
 
       const routerRoot = getRouterRootFromOneOptions(options)
 

--- a/tests/test/app-cases/basic/app/page-in-basic-app-case.tsx
+++ b/tests/test/app-cases/basic/app/page-in-basic-app-case.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'one'
+import { Text } from 'react-native'
+
+export default function Index() {
+  return (
+    <Text id="content">
+      Hello, this is the page-in-basic-app-case page!{' '}
+      <Link href="/page-in-basic-app-case"></Link>
+    </Text>
+  )
+}

--- a/tests/test/app-cases/basic/routes.d.ts
+++ b/tests/test/app-cases/basic/routes.d.ts
@@ -1,0 +1,15 @@
+// deno-lint-ignore-file
+/* eslint-disable */
+// biome-ignore: needed import
+import type { OneRouter } from 'one'
+
+declare module 'one' {
+  export namespace OneRouter {
+    export interface __routes<T extends string = string> extends Record<string, unknown> {
+      StaticRoutes: `/` | `/_sitemap` | `/page-in-basic-app-case`
+      DynamicRoutes: never
+      DynamicRouteTemplate: never
+      IsTyped: true
+    }
+  }
+}

--- a/tests/test/app-cases/basic/tsconfig.json
+++ b/tests/test/app-cases/basic/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": [
+    "node_modules",
+    ".expo",
+    "**/test",
+    "**/dist",
+    "**/types",
+    "**/__tests__"
+  ],
+}

--- a/tests/test/app-cases/not-found-at-root-with-assets/routes.d.ts
+++ b/tests/test/app-cases/not-found-at-root-with-assets/routes.d.ts
@@ -1,0 +1,15 @@
+// deno-lint-ignore-file
+/* eslint-disable */
+// biome-ignore: needed import
+import type { OneRouter } from 'one'
+
+declare module 'one' {
+  export namespace OneRouter {
+    export interface __routes<T extends string = string> extends Record<string, unknown> {
+      StaticRoutes: `/` | `/_sitemap`
+      DynamicRoutes: never
+      DynamicRouteTemplate: never
+      IsTyped: true
+    }
+  }
+}

--- a/tests/test/app-cases/not-found-at-root-with-assets/tsconfig.json
+++ b/tests/test/app-cases/not-found-at-root-with-assets/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": [
+    "node_modules",
+    ".expo",
+    "**/test",
+    "**/dist",
+    "**/types",
+    "**/__tests__"
+  ],
+}

--- a/tests/test/routes.d.ts
+++ b/tests/test/routes.d.ts
@@ -6,10 +6,10 @@ import type { OneRouter } from 'one'
 declare module 'one' {
   export namespace OneRouter {
     export interface __routes<T extends string = string> extends Record<string, unknown> {
-      StaticRoutes: unknown
-      DynamicRoutes: unknown
-      DynamicRouteTemplate: unknown
-      IsTyped: false
+      StaticRoutes: `/` | `/(auth-guard)` | `/(auth-guard)/auth-guard` | `/(blog)` | `/(blog)/blog/my-first-post` | `/(marketing)/about` | `/(sub-page-group)` | `/(sub-page-group)/sub-page` | `/(sub-page-group)/sub-page/sub` | `/(sub-page-group)/sub-page/sub2` | `/_sitemap` | `/about` | `/auth-guard` | `/blog/my-first-post` | `/expo-video` | `/hooks` | `/hooks/contents` | `/hooks/contents/page-1` | `/hooks/contents/page-2` | `/layouts` | `/layouts/nested-layout/with-slug-layout-folder/[layoutSlug]/` | `/loader` | `/loader/other` | `/middleware` | `/not-found/deep/test` | `/not-found/fallback/test` | `/not-found/test` | `/server-data` | `/sheet` | `/spa/spapage` | `/ssr` | `/ssr/` | `/ssr/basic` | `/sub-page` | `/sub-page/sub` | `/sub-page/sub2` | `/web-extensions`
+      DynamicRoutes: `/dynamic-folder-routes/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}` | `/hooks/contents/with-nested-slug/${OneRouter.SingleRoutePart<T>}` | `/hooks/contents/with-nested-slug/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}` | `/hooks/contents/with-slug/${OneRouter.SingleRoutePart<T>}` | `/layouts/nested-layout/with-slug-layout-folder/${OneRouter.SingleRoutePart<T>}` | `/not-found/+not-found` | `/not-found/deep/+not-found` | `/routes/subpath/${string}` | `/segments-stable-ids/${string}` | `/spa/${OneRouter.SingleRoutePart<T>}` | `/ssr/${OneRouter.SingleRoutePart<T>}` | `/ssr/${string}`
+      DynamicRouteTemplate: `/dynamic-folder-routes/[serverId]/[channelId]` | `/hooks/contents/with-nested-slug/[folderSlug]` | `/hooks/contents/with-nested-slug/[folderSlug]/[fileSlug]` | `/hooks/contents/with-slug/[slug]` | `/layouts/nested-layout/with-slug-layout-folder/[layoutSlug]` | `/not-found/+not-found` | `/not-found/deep/+not-found` | `/routes/subpath/[...subpath]` | `/segments-stable-ids/[...segments]` | `/spa/[spaparams]` | `/ssr/[...rest]` | `/ssr/[param]`
+      IsTyped: true
     }
   }
 }

--- a/tests/test/tsconfig.json
+++ b/tests/test/tsconfig.json
@@ -49,7 +49,8 @@
     "**/test",
     "**/dist",
     "**/types",
-    "**/__tests__"
+    "**/__tests__",
+    "app-cases" // We need to use a different tsconfig.json for each app-case, since each one will have totally different routes and will have different `routes.d.ts`.
   ],
   "typeAcquisition": {
     "enable": true


### PR DESCRIPTION
Getting rid of the annoying type changes after running tests.