### PR TITLE
fix: collapse react-native exports to prevent Metro module duplication

### DIFF
--- a/.github/workflows/build-ios-test-container-app.yml
+++ b/.github/workflows/build-ios-test-container-app.yml
@@ -200,6 +200,20 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build | tee xcodebuild.log | xcpretty
 
+      - name: Bundle hermesc into .app
+        if: ${{ !steps.pre-check-has-build.outputs.cache-hit && !steps.check-has-build.outputs.cache-hit }}
+        run: |
+          # Copy the Pods hermesc into the .app so the test runner can use it.
+          # The Pods hermesc matches the Hermes engine bytecode version in the binary.
+          HERMESC_SRC="ios/Pods/hermes-engine/destroot/bin/hermesc"
+          HERMESC_DST="${{ steps.get-built-app-path.outputs.built_app_path }}/hermesc"
+          if [ -f "$HERMESC_SRC" ]; then
+            cp "$HERMESC_SRC" "$HERMESC_DST"
+            echo "Copied hermesc to $HERMESC_DST ($($HERMESC_DST --version 2>&1 | grep 'HBC bytecode'))"
+          else
+            echo "Warning: hermesc not found at $HERMESC_SRC"
+          fi
+
       - name: Upload Built App to Cache
         if: ${{ !steps.pre-check-has-build.outputs.cache-hit && !steps.check-has-build.outputs.cache-hit }}
         uses: actions/cache/save@v5

--- a/.github/workflows/build-ios-test-container-app.yml
+++ b/.github/workflows/build-ios-test-container-app.yml
@@ -205,13 +205,28 @@ jobs:
         run: |
           # Copy the Pods hermesc into the .app so the test runner can use it.
           # The Pods hermesc matches the Hermes engine bytecode version in the binary.
-          HERMESC_SRC="ios/Pods/hermes-engine/destroot/bin/hermesc"
           APP_DIR="${{ steps.get-built-app-path.outputs.built_app_path }}"
-          if [ -f "$HERMESC_SRC" ] && [ -d "$APP_DIR" ]; then
-            cp "$HERMESC_SRC" "$APP_DIR/hermesc"
-            echo "Copied hermesc ($("$APP_DIR/hermesc" --version 2>&1 | grep 'HBC bytecode'))"
+          if [ ! -d "$APP_DIR" ]; then
+            echo "Warning: app not built at $APP_DIR"
+            exit 0
+          fi
+          # search known paths then fall back to find
+          HERMESC=""
+          for p in \
+            "ios/Pods/hermes-engine/destroot/bin/hermesc" \
+            "ios/Pods/hermes-engine/hermesc/osx-bin/hermesc" \
+            "build/Build/Products/${{ inputs.configuration }}-iphonesimulator/hermes/hermesc"; do
+            if [ -f "$p" ]; then HERMESC="$p"; break; fi
+          done
+          if [ -z "$HERMESC" ]; then
+            HERMESC=$(find ios/Pods build -name hermesc -type f 2>/dev/null | head -1)
+          fi
+          if [ -n "$HERMESC" ]; then
+            cp "$HERMESC" "$APP_DIR/hermesc"
+            echo "Copied hermesc from $HERMESC ($("$APP_DIR/hermesc" --version 2>&1 | grep 'HBC bytecode'))"
           else
-            echo "Warning: hermesc not found at $HERMESC_SRC or app not built"
+            echo "Warning: hermesc not found anywhere in Pods or build"
+            find ios/Pods -name "hermes*" -type f 2>/dev/null | head -20
           fi
 
       - name: Upload Built App to Cache

--- a/.github/workflows/build-ios-test-container-app.yml
+++ b/.github/workflows/build-ios-test-container-app.yml
@@ -206,12 +206,12 @@ jobs:
           # Copy the Pods hermesc into the .app so the test runner can use it.
           # The Pods hermesc matches the Hermes engine bytecode version in the binary.
           HERMESC_SRC="ios/Pods/hermes-engine/destroot/bin/hermesc"
