### PR TITLE
Fix: getLinkingConfig undefined config

### DIFF
--- a/packages/one/src/router/getLinkingConfig.ts
+++ b/packages/one/src/router/getLinkingConfig.ts
@@ -24,10 +24,11 @@ export type OneLinkingOptions = LinkingOptions<object> & {
 }
 
 export function getLinkingConfig(routes: RouteNode, metaOnly = true): OneLinkingOptions {
+  const config = getNavigationConfig(routes, metaOnly)
   return {
     prefixes: [],
     // @ts-expect-error
-    config: getNavigationConfig(routes, metaOnly),
+    config,
     // A custom getInitialURL is used on native to ensure the app always starts at
     // the root path if it's launched from something other than a deep link.
     // This helps keep the native functionality working like the web functionality.
@@ -39,8 +40,7 @@ export function getLinkingConfig(routes: RouteNode, metaOnly = true): OneLinking
     getPathFromState(state: State, options: Parameters<typeof getPathFromState>[1]) {
       return (
         getPathFromState(state, {
-          screens: [],
-          ...this.config,
+          ...config,
           ...options,
         }) ?? '/'
       )


### PR DESCRIPTION
### Description:
Fixes an issue with `Tabs` layout trying to access the `config` on an `undefined` `this`. `getPathFromState` is being called such that it doesn't have access to `this`. Instead I extract the config to a variable which will be closed over and available to the function.

I also removed the `screens: []` since the config object already contains a screens field and would override it.


### Error stack trace:
```
Error on route "(tabs)"
Cannot read properties of undefined (reading 'config')
TypeError: Cannot read properties of undefined (reading 'config')
    at getPathFromState (http://localhost:8081/node_modules/.vite/deps/one.js?v=14332b62:7995:17)
    at http://localhost:8081/node_modules/.vite/deps/one.js?v=14332b62:6485:18
    at http://localhost:8081/node_modules/.vite/deps/one.js?v=14332b62:27955:21
    at Array.map (<anonymous>)
    at BottomTabBar (http://localhost:8081/node_modules/.vite/deps/one.js?v=14332b62:27921:24)
    at react-stack-bottom-frame (http://localhost:8081/node_modules/.vite/deps/chunk-BQ3EOCMK.js?v=14332b62:16894:20)
    at renderWithHooks (http://localhost:8081/node_modules/.vite/deps/chunk-BQ3EOCMK.js?v=14332b62:5008:24)
    at updateFunctionComponent (http://localhost:8081/node_modules/.vite/deps/chunk-BQ3EOCMK.js?v=14332b62:6674:21)
    at beginWork (http://localhost:8081/node_modules/.vite/deps/chunk-BQ3EOCMK.js?v=14332b62:7750:20)
    at runWithFiberInDEV (http://localhost:8081/node_modules/.vite/deps/chunk-BQ3EOCMK.js?v=14332b62:1428:18)
```