### PR TITLE
Fix undefined reference

### DIFF
--- a/packages/one/src/router/getLinkingConfig.ts
+++ b/packages/one/src/router/getLinkingConfig.ts
@@ -24,7 +24,7 @@ export type OneLinkingOptions = LinkingOptions<object> & {
 }
 
 export function getLinkingConfig(routes: RouteNode, metaOnly = true): OneLinkingOptions {
-  return {
+  const linkingConfig = {
     prefixes: [],
     // @ts-expect-error
     config: getNavigationConfig(routes, metaOnly),
@@ -49,6 +49,8 @@ export function getLinkingConfig(routes: RouteNode, metaOnly = true): OneLinking
     // This is a convenience for usage in the package.
     getActionFromState,
   }
+  linkingConfig.getPathFromState = linkingConfig.getPathFromState.bind(linkingConfig)
+  return linkingConfig
 }
 
 export const stateCache = new Map<string, any>()

--- a/packages/one/src/router/getLinkingConfig.ts
+++ b/packages/one/src/router/getLinkingConfig.ts
@@ -24,7 +24,7 @@ export type OneLinkingOptions = LinkingOptions<object> & {
 }
 
 export function getLinkingConfig(routes: RouteNode, metaOnly = true): OneLinkingOptions {
-  const linkingConfig = {
+  const linkingConfig: OneLinkingOptions = {
     prefixes: [],
     // @ts-expect-error
     config: getNavigationConfig(routes, metaOnly),


### PR DESCRIPTION
React Navigation no longer calls `getPathFromState` from the options object meaning that the "this" parameter is undefined. This causes an exception. Therefore, I bind the context of the this parameter to ensure that its always present.