### PR TITLE
fix docs: typo 'word' -> 'world' in routing Dynamic Routes section

### DIFF
--- a/apps/onestack.dev/data/docs/routing.mdx
+++ b/apps/onestack.dev/data/docs/routing.mdx
@@ -54,7 +54,7 @@ All `index` files match against `/`, so `app/index.tsx` matches to your root `/`
 
 ### Dynamic Routes
 
-The segments of a route, for example `/hello/world`, are referred to as "route parameters" or just "params", where "hello" and "word" are each a single parameter. Pages can match against parameters dynamically in two ways: matching a single parameter, or matching all parameters below them.
+The segments of a route, for example `/hello/world`, are referred to as "route parameters" or just "params", where "hello" and "world" are each a single parameter. Pages can match against parameters dynamically in two ways: matching a single parameter, or matching all parameters below them.
 
 #### Single Parameter Routes
 


### PR DESCRIPTION
Noticed while getting oriented. Fixes a typo in the Dynamic Routes documentation. 'word' -> 'world' in the example path `/hello/world`.