-          HERMESC_DST="${{ steps.get-built-app-path.outputs.built_app_path }}/hermesc"
-          if [ -f "$HERMESC_SRC" ]; then
-            cp "$HERMESC_SRC" "$HERMESC_DST"
-            echo "Copied hermesc to $HERMESC_DST ($($HERMESC_DST --version 2>&1 | grep 'HBC bytecode'))"
+          APP_DIR="${{ steps.get-built-app-path.outputs.built_app_path }}"
+          if [ -f "$HERMESC_SRC" ] && [ -d "$APP_DIR" ]; then
+            cp "$HERMESC_SRC" "$APP_DIR/hermesc"
+            echo "Copied hermesc ($("$APP_DIR/hermesc" --version 2>&1 | grep 'HBC bytecode'))"
           else
-            echo "Warning: hermesc not found at $HERMESC_SRC"
+            echo "Warning: hermesc not found at $HERMESC_SRC or app not built"
           fi
 
       - name: Upload Built App to Cache

--- a/.github/workflows/build-ios-test-container-app.yml
+++ b/.github/workflows/build-ios-test-container-app.yml
@@ -8,8 +8,12 @@ env:
   ios_app_name: RNTestContainer
   # A unique ID to identify the app on GitHub Actions, this is used as part of cache keys and artifact names, must be unique among all workflows
   app_id: ios-rn-test-container-app
-  # rolldown native pipeline outputs ESM which requires Hermes V1
-  RCT_HERMES_V1_ENABLED: '1'
+  # rolldown native pipeline needs Hermes V1 for ESM, but the iOS tests
+  # currently use Metro which produces CJS bytecode compiled by the npm
+  # hermes-compiler (bytecode v96). Enabling V1 here creates a version
+  # mismatch — the app ships hermesvm (v98) but hermesc produces v96.
+  # Disabled until the test infra can find a matching V1 hermesc on CI.
+  # RCT_HERMES_V1_ENABLED: '1'
   # The command used to prebuild the app
   prebuild_command: bun run prebuild:native --platform ios --no-install # --no-install is used to skip installing dependencies, specifically `pod install` as we want to do it after the Cache Pods step
 
@@ -199,35 +203,6 @@ jobs:
             -sdk 'iphonesimulator' \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build | tee xcodebuild.log | xcpretty
-
-      - name: Bundle hermesc into .app
-        if: ${{ !steps.pre-check-has-build.outputs.cache-hit && !steps.check-has-build.outputs.cache-hit }}
-        run: |
-          # Copy the Pods hermesc into the .app so the test runner can use it.
-          # The Pods hermesc matches the Hermes engine bytecode version in the binary.
-          APP_DIR="${{ steps.get-built-app-path.outputs.built_app_path }}"
-          if [ ! -d "$APP_DIR" ]; then
-            echo "Warning: app not built at $APP_DIR"
-            exit 0
-          fi
-          # search known paths then fall back to find
-          HERMESC=""
-          for p in \
-            "ios/Pods/hermes-engine/destroot/bin/hermesc" \
-            "ios/Pods/hermes-engine/hermesc/osx-bin/hermesc" \
-            "build/Build/Products/${{ inputs.configuration }}-iphonesimulator/hermes/hermesc"; do
-            if [ -f "$p" ]; then HERMESC="$p"; break; fi
-          done
-          if [ -z "$HERMESC" ]; then
-            HERMESC=$(find ios/Pods build -name hermesc -type f 2>/dev/null | head -1)
-          fi
-          if [ -n "$HERMESC" ]; then
-            cp "$HERMESC" "$APP_DIR/hermesc"
-            echo "Copied hermesc from $HERMESC ($("$APP_DIR/hermesc" --version 2>&1 | grep 'HBC bytecode'))"
-          else
-            echo "Warning: hermesc not found anywhere in Pods or build"
-            find ios/Pods -name "hermes*" -type f 2>/dev/null | head -20
-          fi
 
       - name: Upload Built App to Cache
         if: ${{ !steps.pre-check-has-build.outputs.cache-hit && !steps.check-has-build.outputs.cache-hit }}

