### PR TITLE
fix: support bracket notation for env var replacement in Vite define

### DIFF
--- a/packages/vxrn/src/exports/loadEnv.test.ts
+++ b/packages/vxrn/src/exports/loadEnv.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { loadEnv } from './loadEnv'
+
+describe('loadEnv', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    // Set a known public env var that matches the default ONE_ prefix
+    process.env.ONE_PUBLIC_TEST_KEY = 'test-value'
+  })
+
+  afterEach(() => {
+    // Restore original env to avoid leaking between tests
+    process.env = { ...originalEnv }
+  })
+
+  it('generates dot-notation define keys for process.env', async () => {
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine['process.env.ONE_PUBLIC_TEST_KEY']).toBe('"test-value"')
+  })
+
+  it('generates double-quote bracket-notation define keys for process.env', async () => {
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine['process.env["ONE_PUBLIC_TEST_KEY"]']).toBe('"test-value"')
+  })
+
+  it('generates single-quote bracket-notation define keys for process.env', async () => {
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine["process.env['ONE_PUBLIC_TEST_KEY']"]).toBe('"test-value"')
+  })
+
+  it('generates dot-notation define keys for import.meta.env', async () => {
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine['import.meta.env.ONE_PUBLIC_TEST_KEY']).toBe('"test-value"')
+  })
+
+  it('generates double-quote bracket-notation define keys for import.meta.env', async () => {
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine['import.meta.env["ONE_PUBLIC_TEST_KEY"]']).toBe('"test-value"')
+  })
+
+  it('generates single-quote bracket-notation define keys for import.meta.env', async () => {
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine["import.meta.env['ONE_PUBLIC_TEST_KEY']"]).toBe('"test-value"')
+  })
+
+  it('generates all six define keys per env var', async () => {
+    const { clientEnvDefine } = await loadEnv('test')
+
+    const expectedKeys = [
+      'process.env.ONE_PUBLIC_TEST_KEY',
+      'process.env["ONE_PUBLIC_TEST_KEY"]',
+      "process.env['ONE_PUBLIC_TEST_KEY']",
+      'import.meta.env.ONE_PUBLIC_TEST_KEY',
+      'import.meta.env["ONE_PUBLIC_TEST_KEY"]',
+      "import.meta.env['ONE_PUBLIC_TEST_KEY']",
+    ]
+
+    for (const key of expectedKeys) {
+      expect(clientEnvDefine).toHaveProperty(key)
+    }
+  })
+
+  it('does not generate define keys for non-public env vars', async () => {
+    process.env.SECRET_KEY = 'secret'
+
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine['process.env.SECRET_KEY']).toBeUndefined()
+    expect(clientEnvDefine['process.env["SECRET_KEY"]']).toBeUndefined()
+  })
+
+  it('includes VITE_ prefixed vars in clientEnvDefine', async () => {
+    process.env.VITE_APP_TITLE = 'My App'
+
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine['process.env.VITE_APP_TITLE']).toBe('"My App"')
+    expect(clientEnvDefine['process.env["VITE_APP_TITLE"]']).toBe('"My App"')
+  })
+
+  it('includes TAMAGUI_ prefixed vars in clientEnvDefine', async () => {
+    process.env.TAMAGUI_TARGET = 'web'
+
+    const { clientEnvDefine } = await loadEnv('test')
+
+    expect(clientEnvDefine['process.env.TAMAGUI_TARGET']).toBe('"web"')
+    expect(clientEnvDefine['process.env["TAMAGUI_TARGET"]']).toBe('"web"')
+  })
+
+  it('includes vars matching custom userPrefix', async () => {
+    process.env.CUSTOM_PUBLIC_FOO = 'bar'
+
+    const { clientEnvDefine } = await loadEnv('test', process.cwd(), 'CUSTOM_PUBLIC_')
+
+    expect(clientEnvDefine['process.env.CUSTOM_PUBLIC_FOO']).toBe('"bar"')
+    expect(clientEnvDefine['process.env["CUSTOM_PUBLIC_FOO"]']).toBe('"bar"')
+  })
+})

--- a/packages/vxrn/src/exports/loadEnv.ts
+++ b/packages/vxrn/src/exports/loadEnv.ts
@@ -49,7 +49,11 @@ export async function loadEnv(
         const stringified = JSON.stringify(val)
         return [
           [`process.env.${key}`, stringified],
+          [`process.env["${key}"]`, stringified],
+          [`process.env['${key}']`, stringified],
           [`import.meta.env.${key}`, stringified],
+          [`import.meta.env["${key}"]`, stringified],
+          [`import.meta.env['${key}']`, stringified],
         ]
       })
     ),


### PR DESCRIPTION
## Problem

Vite's `define` config performs literal text replacement on source code. The `clientEnvDefine` object in `loadEnv.ts` currently only generates dot-notation keys:

```js
`process.env.${key}`
`import.meta.env.${key}`
```

This means bracket notation access — which is common in TypeScript codebases where `noPropertyAccessFromIndexSignature` is enabled — is **never replaced** and resolves to `undefined` at runtime:

```ts
// ✅ Works — replaced by Vite
process.env.ONE_PUBLIC_POSTHOG_KEY

// ❌ Broken — not replaced, becomes undefined
process.env["ONE_PUBLIC_POSTHOG_KEY"]
```

TypeScript's `noPropertyAccessFromIndexSignature` compiler option (part of strict configs) requires bracket notation for index signatures, which makes `process.env["KEY"]` the natural way to access env vars. This creates a subtle bug where env vars silently resolve to `undefined` in client bundles.

## Fix

Add bracket-notation entries (both double and single quotes) to the `clientEnvDefine` output for both `process.env` and `import.meta.env`:

```ts
return [
  [`process.env.${key}`, stringified],
  [`process.env["${key}"]`, stringified],
  [`process.env['${key}']`, stringified],
  [`import.meta.env.${key}`, stringified],
  [`import.meta.env["${key}"]`, stringified],
  [`import.meta.env['${key}']`, stringified],
]
```

Note: Metro's Babel plugin (`import-meta-env-plugin.ts`) already handles both notations via AST analysis, so this only affects the Vite/web path.