### PR TITLE
feat(site): llms-full.txt

### DIFF
--- a/apps/onestack.dev/app/llms-full.txt+api.ts
+++ b/apps/onestack.dev/app/llms-full.txt+api.ts
@@ -32,7 +32,11 @@ export async function GET() {
 
     for (const file of orderedFiles) {
       const filePath = join(docsPath, file)
-      const content = await readFile(filePath, 'utf-8')
+      const resolvedFilePath = resolve(filePath)
+      if (!resolvedFilePath.startsWith(resolve(docsPath))) {
+        throw new Error(`Path traversal detected: ${filePath}`)
+      }
+      const content = await readFile(resolvedFilePath, 'utf-8')
       consolidatedContent += content
       consolidatedContent += '\n\n\n\n'
     }

--- a/apps/onestack.dev/app/llms-full.txt+api.ts
+++ b/apps/onestack.dev/app/llms-full.txt+api.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { glob } from 'glob'
+import { docsRoutes } from '~/features/docs/docsRoutes'
+
+export async function GET() {
+  try {
+    // Get all MDX files from the docs directory
+    const docsPath = join(process.cwd(), 'data/docs')
+    const mdxFiles = await glob('*.mdx', { cwd: docsPath })
+
+    let consolidatedContent = '# One Framework - Complete Documentation #\n\n'
+    consolidatedContent += 'This is a consolidated version of all One framework documentation for LLM assistance.\n\n\n\n'
+
+    // Create ordered list based on docsRoutes structure
+    const orderedFiles: string[] = []
+
+    for (const section of docsRoutes) {
+      if (section.pages) {
+        for (const page of section.pages) {
+          const filename = page.route.replace('/docs/', '') + '.mdx'
+          if (mdxFiles.includes(filename)) {
+            orderedFiles.push(filename)
+          }
+        }
+      }
+    }
+
+    // Add any remaining files not in docsRoutes
+    const remainingFiles = mdxFiles.filter(file => !orderedFiles.includes(file))
+    orderedFiles.push(...remainingFiles.sort())
+
+    for (const file of orderedFiles) {
+      const filePath = join(docsPath, file)
+      const content = await readFile(filePath, 'utf-8')
+      consolidatedContent += content
+      consolidatedContent += '\n\n\n\n'
+    }
+
+    return new Response(consolidatedContent, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    })
+  } catch (error) {
+    console.error('Error generating consolidated docs:', error)
+    return new Response('Error generating documentation', {
+      status: 500,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    })
+  }
+}


### PR DESCRIPTION
This implementation isn't ideal, as it generates the document upon request every time, whereas it should be statically built.

But the problem with using an SSG route is that it cannot avoid the root `_layout` being applied.