--- a/packages/color-scheme/package.json
+++ b/packages/color-scheme/package.json
@@ -5,10 +5,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "react-native": {
-        "import": "./dist/esm/index.native.js",
-        "require": "./dist/cjs/index.native.js"
-      },
+      "react-native": "./dist/esm/index.native.js",
       "types": "./types/index.d.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -14,50 +14,32 @@
   },
   "exports": {
     ".": {
-      "react-native": {
-        "import": "./dist/esm/index.native.js",
-        "require": "./dist/cjs/index.native.js"
-      },
+      "react-native": "./dist/esm/index.native.js",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"
     },
     "./color": {
-      "react-native": {
-        "import": "./dist/esm/color/index.native.js",
-        "require": "./dist/cjs/color/index.native.js"
-      },
+      "react-native": "./dist/esm/color/index.native.js",
       "import": "./dist/esm/color/index.mjs",
       "require": "./dist/cjs/color/index.cjs"
     },
     "./zoom": {
-      "react-native": {
-        "import": "./dist/esm/zoom/index.native.js",
-        "require": "./dist/cjs/zoom/index.native.js"
-      },
+      "react-native": "./dist/esm/zoom/index.native.js",
       "import": "./dist/esm/zoom/index.mjs",
       "require": "./dist/cjs/zoom/index.cjs"
     },
     "./toolbar": {
-      "react-native": {
-        "import": "./dist/esm/toolbar/index.native.js",
-        "require": "./dist/cjs/toolbar/index.native.js"
-      },
+      "react-native": "./dist/esm/toolbar/index.native.js",
       "import": "./dist/esm/toolbar/index.mjs",
       "require": "./dist/cjs/toolbar/index.cjs"
     },
     "./menu": {
-      "react-native": {
-        "import": "./dist/esm/menu/index.native.js",
-        "require": "./dist/cjs/menu/index.native.js"
-      },
+      "react-native": "./dist/esm/menu/index.native.js",
       "import": "./dist/esm/menu/index.mjs",
       "require": "./dist/cjs/menu/index.cjs"
     },
     "./split-view": {
-      "react-native": {
-        "import": "./dist/esm/split-view/index.native.js",
-        "require": "./dist/cjs/split-view/index.native.js"
-      },
+      "react-native": "./dist/esm/split-view/index.native.js",
       "import": "./dist/esm/split-view/index.mjs",
       "require": "./dist/cjs/split-view/index.cjs"
     }

--- a/packages/one/package.json
+++ b/packages/one/package.json
@@ -10,19 +10,13 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "react-native": {
-        "import": "./dist/esm/index.native.js",
-        "require": "./dist/cjs/index.native.js"
-      },
+      "react-native": "./dist/esm/index.native.js",
       "types": "./types/index.d.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"
     },
     "./ui": {
-      "react-native": {
-        "import": "./dist/esm/ui/index.native.js",
-        "require": "./dist/cjs/ui/index.native.js"
-      },
+      "react-native": "./dist/esm/ui/index.native.js",
       "types": "./types/ui/index.d.ts",
       "import": "./dist/esm/ui/index.mjs",
       "require": "./dist/cjs/ui/index.cjs"
@@ -108,10 +102,7 @@
       "require": "./dist/cjs/image.js"
     },
     "./drawer": {
-      "react-native": {
-        "import": "./dist/esm/drawer.native.js",
-        "require": "./dist/cjs/drawer.native.js"
-      },
+      "react-native": "./dist/esm/drawer.native.js",
       "types": "./types/drawer.d.ts",
       "import": "./dist/esm/drawer.mjs",
       "require": "./dist/cjs/drawer.js"

--- a/packages/query-string/package.json
+++ b/packages/query-string/package.json
@@ -9,10 +9,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "react-native": {
-        "import": "./dist/esm/index.native.js",
-        "require": "./dist/cjs/index.native.js"
-      },
+      "react-native": "./dist/esm/index.native.js",
       "types": "./types/index.d.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"

--- a/packages/safe-area/package.json
+++ b/packages/safe-area/package.json
@@ -20,10 +20,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "react-native": {
-        "import": "./dist/esm/index.native.js",
-        "require": "./dist/cjs/index.native.js"
-      },
+      "react-native": "./dist/esm/index.native.js",
       "types": "./types/index.d.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"

--- a/packages/test/src/internal-utils/ios.ts
+++ b/packages/test/src/internal-utils/ios.ts
@@ -317,7 +317,7 @@ export async function getWebDriverConfig(): Promise<WebdriverIOConfig> {
   const wdOpts = {
     hostname: process.env.APPIUM_HOST || 'localhost',
     port: process.env.APPIUM_PORT ? Number.parseInt(process.env.APPIUM_PORT, 10) : 4723,
-    connectionRetryTimeout: 180 * 1000,
+    connectionRetryTimeout: 60 * 1000,
     connectionRetryCount: 3,
     logLevel: 'warn' as const,
     capabilities,

--- a/packages/test/src/internal-utils/ios.ts
+++ b/packages/test/src/internal-utils/ios.ts
@@ -223,42 +223,22 @@ async function prepareTestApp() {
 
   // Compile the JS bundle to Hermes bytecode
   // The Release app is built with Hermes enabled, so we must emit bytecode
-  // Try multiple locations for hermesc
+  // Try multiple locations for hermesc.
+  // The Pods hermesc MUST match the Hermes engine in the .app binary.
+  // The npm hermes-compiler may be a different bytecode version (e.g. V0 vs V1).
   const possibleHermescPaths = [
+    // from the .app bundle itself (most reliable - matches the engine exactly)
+    path.join(appPath, '..', '..', '..', '..', 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),
+    // rn-test-container Pods (monorepo sibling)
+    path.join(root, '..', 'rn-test-container', 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),
+    // local project Pods
     path.join(root, 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),
-    // RN 0.83+: hermes-compiler package
+    // RN 0.83+: hermes-compiler package (fallback — may be wrong bytecode version)
     path.join(root, 'node_modules', 'hermes-compiler', 'hermesc', 'osx-bin', 'hermesc'),
-    path.join(
-      root,
-      '..',
-      '..',
-      'node_modules',
-      'hermes-compiler',
-      'hermesc',
-      'osx-bin',
-      'hermesc'
-    ),
+    path.join(root, '..', '..', 'node_modules', 'hermes-compiler', 'hermesc', 'osx-bin', 'hermesc'),
     // RN <0.83: react-native/sdks
-    path.join(
-      root,
-      'node_modules',
-      'react-native',
-      'sdks',
-      'hermesc',
-      'osx-bin',
-      'hermesc'
-    ),
-    path.join(
-      root,
-      '..',
-      '..',
-      'node_modules',
-      'react-native',
-      'sdks',
-      'hermesc',
-      'osx-bin',
-      'hermesc'
-    ),
+    path.join(root, 'node_modules', 'react-native', 'sdks', 'hermesc', 'osx-bin', 'hermesc'),
+    path.join(root, '..', '..', 'node_modules', 'react-native', 'sdks', 'hermesc', 'osx-bin', 'hermesc'),
   ]
 
   let hermescPath: string | undefined

--- a/packages/test/src/internal-utils/ios.ts
+++ b/packages/test/src/internal-utils/ios.ts
@@ -317,7 +317,7 @@ export async function getWebDriverConfig(): Promise<WebdriverIOConfig> {
   const wdOpts = {
     hostname: process.env.APPIUM_HOST || 'localhost',
     port: process.env.APPIUM_PORT ? Number.parseInt(process.env.APPIUM_PORT, 10) : 4723,
-    connectionRetryTimeout: 60 * 1000,
+    connectionRetryTimeout: 120 * 1000,
     connectionRetryCount: 3,
     logLevel: 'warn' as const,
     capabilities,

--- a/packages/test/src/internal-utils/ios.ts
+++ b/packages/test/src/internal-utils/ios.ts
@@ -223,17 +223,10 @@ async function prepareTestApp() {
 
   // Compile the JS bundle to Hermes bytecode
   // The Release app is built with Hermes enabled, so we must emit bytecode
-  // Try multiple locations for hermesc.
-  // The Pods hermesc MUST match the Hermes engine in the .app binary.
-  // The npm hermes-compiler may be a different bytecode version (e.g. V0 vs V1).
+  // Try multiple locations for hermesc
   const possibleHermescPaths = [
-    // bundled into .app by CI build workflow (matches engine exactly)
-    path.join(appPath, 'hermesc'),
-    // rn-test-container Pods (local builds)
-    path.join(root, '..', 'rn-test-container', 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),
-    // local project Pods
     path.join(root, 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),
-    // RN 0.83+: hermes-compiler package (fallback — may be wrong bytecode version)
+    // RN 0.83+: hermes-compiler package
     path.join(root, 'node_modules', 'hermes-compiler', 'hermesc', 'osx-bin', 'hermesc'),
     path.join(root, '..', '..', 'node_modules', 'hermes-compiler', 'hermesc', 'osx-bin', 'hermesc'),
     // RN <0.83: react-native/sdks

--- a/packages/test/src/internal-utils/ios.ts
+++ b/packages/test/src/internal-utils/ios.ts
@@ -227,9 +227,9 @@ async function prepareTestApp() {
   // The Pods hermesc MUST match the Hermes engine in the .app binary.
   // The npm hermes-compiler may be a different bytecode version (e.g. V0 vs V1).
   const possibleHermescPaths = [
-    // from the .app bundle itself (most reliable - matches the engine exactly)
-    path.join(appPath, '..', '..', '..', '..', 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),
-    // rn-test-container Pods (monorepo sibling)
+    // bundled into .app by CI build workflow (matches engine exactly)
+    path.join(appPath, 'hermesc'),
+    // rn-test-container Pods (local builds)
     path.join(root, '..', 'rn-test-container', 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),
     // local project Pods
     path.join(root, 'ios', 'Pods', 'hermes-engine', 'destroot', 'bin', 'hermesc'),

--- a/packages/test/src/utils/appium.ts
+++ b/packages/test/src/utils/appium.ts
@@ -4,6 +4,60 @@ import type { ChainablePromiseElement, Browser } from 'webdriverio'
 import { remote } from 'webdriverio'
 import type { WebdriverIOConfig } from '../internal-utils/ios'
 
+export class AppCrashedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AppCrashedError'
+  }
+}
+
+/**
+ * checks if the app is still running by querying the WebDriver session.
+ * throws AppCrashedError if the app has crashed.
+ */
+export async function assertAppRunning(driver: Browser): Promise<void> {
+  try {
+    await driver.getPageSource()
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    if (msg.includes('is not running') || msg.includes('possibly crashed')) {
+      throw new AppCrashedError(`App has crashed: ${msg}`)
+    }
+    // other errors (e.g. transient WDA issues) - don't throw
+  }
+}
+
+/**
+ * like element.waitForDisplayed but checks for app crashes periodically.
+ * if the app crashes, fails immediately instead of waiting for the full timeout.
+ */
+async function waitForDisplayedOrAppCrash(
+  driver: Browser,
+  element: ChainablePromiseElement,
+  timeout: number,
+  crashCheckInterval = 10_000
+): Promise<void> {
+  const start = Date.now()
+  while (true) {
+    const remaining = timeout - (Date.now() - start)
+    if (remaining <= 0) {
+      throw new Error(
+        `Element "${await element.selector}" not displayed after ${timeout}ms`
+      )
+    }
+
+    const waitChunk = Math.min(crashCheckInterval, remaining)
+    try {
+      await element.waitForDisplayed({ timeout: waitChunk })
+      return
+    } catch {
+      // check if the app crashed before continuing to wait
+      await assertAppRunning(driver)
+      // app is alive, element just not found yet - keep waiting
+    }
+  }
+}
+
 /**
  * Like `element.setValue` but types slowly, character by character, to reduce the risk of missing characters.
  *
@@ -100,9 +154,11 @@ export async function setValueSafe(
  * Currently, this only works when the `TestNavigationHelper` component is shown on the screen.
  */
 export async function navigateTo(driver: Browser, path: string) {
+  const NAVIGATE_TIMEOUT = 2 * 60 * 1000
+
   const quickNavigatePixel = driver.$('~quick-navigate-pixel')
   try {
-    await quickNavigatePixel.waitForDisplayed({ timeout: 2 * 60 * 1000 })
+    await waitForDisplayedOrAppCrash(driver, quickNavigatePixel, NAVIGATE_TIMEOUT)
     await driver.setClipboard(Buffer.from(path).toString('base64'), 'plaintext')
     await quickNavigatePixel.click()
     await driver.pause(50)
@@ -135,6 +191,9 @@ export async function navigateTo(driver: Browser, path: string) {
 
     return
   } catch (e) {
+    // if the app crashed, don't bother with fallback - fail immediately
+    if (e instanceof AppCrashedError) throw e
+
     console.warn(
       `Quick navigate pixel not found, falling back to input field navigation: ${e instanceof Error ? e.message : 'Unknown error'}`
     )
@@ -142,7 +201,7 @@ export async function navigateTo(driver: Browser, path: string) {
   }
 
   const navigatePathInput = driver.$('~test-navigate-path-input')
-  await navigatePathInput.waitForDisplayed({ timeout: 2 * 60 * 1000 })
+  await waitForDisplayedOrAppCrash(driver, navigatePathInput, NAVIGATE_TIMEOUT)
   await setValueSafe(driver, navigatePathInput, path)
   await driver.$('~test-navigate').click()
   await driver.pause(100)
@@ -151,6 +210,7 @@ export async function navigateTo(driver: Browser, path: string) {
 /**
  * Note that this will not throw an error if the element is not displayed.
  * Instead, it will return the element as is.
+ * DOES throw AppCrashedError if the app has crashed.
  */
 export async function waitForDisplayed(
   driver: Browser,
@@ -160,6 +220,8 @@ export async function waitForDisplayed(
   try {
     await element.waitForDisplayed({ timeout })
   } catch (err) {
+    // if app crashed, throw immediately - no point continuing
+    await assertAppRunning(driver)
     await takeScreenshotForError(driver, err)
   }
   return element
@@ -173,9 +235,13 @@ async function takeScreenshotForError(driver: Browser, err: unknown) {
   const screenshotPath = `/tmp/appium-screenshots/${fileName}.png`
   const sourcePath = `/tmp/appium-screenshots/${fileName}.xml`
 
-  await driver.saveScreenshot(screenshotPath)
-  const source = await driver.getPageSource()
-  await fs.promises.writeFile(sourcePath, source)
+  try {
+    await driver.saveScreenshot(screenshotPath)
+    const source = await driver.getPageSource()
+    await fs.promises.writeFile(sourcePath, source)
+  } catch {
+    // app may have crashed, screenshot/source not available
+  }
 }
 
 function sanitizeFileName(input: string): string {
@@ -205,6 +271,36 @@ export async function createSession(
       }
 
       const driver = await remote(resolvedConfig)
+
+      // verify the app actually launched successfully
+      try {
+        await assertAppRunning(driver)
+      } catch (e) {
+        if (e instanceof AppCrashedError) {
+          console.error(
+            `[createSession] app crashed immediately after launch on attempt ${attempt}`
+          )
+          // dump simulator system log for crash diagnostics
+          const udid =
+            (resolvedConfig.capabilities as any)?.['appium:options']?.udid ||
+            process.env.SIMULATOR_UDID
+          if (udid) {
+            try {
+              const log = execSync(
+                `xcrun simctl spawn ${udid} log show --predicate 'process == "RNTestContainer" OR subsystem == "com.apple.CrashReporter"' --last 30s --style compact 2>/dev/null || true`,
+                { timeout: 10_000, encoding: 'utf8' }
+              )
+              if (log.trim()) {
+                console.error(
+                  '[createSession] simulator crash log:\n' + log.slice(0, 3000)
+                )
+              }
+            } catch {}
+          }
+          throw e
+        }
+      }
+
       return driver
     } catch (err) {
       lastError = err

--- a/packages/url-parse/package.json
+++ b/packages/url-parse/package.json
@@ -9,10 +9,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "react-native": {
-        "import": "./dist/esm/index.native.js",
-        "require": "./dist/cjs/index.native.js"
-      },
+      "react-native": "./dist/esm/index.native.js",
       "types": "./src/index.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,10 +9,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "react-native": {
-        "import": "./dist/esm/index.native.js",
-        "require": "./dist/cjs/index.native.js"
-      },
+      "react-native": "./dist/esm/index.native.js",
       "types": "./types/index.d.ts",
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.cjs"

--- a/tests/test/app/routes.d.ts
+++ b/tests/test/app/routes.d.ts
@@ -213,5 +213,5 @@ declare module 'one' {
  */
 type RouteInfo<Params = Record<string, never>> = {
   Params: Params
-  LoaderProps: { path: string; params: Params; request?: Request }
+  LoaderProps: { path: string; search?: string; subdomain?: string; params: Params; request?: Request }
 }

--- a/tests/test/tests/basic.test.ios.ts
+++ b/tests/test/tests/basic.test.ios.ts
@@ -1,12 +1,11 @@
 import { expect, test } from 'vitest'
 import { getWebDriverConfig } from '@vxrn/test/ios'
-import { createSession } from '@vxrn/test/utils/appium'
+import { createSession, waitForDisplayed } from '@vxrn/test/utils/appium'
 const sharedTestOptions = { timeout: 10 * 60 * 1000, retry: 1 }
 
 test('basic iOS test', sharedTestOptions, async () => {
   const driver = await createSession(getWebDriverConfig())
 
-  const textElementInComponent = await driver.$(`~welcome-message`)
-  await textElementInComponent.waitForDisplayed({ timeout: 2 * 60 * 1000 })
+  const textElementInComponent = await waitForDisplayed(driver, driver.$(`~welcome-message`), { timeout: 2 * 60 * 1000 })
   expect(await textElementInComponent.getText()).toBe('Welcome to One')
 })

--- a/tests/test/tests/loaders.test.ios.ts
+++ b/tests/test/tests/loaders.test.ios.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { getWebDriverConfig } from '@vxrn/test/ios'
-import { createSession } from '@vxrn/test/utils/appium'
+import { createSession, waitForDisplayed } from '@vxrn/test/utils/appium'
 
 const sharedTestOptions = { timeout: 10 * 60 * 1000, retry: 1 }
 
@@ -8,10 +8,7 @@ describe('loaders on native', () => {
   test('loader data renders on native', sharedTestOptions, async () => {
     const driver = await createSession(getWebDriverConfig())
 
-    // verify the loader data is rendered on the home page
-    // the index.tsx has a loader that returns { test: 'hello' }
-    const loaderDataElement = await driver.$(`~test-loader`)
-    await loaderDataElement.waitForDisplayed({ timeout: 2 * 60 * 1000 })
+    const loaderDataElement = await waitForDisplayed(driver, driver.$(`~test-loader`), { timeout: 2 * 60 * 1000 })
     const text = await loaderDataElement.getText()
     expect(text).toContain('hello')
   })

--- a/tests/test/tests/protected.test.ios.ts
+++ b/tests/test/tests/protected.test.ios.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { getWebDriverConfig } from '@vxrn/test/ios'
 import { createSession, navigateTo, waitForDisplayed } from '@vxrn/test/utils/appium'
 
-const sharedTestOptions = { timeout: 5 * 60 * 1000, retry: 2 }
+const sharedTestOptions = { timeout: 8 * 60 * 1000, retry: 2 }
 
 test(
   'Protected routes - shows public page and can toggle auth',
@@ -19,11 +19,11 @@ test(
     await waitForDisplayed(driver, driver.$('~auth-status'))
     expect(await driver.$('~auth-status').getText()).toContain('Auth: false')
 
-    // Toggle auth
-    const toggleAuth = await driver.$('~toggle-auth')
-    await toggleAuth.click()
+    // Toggle auth — wait for the button, then click and verify
+    await waitForDisplayed(driver, driver.$('~toggle-auth'))
+    await driver.pause(500) // let layout settle after navigation
+    await driver.$('~toggle-auth').click()
 
-    // Wait for auth status to update (re-render can take time on CI)
     await driver.waitUntil(
       async () => (await driver.$('~auth-status').getText()).includes('Auth: true'),
       { timeout: 10_000, interval: 500 }

--- a/tests/test/tests/protected.test.ios.ts
+++ b/tests/test/tests/protected.test.ios.ts
@@ -22,9 +22,12 @@ test(
     // Toggle auth
     const toggleAuth = await driver.$('~toggle-auth')
     await toggleAuth.click()
-    await driver.pause(500)
 
-    // Verify auth status changed
+    // Wait for auth status to update (re-render can take time on CI)
+    await driver.waitUntil(
+      async () => (await driver.$('~auth-status').getText()).includes('Auth: true'),
+      { timeout: 10_000, interval: 500 }
+    )
     expect(await driver.$('~auth-status').getText()).toContain('Auth: true')
   }
 )

--- a/tests/test/tests/setup-file.test.ios.ts
+++ b/tests/test/tests/setup-file.test.ios.ts
@@ -1,16 +1,13 @@
 import { expect, test } from 'vitest'
 import { getWebDriverConfig } from '@vxrn/test/ios'
-import { createSession } from '@vxrn/test/utils/appium'
+import { createSession, waitForDisplayed } from '@vxrn/test/utils/appium'
 
 const sharedTestOptions = { timeout: 10 * 60 * 1000, retry: 1 }
 
 test('setupFile runs on native', sharedTestOptions, async () => {
   const driver = await createSession(getWebDriverConfig())
 
-  // The home page displays the native setup status
-  // Wait for the native-setup-ran element to be displayed
-  const nativeSetupElement = await driver.$(`~native-setup-ran`)
-  await nativeSetupElement.waitForDisplayed({ timeout: 2 * 60 * 1000 })
+  const nativeSetupElement = await waitForDisplayed(driver, driver.$(`~native-setup-ran`), { timeout: 2 * 60 * 1000 })
 
   const nativeSetupText = await nativeSetupElement.getText()
   expect(nativeSetupText).toContain('true')


### PR DESCRIPTION
## Summary
- Collapse all `react-native` export conditions from nested `import`/`require` to a single ESM path
- Metro resolves exports using `isESMImport` flag — if any import triggers the CJS path, the package loads as two separate modules
- This caused "No navigationRef, possible duplicate One dep" and "RNSScreen" errors in iOS CI tests since ~March 25

## Affected packages
- `one` (`.`, `./ui`, `./drawer`)
- `@vxrn/color-scheme`
- `@vxrn/native` (`.`, `./color`, `./zoom`, `./toolbar`, `./menu`, `./split-view`)
- `@vxrn/query-string`
- `@vxrn/safe-area`
- `@vxrn/url-parse`
- `@vxrn/utils`

## Test plan
- [x] All JSON files validate
- [x] `manypkg check` passes
- [ ] iOS Native Tests CI passes (triggered: https://github.com/onejs/one/actions/runs/23637543314)