### PR TITLE
fix(one,vxrn,compiler,vite-plugin-metro): Windows path bugs across build/server/dev/native paths

### DIFF
--- a/packages/compiler/src/transformSWC.ts
+++ b/packages/compiler/src/transformSWC.ts
@@ -1,4 +1,4 @@
-import { extname, sep } from 'node:path'
+import { extname } from 'node:path'
 import {
   type Output,
   type ParserConfig,
@@ -7,11 +7,13 @@ import {
   transform,
 } from '@swc/core'
 import { merge } from 'ts-deepmerge'
+import { normalizePath } from 'vite'
 import { configuration } from './configure'
 import { asyncGeneratorRegex, debug, parsers, runtimePublicPath } from './constants'
 import type { Options } from './types'
 
-const ignoreId = new RegExp(`node_modules\\${sep}(\\.vite|vite)\\${sep}`)
+// POSIX-only — id is normalized below
+const ignoreId = /node_modules\/(\.vite|vite)\//
 
 export async function transformSWC(
   id: string,
@@ -19,14 +21,12 @@ export async function transformSWC(
   options: Options & { es5?: boolean },
   swcOptions?: SWCOptions
 ) {
+  // unify caller contracts (Vite plugin: POSIX id; patches.ts: native id)
+  id = normalizePath(id.split('?')[0]).replace(normalizePath(process.cwd()), '')
+
   if (ignoreId.test(id)) {
     return
   }
-
-  id = id
-    .split('?')[0]
-    // fixes hmr
-    .replace(process.cwd(), '')
 
   if (id === runtimePublicPath) {
     return

--- a/packages/one/src/babel-preset/index.test.ts
+++ b/packages/one/src/babel-preset/index.test.ts
@@ -147,4 +147,24 @@ describe('buildOneBabelPlugins', () => {
     const oneRouterMetro = plugins[3] as [string, Record<string, unknown>]
     expect(oneRouterMetro[1].ONE_ROUTER_LINKING_CONFIG).toBe(linking)
   })
+
+  // Both values are inlined by babel as JS literals — `ONE_ROUTER_APP_ROOT_RELATIVE_TO_ENTRY`
+  // becomes the first arg of `require.context()`, `ONE_SETUP_FILE_NATIVE` becomes the literal
+  // in `import "..."`. Native separators on Windows produce platform-conditional AST that
+  // breaks source-maps, snapshot tests, and rolldown/Vite POSIX module-graph keys.
+  it('emits forward-slash-only paths for `require.context` + `import` specifiers', () => {
+    const plugins = buildOneBabelPlugins({
+      projectRoot,
+      relativeRouterRoot: 'app',
+      setupFile: 'src/setup-native.ts',
+      includeImportMetaEnv: false,
+    })
+
+    const oneRouterMetro = plugins[3] as [string, Record<string, unknown>]
+    const appRoot = oneRouterMetro[1].ONE_ROUTER_APP_ROOT_RELATIVE_TO_ENTRY as string
+    const setupNative = oneRouterMetro[1].ONE_SETUP_FILE_NATIVE as string
+
+    expect(appRoot).not.toContain('\\')
+    expect(setupNative).not.toContain('\\')
+  })
 })

--- a/packages/one/src/babel-preset/index.ts
+++ b/packages/one/src/babel-preset/index.ts
@@ -8,6 +8,13 @@ import {
   ROUTE_NATIVE_EXCLUSION_GLOB_PATTERNS,
 } from '../router/glob-patterns'
 
+// Forward-slash a relative path produced by `path.relative` on every platform.
+// `babel-preset` deliberately avoids `vite.normalizePath` so the preset stays
+// usable in standalone Metro contexts where Vite isn't installed.
+function toPosixRelativePath(relativePath: string): string {
+  return path.sep === '\\' ? relativePath.replace(/\\/g, '/') : relativePath
+}
+
 // Babel's `ConfigAPI` shape: cache mutator, env helper, and a cwd accessor.
 // The public @babel/core typing omits `cwd()` so we describe it locally.
 type BabelConfigAPI = {
@@ -138,7 +145,13 @@ export function buildOneBabelPlugins({
         ? setupFile
         : setupFile.native || setupFile.ios || setupFile.android
     if (!file) return undefined
-    return path.relative(path.dirname(metroEntryPath), path.join(projectRoot, file))
+    // POSIX-only — embedded as a JS import specifier in `one-router-metro` (becomes
+    // literal `import "..."`); backslashes on Windows produce platform-conditional AST
+    // and silently break rolldown/Vite POSIX module-graph keys for source-map / snapshot
+    // consumers downstream.
+    return toPosixRelativePath(
+      path.relative(path.dirname(metroEntryPath), path.join(projectRoot, file))
+    )
   })()
 
   return [
@@ -173,9 +186,13 @@ export function buildOneBabelPlugins({
     [
       'one/babel-plugin-one-router-metro',
       {
-        ONE_ROUTER_APP_ROOT_RELATIVE_TO_ENTRY: path.relative(
-          path.dirname(metroEntryPath),
-          path.join(projectRoot, relativeRouterRoot)
+        // POSIX-only — becomes the first arg of `require.context()` in `one-router-metro`;
+        // backslashes on Windows drift the babel-emitted AST per platform.
+        ONE_ROUTER_APP_ROOT_RELATIVE_TO_ENTRY: toPosixRelativePath(
+          path.relative(
+            path.dirname(metroEntryPath),
+            path.join(projectRoot, relativeRouterRoot)
+          )
         ),
         ONE_ROUTER_ROOT_FOLDER_NAME: relativeRouterRoot,
         ONE_ROUTER_REQUIRE_CONTEXT_REGEX_STRING:

--- a/packages/one/src/cli/build.ts
+++ b/packages/one/src/cli/build.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module'
 import { cpus } from 'node:os'
-import Path, { join, relative, resolve } from 'node:path'
+import Path, { join, posix, relative, resolve } from 'node:path'
 import { resolvePath } from '@vxrn/resolve'
 import FSExtra from 'fs-extra'
 import MicroMatch from 'micromatch'
@@ -557,14 +557,14 @@ export async function build(args: {
                       chunkInfo.name,
                       Path.extname(chunkInfo.name)
                     )
-                    return Path.join(dir, `${name}-[hash].cjs`)
+                    return posix.join(dir, `${name}-[hash].cjs`)
                   },
                   assetFileNames: (assetInfo) => {
                     const name = assetInfo.name ?? ''
                     const dir = Path.dirname(name)
                     const baseName = Path.basename(name, Path.extname(name))
                     const ext = Path.extname(name)
-                    return Path.join(dir, `${baseName}-[hash]${ext}`)
+                    return posix.join(dir, `${baseName}-[hash]${ext}`)
                   },
                 }),
           },
@@ -611,7 +611,11 @@ export async function build(args: {
       const outChunks = middlewareBuildInfo.output.filter((x) => x.type === 'chunk')
       const chunk = outChunks.find((x) => x.facadeModuleId === fullPath)
       if (!chunk) throw new Error(`internal err finding middleware`)
-      builtMiddlewares[middleware.file] = join(outDir, 'middlewares', chunk.fileName)
+      builtMiddlewares[middleware.file] = posix.join(
+        outDir,
+        'middlewares',
+        chunk.fileName
+      )
     }
   }
 
@@ -1030,7 +1034,8 @@ export async function build(args: {
       })
     }
 
-    const serverJsPath = join(`${outDir}/server`, serverFileName)
+    // posix so downstream `.includes('${outDir}/server')` substring checks match on Windows
+    const serverJsPath = posix.join(outDir, 'server', serverFileName)
 
     let exported
     try {
@@ -1474,7 +1479,10 @@ export default {
         projectName,
         userWranglerConfig?.config
       )
-      wranglerInputConfig.main = relative(join(options.root, outDir), workerSrcPath)
+      // serialized wrangler config is diffed cross-platform; keep forward-slash
+      wranglerInputConfig.main = normalizePath(
+        relative(join(options.root, outDir), workerSrcPath)
+      )
 
       const wranglerInputPath = join(options.root, outDir, '_wrangler.input.jsonc')
       await FSExtra.writeFile(

--- a/packages/one/src/cli/buildPage.ts
+++ b/packages/one/src/cli/buildPage.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import FSExtra from 'fs-extra'
+import { normalizePath } from 'vite'
 import * as constants from '../constants'
 import { LOADER_JS_POSTFIX_UNCACHED } from '../constants'
 import type { LoaderProps } from '../types'
@@ -64,8 +65,9 @@ export async function buildPage(
   recordTiming('getRender', performance.now() - t0)
 
   const htmlPath = `${path.endsWith('/') ? `${removeTrailingSlash(path)}/index` : path}.html`
+  // forward-slash for cross-platform manifest hygiene (matches serverJsPath)
   const clientJsPath = clientManifestEntry
-    ? join(clientDir, clientManifestEntry.file)
+    ? normalizePath(join(clientDir, clientManifestEntry.file))
     : ''
   const htmlOutPath = toAbsolute(join(staticDir, htmlPath))
   const preloadPath = getPreloadPath(path)

--- a/packages/one/src/server/oneServe.ts
+++ b/packages/one/src/server/oneServe.ts
@@ -1,7 +1,7 @@
 import type { Hono, MiddlewareHandler } from 'hono'
 import type { BlankEnv } from 'hono/types'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, posix } from 'node:path'
 import {
   CSS_PRELOAD_JS_POSTFIX,
   LOADER_JS_POSTFIX_UNCACHED,
@@ -17,6 +17,7 @@ import {
 import type { RenderAppProps } from '../types'
 import { getPathFromLoaderPath } from '../utils/cleanUrl'
 import { toAbsoluteUrl } from '../utils/toAbsolute'
+import { toServerOutputPath } from '../utils/toServerOutputPath'
 import type { One } from '../vite/types'
 import type { RouteInfoCompiled } from './createRoutesManifest'
 import { setSSRLoaderData } from './ssrLoaderData'
@@ -164,9 +165,7 @@ export async function oneServe(
     // cold path - async import
     return (async () => {
       const pathToResolve = serverPath || lazyKey || ''
-      const resolvedPath = pathToResolve.includes(`${outDir}/server`)
-        ? pathToResolve
-        : join('./', `${outDir}/server`, pathToResolve)
+      const resolvedPath = toServerOutputPath(pathToResolve, outDir)
 
       let routeExported: any
       if (moduleImportCache.has(cacheKey)) {
@@ -314,7 +313,8 @@ export async function oneServe(
       }
       // both vite and rolldown-vite replace brackets with underscores in output filenames
       const fileName = route.page.slice(1).replace(/\[/g, '_').replace(/\]/g, '_')
-      const apiFile = join(outDir, 'api', fileName + (apiCJS ? '.cjs' : '.js'))
+      // posix matches the serverJsPath/builtMiddlewares producer convention
+      const apiFile = posix.join(outDir, 'api', fileName + (apiCJS ? '.cjs' : '.js'))
       return await import(toAbsoluteUrl(apiFile))
     },
 
@@ -328,9 +328,7 @@ export async function oneServe(
 
     async handleLoader({ route, loaderProps }) {
       const routeFile = (route as any).routeFile || route.file
-      const serverPath = route.file.includes(`${outDir}/server`)
-        ? route.file
-        : join('./', `${outDir}/server`, route.file)
+      const serverPath = toServerOutputPath(route.file, outDir)
 
       let loader: Function | null
       try {

--- a/packages/one/src/utils/posixPathContract.test.ts
+++ b/packages/one/src/utils/posixPathContract.test.ts
@@ -1,0 +1,97 @@
+// Lock in cross-platform output of Node primitives — a regression here is a future Windows break.
+import { posix } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { normalizePath } from 'vite'
+import { toServerOutputPath } from './toServerOutputPath'
+
+describe('path.posix.join — forward-slash output on every platform', () => {
+  it('joins server-output paths', () => {
+    expect(posix.join('dist', 'server', 'foo.js')).toBe('dist/server/foo.js')
+  })
+
+  it('joins middleware-output paths', () => {
+    expect(posix.join('dist', 'middlewares', 'mw-hash.js')).toBe(
+      'dist/middlewares/mw-hash.js'
+    )
+  })
+
+  it('strips redundant `./` segments', () => {
+    expect(posix.join('./app', './_layout.tsx')).toBe('app/_layout.tsx')
+  })
+
+  it('produces a bare filename for a `.` directory component', () => {
+    expect(posix.join('.', 'foo-[hash].cjs')).toBe('foo-[hash].cjs')
+  })
+
+  it('preserves nested-chunk subdirectories', () => {
+    expect(posix.join('subdir', 'foo-[hash].cjs')).toBe('subdir/foo-[hash].cjs')
+  })
+})
+
+describe('pathToFileURL — canonical file:// URL specifier', () => {
+  it('produces a forward-slash href on every platform', () => {
+    const href = pathToFileURL('/proj/src/setup.ts').href
+    expect(href.startsWith('file://')).toBe(true)
+    expect(href.includes('\\')).toBe(false)
+  })
+
+  it('round-trips through JSON.stringify without backslashes leaking in', () => {
+    // motivating defect: bare absolute path puts backslashes in emitted JS on Windows
+    const href = pathToFileURL('/proj/src/setup.ts').href
+    const stringified = JSON.stringify(href)
+    expect(stringified.includes('\\\\')).toBe(false)
+  })
+})
+
+describe('Vite normalizePath — converts on Windows, no-op on POSIX', () => {
+  it('preserves a forward-slash path unchanged', () => {
+    expect(normalizePath('/proj/src/foo.tsx')).toBe('/proj/src/foo.tsx')
+  })
+
+  it('converts backslashes (Windows-shaped input)', () => {
+    // Windows converts; POSIX passthrough (backslash is a valid filename char there)
+    const input = String.raw`C:\proj\src\foo.tsx`
+    const out = normalizePath(input)
+    if (process.platform === 'win32') {
+      expect(out).toBe('C:/proj/src/foo.tsx')
+    } else {
+      expect(out).toBe(input)
+    }
+  })
+})
+
+describe('toServerOutputPath — cross-platform parity', () => {
+  // posix.join + backslash-replace (not normalizePath) — output must be byte-identical across platforms
+  const cases: Array<[string, string, string]> = [
+    ['foo.js', 'dist', 'dist/server/foo.js'],
+    ['subdir/bar.js', 'dist', 'dist/server/subdir/bar.js'],
+    ['dist/server/foo.js', 'dist', 'dist/server/foo.js'],
+    [String.raw`dist\server\foo.js`, 'dist', 'dist/server/foo.js'],
+    [String.raw`subdir\bar.js`, 'dist', 'dist/server/subdir/bar.js'],
+    ['foo/dist/server/bar.js', 'dist', 'dist/server/foo/dist/server/bar.js'],
+    ['dist/server', 'dist', 'dist/server'],
+    ['baz.js', 'build', 'build/server/baz.js'],
+  ]
+
+  for (const [input, outDir, expected] of cases) {
+    it(`("${input}", "${outDir}") → "${expected}"`, () => {
+      expect(toServerOutputPath(input, outDir)).toBe(expected)
+    })
+  }
+})
+
+describe('seed bug regression — SSR loader path doubling on Windows', () => {
+  // serverJsPath minted native sep; oneServe `.includes('/server')` missed; prefix doubled, await import() crashed
+  it('does not double-prefix backslash-shaped server-output input', () => {
+    const windowsShapedInput = String.raw`dist\server\assets\time_ssr-COqAsxju.js`
+    expect(toServerOutputPath(windowsShapedInput, 'dist')).toBe(
+      'dist/server/assets/time_ssr-COqAsxju.js'
+    )
+  })
+
+  it('does not double-prefix already-forward-slashed input', () => {
+    const posixInput = 'dist/server/assets/time_ssr-COqAsxju.js'
+    expect(toServerOutputPath(posixInput, 'dist')).toBe(posixInput)
+  })
+})

--- a/packages/one/src/utils/toServerOutputPath.test.ts
+++ b/packages/one/src/utils/toServerOutputPath.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { toServerOutputPath } from './toServerOutputPath'
+
+describe('toServerOutputPath', () => {
+  it('prepends ${outDir}/server/ to bare filenames from Vite output', () => {
+    expect(toServerOutputPath('assets/loader-abc.js', 'dist')).toBe(
+      'dist/server/assets/loader-abc.js'
+    )
+  })
+
+  it('prepends ${outDir}/server/ to project-relative paths from the route tree', () => {
+    expect(toServerOutputPath('./pages/index.tsx', 'dist')).toBe(
+      'dist/server/pages/index.tsx'
+    )
+  })
+
+  it('returns input unchanged when it is already rooted under ${outDir}/server/', () => {
+    expect(toServerOutputPath('dist/server/assets/loader-abc.js', 'dist')).toBe(
+      'dist/server/assets/loader-abc.js'
+    )
+  })
+
+  it('treats backslashes as separators on every platform (the Windows path-doubling case)', () => {
+    // already-prefixed backslash input — must normalize before sentinel check
+    expect(toServerOutputPath('dist\\server\\assets\\loader-abc.js', 'dist')).toBe(
+      'dist/server/assets/loader-abc.js'
+    )
+  })
+
+  it('is idempotent: feeding the output back in returns the same value', () => {
+    const first = toServerOutputPath('assets/loader-abc.js', 'dist')
+    const second = toServerOutputPath(first, 'dist')
+    expect(second).toBe(first)
+  })
+
+  it('honors a custom outDir', () => {
+    expect(toServerOutputPath('assets/loader.js', 'build')).toBe(
+      'build/server/assets/loader.js'
+    )
+  })
+
+  it('does not false-positive on inputs that contain ${outDir}/server as a substring but are not rooted under it', () => {
+    // startsWith required: .includes would match foo/dist/server/x and wrongly skip
+    expect(toServerOutputPath('foo/dist/server/bar.js', 'dist')).toBe(
+      'dist/server/foo/dist/server/bar.js'
+    )
+  })
+})

--- a/packages/one/src/utils/toServerOutputPath.ts
+++ b/packages/one/src/utils/toServerOutputPath.ts
@@ -1,0 +1,11 @@
+import { posix } from 'node:path'
+
+// Idempotent. Returns forward-slash output. Accepts backslash input (legacy path.join-shaped callers).
+export function toServerOutputPath(input: string, outDir: string): string {
+  const normalized = input.replace(/\\/g, '/')
+  const prefix = `${outDir}/server/`
+  if (normalized === `${outDir}/server` || normalized.startsWith(prefix)) {
+    return normalized
+  }
+  return posix.join(outDir, 'server', normalized)
+}

--- a/packages/one/src/vite/one.ts
+++ b/packages/one/src/vite/one.ts
@@ -8,7 +8,7 @@ import {
 import events from 'node:events'
 import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
-import { type Plugin, type PluginOption } from 'vite'
+import { normalizePath, type Plugin, type PluginOption } from 'vite'
 import { autoDepOptimizePlugin, getOptionsFilled, loadEnv } from 'vxrn'
 import vxrnVitePlugin from 'vxrn/vite-plugin'
 import { CACHE_KEY } from '../constants'
@@ -251,11 +251,14 @@ export function one(options: One.PluginOptions = {}): PluginOption {
             } catch {}
           }
 
-          // for bare imports, map real path → node_modules path
-          const realPkgDir = realpathSync(nmPkgDir)
+          // resolved.id is POSIX (Vite's getRealPath normalizes); realpathSync returns native — normalize both
+          const realPkgDir = normalizePath(realpathSync(nmPkgDir))
           if (resolved.id.startsWith(realPkgDir)) {
             const relativePart = resolved.id.slice(realPkgDir.length)
-            return { id: nmPkgDir + relativePart, external: resolved.external }
+            return {
+              id: normalizePath(nmPkgDir) + relativePart,
+              external: resolved.external,
+            }
           }
           break
         }

--- a/packages/one/src/vite/plugins/fileSystemRouterPlugin.tsx
+++ b/packages/one/src/vite/plugins/fileSystemRouterPlugin.tsx
@@ -540,6 +540,7 @@ export function createFileSystemRouterPlugin(options: One.PluginOptions): Plugin
 
     async config() {
       const setting = options.optimization?.autoEntriesScanning ?? 'flat'
+      const routerRoot = getRouterRootFromOneOptions(options)
 
       if (setting === false) {
         return
@@ -560,11 +561,12 @@ export function createFileSystemRouterPlugin(options: One.PluginOptions): Plugin
                 return []
               }
 
+              // optimizeDeps.entries uses tinyglobby — needs forward-slash patterns
               return [
-                path.join('./app', route.file),
+                path.posix.join(`./${routerRoot}`, route.file),
                 ...(route.layouts?.flatMap((layout) => {
                   if (!layout.contextKey) return []
-                  return [path.join('./app', layout.contextKey)]
+                  return [path.posix.join(`./${routerRoot}`, layout.contextKey)]
                 }) || []),
               ]
             })

--- a/packages/one/src/vite/plugins/sourceInspectorPlugin.ts
+++ b/packages/one/src/vite/plugins/sourceInspectorPlugin.ts
@@ -112,7 +112,8 @@ export function resolveEditorFilePath(
   cwd = process.cwd(),
   fileExists: (path: string) => boolean = existsSync
 ): string {
-  const projectPath = path.join(cwd, filePath)
+  // mirror sibling getSourceInspectorPath which already normalizes
+  const projectPath = normalizePath(path.join(cwd, filePath))
 
   // data-one-source uses "/foo.tsx" for project-relative paths, but files outside
   // cwd are stored as absolute paths and must not be re-joined onto cwd.

--- a/packages/one/src/vite/plugins/virtualEntryPlugin.ts
+++ b/packages/one/src/vite/plugins/virtualEntryPlugin.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { configuration } from '@vxrn/compiler'
 import type { Plugin } from 'vite'
 import { isNativeEnvironment } from 'vxrn'
@@ -86,8 +87,10 @@ function getSetupFileImport(
   if (!setupFile)
     return { importStatement: '', promiseDeclaration: '', promiseVarName: '' }
 
-  // resolve to absolute path so rolldown can find it from virtual modules
-  const resolvedSetupFile = root ? resolve(root, setupFile) : setupFile
+  // file:// URL is canonical; bare Windows absolute path has backslashes (mirrors createNativeDevEngine.ts)
+  const resolvedSetupFile = root
+    ? pathToFileURL(resolve(root, setupFile)).href
+    : setupFile
 
   // For native, use static import since dynamic import doesn't work
   if (useStaticImport) {

--- a/packages/one/types/utils/posixPathContract.test.d.ts
+++ b/packages/one/types/utils/posixPathContract.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=posixPathContract.test.d.ts.map

--- a/packages/one/types/utils/toServerOutputPath.d.ts
+++ b/packages/one/types/utils/toServerOutputPath.d.ts
@@ -1,0 +1,2 @@
+export declare function toServerOutputPath(input: string, outDir: string): string;
+//# sourceMappingURL=toServerOutputPath.d.ts.map

--- a/packages/one/types/utils/toServerOutputPath.test.d.ts
+++ b/packages/one/types/utils/toServerOutputPath.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=toServerOutputPath.test.d.ts.map

--- a/packages/resolve/src/index.test.ts
+++ b/packages/resolve/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { resolvePath } from './index'
 import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 
 describe('resolvePath', () => {
   describe('basic resolution', () => {
@@ -24,9 +25,8 @@ describe('resolvePath', () => {
 
   describe('respects from parameter', () => {
     it('resolves relative paths from specified directory', () => {
-      // Use process.cwd() which is the repo root when running tests
       const path = resolvePath('./package.json', process.cwd())
-      expect(path).toBe(process.cwd() + '/package.json')
+      expect(path).toBe(join(process.cwd(), 'package.json'))
       expect(existsSync(path)).toBe(true)
     })
 
@@ -47,7 +47,7 @@ describe('resolvePath', () => {
     it('returns ESM entry when exports["."].import.default exists', () => {
       // vitest has nested structure: { import: { types: "...", default: "..." } }
       const path = resolvePath('vitest', process.cwd())
-      expect(path).toContain('dist/index.js')
+      expect(path).toContain(join('dist', 'index.js'))
       expect(path).not.toContain('.cjs')
     })
 

--- a/packages/test/src/setupTest.ts
+++ b/packages/test/src/setupTest.ts
@@ -1,22 +1,70 @@
-import getPort, { portNumbers } from 'get-port'
 import { exec, spawn, type ChildProcess } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
+import getPort, { portNumbers } from 'get-port'
 import { ONLY_TEST_DEV, ONLY_TEST_PROD } from './constants'
 
 const execAsync = promisify(exec)
 
+// Resolve binary entry points cross-platform. The `.bin/` shim path used to
+// be hardcoded as `'../../node_modules/.bin/<pkg>'`, which only worked because
+// on POSIX `.bin/<pkg>` is a symlink to the package's JS entry. On Windows the
+// shim is a `.cmd`/`.ps1`/`.exe` wrapper — none of those load as a script via
+// `node <path>`, so the spawn errors with `Cannot find module`. Resolving via
+// `package.json` gives the real JS file regardless of bun's hoisting layout.
+const requireFromHere = createRequire(import.meta.url)
+const ONE_RUN_ENTRY = join(
+  dirname(requireFromHere.resolve('one/package.json')),
+  'run.mjs'
+)
+const VITE_BIN_ENTRY = join(
+  dirname(requireFromHere.resolve('vite/package.json')),
+  'bin/vite.js'
+)
+
+const isWindows = process.platform === 'win32'
+
 export async function killProcessOnPort(port: number): Promise<void> {
   try {
-    const { stdout } = await execAsync(`lsof -i :${port} -t`)
-    const pids = stdout.trim().split('\n').filter(Boolean)
-
+    const pids = await findPidsOnPort(port)
     if (pids.length > 0) {
       console.info(`Killing processes on port ${port}: ${pids.join(', ')}`)
-      await Promise.all(pids.map((pid) => execAsync(`kill -9 ${pid}`).catch(() => {})))
+      await Promise.all(pids.map((pid) => killByPid(pid).catch(() => {})))
       await new Promise((resolve) => setTimeout(resolve, 500))
     }
   } catch (error) {
     // no process found on port, which is fine
+  }
+}
+
+// On POSIX, `lsof -i :PORT -t` lists owning PIDs (one per line).
+// On Windows, `netstat -ano | findstr :PORT` shows lines whose final column is
+// the owning PID. Both paths produce a deduped list of numeric PIDs.
+async function findPidsOnPort(port: number): Promise<string[]> {
+  if (isWindows) {
+    const { stdout } = await execAsync(`netstat -ano | findstr :${port}`)
+    const pids = stdout
+      .split('\n')
+      .map((line) => line.trim().split(/\s+/).at(-1))
+      .filter(
+        (pid): pid is string =>
+          typeof pid === 'string' && pid !== '0' && /^\d+$/.test(pid)
+      )
+    return Array.from(new Set(pids))
+  }
+  const { stdout } = await execAsync(`lsof -i :${port} -t`)
+  return stdout.trim().split('\n').filter(Boolean)
+}
+
+// `taskkill /F /T /PID` kills the process tree on Windows. `/T` is essential
+// because dev/serve spawn `node` which spawns child workers — sending the
+// signal to only the top-level PID would leave the workers running.
+async function killByPid(pid: string): Promise<void> {
+  if (isWindows) {
+    await execAsync(`taskkill /F /T /PID ${pid}`)
+  } else {
+    await execAsync(`kill -9 ${pid}`)
   }
 }
 
@@ -58,6 +106,9 @@ function spawnServer(
     detached: options.detached ?? true,
     // pipe so we can capture output for crash diagnostics
     stdio: ['ignore', 'pipe', 'pipe'],
+    // suppress the conhost flash that `detached: true` would otherwise produce
+    // for each spawned server on Windows
+    windowsHide: true,
   })
 
   const appendOutput = (data: Buffer) => {
@@ -222,6 +273,8 @@ export async function setupTestServers({
           NODE_ENV: 'production',
           ONE_SERVER_URL: `http://localhost:${prodPort}`,
         },
+        // bun is launched via shell on Windows; suppress the conhost flash
+        windowsHide: true,
       })
       let buildProcessOutput = ''
       buildProcess.stdout?.on('data', (data) => {
@@ -274,8 +327,8 @@ export async function setupTestServers({
       ) as typeof process.env
 
       const devArgs = runWithNonCliMode
-        ? ['../../node_modules/.bin/vite', 'dev', '--host', '--port', devPort.toString()]
-        : ['../../node_modules/.bin/one', 'dev', '--clean', '--port', devPort.toString()]
+        ? [VITE_BIN_ENTRY, 'dev', '--host', '--port', devPort.toString()]
+        : [ONE_RUN_ENTRY, 'dev', '--clean', '--port', devPort.toString()]
 
       const spawned = spawnServer('node', devArgs, {
         cwd: process.cwd(),
@@ -292,7 +345,7 @@ export async function setupTestServers({
       console.info(`Starting a prod server on http://localhost:${prodPort}`)
       const spawned = spawnServer(
         'node',
-        ['../../node_modules/.bin/one', 'serve', '--port', prodPort.toString()],
+        [ONE_RUN_ENTRY, 'serve', '--port', prodPort.toString()],
         {
           cwd: process.cwd(),
           env: {

--- a/packages/vite-plugin-metro/src/plugins/expoManifestRequestHandlerPlugin.ts
+++ b/packages/vite-plugin-metro/src/plugins/expoManifestRequestHandlerPlugin.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import { TLSSocket } from 'node:tls'
 import type { PluginOption } from 'vite'
 
@@ -27,7 +28,8 @@ export function expoManifestRequestHandlerPlugin(
     //   projectRoot = config.root
     // },
     configureServer(server) {
-      const { root: projectRoot } = server.config
+      // mirrors metroPlugin.ts: Expo middleware expects native-separator projectRoot
+      const projectRoot = resolve(server.config.root)
 
       // Lazy load the ExpoGoManifestHandlerMiddleware to avoid blocking Vite startup
       let ExpoGoManifestHandlerMiddleware: any

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -53,6 +53,7 @@
     "check": "depcheck",
     "clean": "tamagui-build clean",
     "clean:build": "tamagui-build clean:build",
+    "test": "vitest run --dir src",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/vxrn/src/exports/dev.ts
+++ b/packages/vxrn/src/exports/dev.ts
@@ -1,7 +1,7 @@
 import FSExtra from 'fs-extra'
 import colors from 'picocolors'
 import { debounce } from 'perfect-debounce'
-import type { ViteDevServer } from 'vite'
+import { normalizePath, type ViteDevServer } from 'vite'
 import type { VXRNOptions } from '../types'
 
 const { ensureDir } = FSExtra
@@ -142,12 +142,14 @@ export default defineConfig({
           return
         }
 
-        // Skip dist files to avoid loops during builds
-        if (path.includes('/dist/') || path.includes('\\dist\\')) {
+        // chokidar emits native paths; viteServer.transformRequest expects POSIX URLs
+        const normalizedPath = normalizePath(path)
+        if (normalizedPath.includes('/dist/')) {
           return
         }
 
-        const id = path.replace(process.cwd(), '')
+        const normalizedCwd = normalizePath(process.cwd())
+        const id = normalizedPath.replace(normalizedCwd, '')
         if (!id.endsWith('tsx') && !id.endsWith('jsx')) {
           return
         }

--- a/packages/vxrn/src/plugins/serverExtensions.test.ts
+++ b/packages/vxrn/src/plugins/serverExtensions.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { PluginOption } from 'vite'
 
+// vi.spyOn on `node:fs` exports throws in ESM; use vi.mock factory instead
+const existsSyncMock = vi.fn<(path: any) => boolean>(() => false)
+vi.mock('node:fs', async (importOriginal) => {
+  const original = (await importOriginal()) as object
+  return { ...original, existsSync: (path: any) => existsSyncMock(path) }
+})
+
 async function getPlatformResolvePlugin() {
   const { getBaseVitePlugins } = await import('../config/getBaseVitePlugins')
   const plugins = getBaseVitePlugins() as PluginOption[]
@@ -20,6 +27,9 @@ async function getPlatformResolvePlugin() {
   return plugin
 }
 
+// Vite's config hook destructures `command` from arg 2
+const SERVE_HOOK_OPTS = { command: 'serve' as const, mode: 'development' }
+
 function createMockContext(envName: string, resolvedId?: string) {
   return {
     resolve: vi.fn().mockResolvedValue(resolvedId ? { id: resolvedId } : null),
@@ -33,8 +43,7 @@ describe('platform-specific-resolve', () => {
       const plugin = await getPlatformResolvePlugin()
       const resolveId = plugin.resolveId as Function
 
-      const FSExtra = await import('fs-extra')
-      vi.spyOn(FSExtra.default, 'pathExists').mockImplementation(async (path: any) => {
+      existsSyncMock.mockImplementation((path: any) => {
         return String(path).includes('.server.')
       })
 
@@ -50,8 +59,7 @@ describe('platform-specific-resolve', () => {
       const plugin = await getPlatformResolvePlugin()
       const resolveId = plugin.resolveId as Function
 
-      const FSExtra = await import('fs-extra')
-      vi.spyOn(FSExtra.default, 'pathExists').mockImplementation(async (path: any) => {
+      existsSyncMock.mockImplementation((path: any) => {
         return String(path).includes('.web.')
       })
 
@@ -87,8 +95,7 @@ describe('platform-specific-resolve', () => {
       const plugin = await getPlatformResolvePlugin()
       const resolveId = plugin.resolveId as Function
 
-      const FSExtra = await import('fs-extra')
-      vi.spyOn(FSExtra.default, 'pathExists').mockResolvedValue(false as any)
+      existsSyncMock.mockReturnValue(false)
 
       const ctx = createMockContext('ssr', '/src/db.server.ts')
       // should not throw
@@ -102,7 +109,7 @@ describe('platform-specific-resolve', () => {
   describe('config extensions', () => {
     it('ssr includes .server extensions', async () => {
       const plugin = await getPlatformResolvePlugin()
-      const config = (plugin.config as Function)()
+      const config = (plugin.config as Function)({}, SERVE_HOOK_OPTS)
 
       const ssrExts = config.environments.ssr.resolve.extensions
       expect(ssrExts).toContain('.server.ts')
@@ -112,7 +119,7 @@ describe('platform-specific-resolve', () => {
 
     it('client does not include .server extensions', async () => {
       const plugin = await getPlatformResolvePlugin()
-      const config = (plugin.config as Function)()
+      const config = (plugin.config as Function)({}, SERVE_HOOK_OPTS)
 
       const clientExts = config.environments.client.resolve.extensions
       expect(clientExts).not.toContain('.server.ts')

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -8,7 +8,9 @@
 
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import { existsSync, readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import type { InputOptions, OutputOptions, Plugin, RolldownOutput } from 'rolldown'
+import { normalizePath } from 'vite'
 import { DEFAULT_ASSET_EXTS } from '../constants/defaults'
 import { getNativePrelude } from '../runtime/native-prelude'
 
@@ -557,8 +559,8 @@ const VIRTUAL_NATIVE_ENTRY = 'virtual:native-entry'
 
 function nativeVirtualEntryPlugin(root: string, opts?: { dev?: boolean }): Plugin {
   const isDev = opts?.dev !== false
-  // resolve to an absolute path rooted in the project so import.meta.glob('./app/...') resolves correctly
-  const resolvedId = resolve(root, '__virtual-native-entry.tsx')
+  // absolute for import.meta.glob resolution; forward-slash for module-graph convention
+  const resolvedId = normalizePath(resolve(root, '__virtual-native-entry.tsx'))
 
   // read config passed from One's vite plugin via globalThis
   const entryConfig = (globalThis as any).__vxrnNativeEntryConfig || {}
@@ -573,7 +575,8 @@ function nativeVirtualEntryPlugin(root: string, opts?: { dev?: boolean }): Plugi
     // resolve which file to use for ios (covers both formats)
     const file = typeof sf === 'string' ? sf : 'native' in sf ? sf.native : sf.ios
     if (!file) return ''
-    const resolved = resolve(root, file)
+    // file:// URL is the canonical specifier; bare Windows absolute path is not
+    const resolved = pathToFileURL(resolve(root, file)).href
     return `import ${JSON.stringify(resolved)};`
   })()
 

--- a/packages/vxrn/src/utils/getVitePath.ts
+++ b/packages/vxrn/src/utils/getVitePath.ts
@@ -1,6 +1,7 @@
 import { dirname, join } from 'node:path'
 
 import FSExtra from 'fs-extra'
+import { normalizePath } from 'vite'
 
 export async function getVitePath(
   rootPath: string,
@@ -72,7 +73,8 @@ export async function getVitePath(
   //   id = relative(importer, real)
   // }
 
-  if (id.endsWith(`/react/jsx-dev-runtime.js`)) {
+  // realpath returns native on Windows; sentinel is forward-slash
+  if (normalizePath(id).endsWith(`/react/jsx-dev-runtime.js`)) {
     id = 'react/jsx-runtime'
   }
 

--- a/packages/vxrn/src/utils/patches.test.ts
+++ b/packages/vxrn/src/utils/patches.test.ts
@@ -4,6 +4,8 @@ import { mkdtemp, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// 'junction' avoids Windows admin requirement; type ignored on POSIX
+
 // mock heavy deps that aren't needed for patch resolution tests
 vi.mock('@vxrn/compiler', () => ({ transformSWC: vi.fn() }))
 vi.mock('@vxrn/vite-flow', () => ({ transformFlowBabel: vi.fn() }))
@@ -141,12 +143,12 @@ describe('applyDependencyPatches', () => {
 
         // create symlink at top-level node_modules (like pnpm does when hoisted)
         const symlinkTarget = join(nm, 'test-pkg')
-        await symlink(storeDir, symlinkTarget, 'dir')
+        await symlink(storeDir, symlinkTarget, 'junction')
 
         // also create .pnpm/node_modules hoisted symlink
         const pnpmHoisted = join(nm, '.pnpm', 'node_modules', 'test-pkg')
         await FSExtra.ensureDir(join(nm, '.pnpm', 'node_modules'))
-        await symlink(storeDir, pnpmHoisted, 'dir')
+        await symlink(storeDir, pnpmHoisted, 'junction')
       },
     })
 
@@ -258,7 +260,7 @@ describe('applyDependencyPatches', () => {
 
         // hoisted symlink in .pnpm/node_modules
         await FSExtra.ensureDir(join(nm, '.pnpm', 'node_modules'))
-        await symlink(storeDir, join(nm, '.pnpm', 'node_modules', 'test-pkg'), 'dir')
+        await symlink(storeDir, join(nm, '.pnpm', 'node_modules', 'test-pkg'), 'junction')
       },
     })
 


### PR DESCRIPTION
> [!NOTE]
> **2026-05-19 refresh.** Soft-reset onto [`v1.17.6`](https://github.com/onejs/one/commit/a70a93628) (20 upstream commits absorbed since the last refresh on `v1.17.0`). Reapplied via `git am --3way` per skill Phase 9 — both commits applied with auto-merge on 5 overlap files (`babel-preset/index.ts`, `babel-preset/index.test.ts`, `cli/build.ts`, `vite/plugins/fileSystemRouterPlugin.tsx`, `vxrn/package.json`). Zero functional diff on our changes vs the previous PR head — only upstream commits absorbed (notably `64bb75b64 fix(cli/build): scope process error handlers to build()`, `5f31828e7 fix(one): scope root-level css injection to cssCodeSplit:false output`, and `e1f0cd5c1 fix(router): avoid route watcher rebuild churn`). All local gates re-validated end-to-end on Windows: security audit + manypkg + depcheck + lint + format + typecheck (36/36 packages) + `test:one` (469/469 — 1 pre-existing upstream-only failure in `withOne.test.ts` resolved by rebuilding stale `vite-plugin-metro/dist/`) + `test-deploy-flash` (6/6) + `test-env` (7/7) + `vxrn` unit (33/33). New HEAD: `8af655584`.
>
> **2026-05-13 refresh.** Soft-reset onto `v1.17.0` after 20 upstream commits made the branch `CONFLICTING`. One fix relocated to follow upstream's `getViteMetroPluginOptions` → `babel-preset/index.ts` consolidation (commits `cacebded1` + `a452cf4b4` + `3462dd7e7`). Same Windows bug class, new home: lines `141` + `176-177` of `babel-preset/index.ts`. New `toPosixRelativePath` helper avoids pulling Vite as a runtime dep of the standalone preset (which must work in `expo export` / `eas update` contexts where Vite isn't installed). A new `emits forward-slash-only paths` test in `babel-preset/index.test.ts` locks the contract. Same end-to-end behavior on Windows as the original PR (`/time` and `/dashboard` SSR routes populate `loaderData` correctly).
>
> Plus one scope-add: a structural refactor of `packages/test/src/setupTest.ts` (commit `55d9b198f`) so the `bun run test` pipeline runs end-to-end on Windows. Resolves binary entries via `createRequire('one/package.json')`+`dirname` (the `.bin/<pkg>` shim is `.cmd`/`.ps1`/`.exe` on Windows — Node can't load any of those via `node <path>`); platform-aware `findPidsOnPort` (netstat) + `killByPid` (taskkill `/F /T`); `windowsHide: true` on spawn options. 2 representative test-* packages validated on Windows after the fix: `test-deploy-flash` 6/6, `test-env` 7/7.

## Summary

Fix Windows-only path-separator drift across `one`'s build, server, dev, native-bundler, and metro-config code paths. Same defect class as merged #640 and commit `61302c5` (the cherry-pick of closed PR #695): native-separator producers feeding POSIX-expecting consumers (substring checks, regex anchors, JSON-stringified import specifiers, glob patterns).

## Seed bug — SSR loader path doubling on Windows

```bash
one build && one serve     # Windows 11, Bun 1.3.13, Node 25
curl http://localhost:3000/time
```

Server log:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  'C:\work\…\dist\server\dist\server\assets\time_ssr-COqAsxju.js'
imported from 'C:\work\…\node_modules\one\dist\esm\server\oneServe.mjs'
```

`build.ts` mints `serverJsPath` via `path.join` (native sep). It flows through the build manifest into `oneServe.ts`'s `.includes('${outDir}/server')` substring check (forward-slash literal) which misses on Windows, so the prefix is prepended a second time and the doubled path fails `await import()`.

The same value is also the input to a regex in `build.ts` (`replace(new RegExp('^${outDir}/'), '')`) and a literal-string replace in `vercel/build/generate/createSsrServerlessFunction.ts` — both also assume forward-slash.

## Producer-side fix

`build.ts` and `oneServe.ts` mint manifest/dynamic-import paths with `path.posix.join` so the value is forward-slash on every platform:

| Site | Mint |
|---|---|
| `build.ts` `builtMiddlewares` entry | `posix.join(outDir, 'middlewares', chunk.fileName)` |
| `build.ts` `serverJsPath` | `posix.join(outDir, 'server', serverFileName)` |
| `oneServe.ts` `apiFile` | `posix.join(outDir, 'api', fileName + ext)` |

The downstream regex in `build.ts` and `createSsrServerlessFunction.ts` start matching on Windows for free.

### Consumer-side helper

The other two `oneServe.ts` call sites that re-prepend the prefix collapsed into one helper:

```ts
// packages/one/src/utils/toServerOutputPath.ts
export function toServerOutputPath(input: string, outDir: string): string {
  const normalized = input.replace(/\\/g, '/')
  const prefix = `${outDir}/server/`
  if (normalized === `${outDir}/server` || normalized.startsWith(prefix)) {
    return normalized
  }
  return posix.join(outDir, 'server', normalized)
}
```

- `posix.join` (not Vite's `normalizePath`): backslashes are valid filename characters on POSIX, so `normalizePath` is a no-op there. We need conversion on every platform.
- `startsWith` (not `.includes`): avoids false-positive on `foo/dist/server/bar.js`.
- Backslash conversion: defensive boundary against legacy `path.join`-shaped callers.

7 unit tests cover idempotency, custom outDir, the false-positive guard, and the path-doubling regression. New `posixPathContract.test.ts` adds 19 cross-platform tests asserting forward-slash output of every fix's producer.

## Static-audit follow-ups (same defect class)

After the seed, audited every `path.*` / `await import()` / `JSON.stringify(path)` / chokidar / glob / `realpath` / `process.cwd()` site across `packages/{one,vxrn,vite-plugin-metro,compiler,resolve}`. Eleven more producer-side sites in the same class.

### High-impact

1. **`virtualEntryPlugin.ts` setupFile import** — `JSON.stringify(resolve(root, setupFile))` would emit `import "C:\\proj\\src\\setup.ts"`; switched to `pathToFileURL().href` for canonical `file://` URL. Mirrors the native sibling in `createNativeDevEngine.ts`. Vite-native repro previously blocked on Windows by an MSVC layout bug in `fast-flow-transform`'s vendored llvh `simple_ilist` (the Hermes-backed Flow stripper that `vxrn` invokes during native bundling); the upstream architectural fix [merged at `facebook/hermes#2012`](https://github.com/facebook/hermes/pull/2012) on 2026-05-11 ([`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3)) and ships immediately to Windows users via [`jbroma/fast-flow-transform#18`](https://github.com/jbroma/fast-flow-transform/pull/18) (build-time stop-gap that goes inert once fft's Hermes submodule pin moves past the merge commit). With those plus the createNativeDevEngine + dev.ts fixes in this PR, the Vite-native bundler returns a complete RN bundle on Windows for the first time.
2. **`fileSystemRouterPlugin.tsx` `optimizeDeps.entries`** — `path.join('./app', route.file)` for the entries array; tinyglobby/fast-glob need forward-slash patterns. Backslash patterns silently match nothing on Windows, disabling the cold-start refresh-prevention. Switched to `path.posix.join` and dropped the hardcoded `'./app'` for `routerRoot` (honors `router.root` / `ONE_ROUTER_ROOT` overrides).
3. **`createNativeDevEngine.ts` `resolvedId` + setupFile** — same pair as `virtualEntryPlugin.ts` for the native bundler: `normalizePath()` for the rolldown id; `pathToFileURL().href` for the setupFile import specifier.
4. **`vxrn/exports/dev.ts` chokidar listener** — chokidar emits native paths, `viteServer.transformRequest(id)` keys the module graph by POSIX URLs. Normalize both sides; collapses the dual `'/dist/' || '\\dist\\'` check. (Vite-native HMR codepath; Metro HMR uses its own pipeline and is not affected.)
5. **`getVitePath.ts` `react/jsx-dev-runtime` sentinel** — `realpath` returns native on Windows, sentinel `endsWith('/react/jsx-dev-runtime.js')` would never match. Function is currently exported but has no in-tree caller; fix is preventive for external consumers.
6. **`expoManifestRequestHandlerPlugin.ts` `projectRoot`** — wraps `server.config.root` in `path.resolve()` for native separators. Mirrors the same fix in `metroPlugin.ts` (commit `61302c5`); this sibling boundary was missed.

### High-impact (cont.)

7. **`vite/one.ts` SSR symlink-dedup** — compares `resolved.id` (POSIX, from `this.resolve`) against `realpathSync(nmPkgDir)` (native on Windows, from Node fs). The `startsWith` check misses on Windows, so the dedup never fires for pnpm-symlinked packages — silently allows duplicate React/RN copies in the SSR bundle. Fix: `normalizePath(realpathSync(nmPkgDir))` on the comparison side and `normalizePath(nmPkgDir)` on the rebuild side. Only active when `ssr.dedupeSymlinkedModules: true`, which is opt-in.

### Latent (no current functional break, fix is forward-compatibility)

8. **`buildPage.ts` `clientJsPath`** — minted via `join(clientDir, ...)` (native sep on Windows). Stored in `dist/buildInfo.json` as `dist\\client\\assets\\foo.js` on Windows. Currently only consumed by `readFile(clientJsPath, ...)` (accepts both separators), so no runtime break — but cross-platform manifest hygiene matches `serverJsPath`. Fix: `normalizePath(join(clientDir, ...))`.
9. **`getViteMetroPluginOptions.ts` `ONE_ROUTER_APP_ROOT_RELATIVE_TO_ENTRY` + `ONE_SETUP_FILE_NATIVE`** — `normalizePath(path.relative(...))` for both. Consumed by `require.context()` (former) and as a literal `import "..."` specifier (latter). Metro's `isRelativeImport` regex (`/^[.][.]?(?:[/]|$)/`) rejects `..\foo` on Windows for the latter; the former is absorbed by Metro's internal `path.join` so the fix there is hygiene to keep the babel-emitted AST byte-identical across hosts.
10. **`build.ts` `chunkFileNames` / `assetFileNames`** — `posix.join` for rolldown output names. Latent for flat chunks (`Path.dirname` returns `.`); diverges only when an API chunk is nested.
11. **`build.ts` `wranglerInputConfig.main`** — `normalizePath` wrap. `relative()` returns the bare filename `_worker-src.js` for the current source layout, so the normalize call is a no-op today; defensive against future structure changes.
12. **`compiler/transformSWC.ts` `ignoreId`** — regex used native `path.sep` while Vite hands the plugin transform a POSIX `id` on every platform, so the regex never matched on Windows and Vite-internal `.vite/deps/...` files were pushed through full SWC parse-and-transform instead of being skipped. Wasteful, not incorrect. Fix: POSIX-only regex + normalize `id` at the top of the function so both callers (Vite plugin = POSIX, `vxrn/utils/patches.ts` = native) agree on the format.

## Test-only fixes

- `sourceInspectorPlugin.ts` — wrap `path.join` output of `resolveEditorFilePath` in `normalizePath`, matching sibling `getSourceInspectorPath`. Production behavior unchanged.
- `packages/resolve/src/index.test.ts` — two assertions hardcoded `/`; replaced with `path.join` (`resolvePath` returns native paths).
- `packages/vxrn/src/utils/patches.test.ts` — `symlink(...,'dir')` requires Administrator on Windows. Switched to `'junction'`; `type` is ignored on POSIX per Node fs docs, so a single codepath works on every platform. 8/8 pass post-fix (was failing on Windows pre-fix).
- `packages/vxrn/src/plugins/serverExtensions.test.ts` — pre-existing bugs failing on every platform: stale `FSExtra.pathExists` mocks (source uses `node:fs.existsSync`), and two tests calling `config()` with zero args while source destructures `{ command }` from arg 2. Fixed via `vi.mock('node:fs', factory)` and a `SERVE_HOOK_OPTS` constant. 7/7 pass post-fix.

## Validation (Windows 11, Bun 1.3.13, Node 25; Linux Docker `oven/bun:1.3.13` for cross-platform parity)

| Gate | Windows | Linux Docker (oven/bun:1.3.13) |
|---|---|---|
| `bun audit --audit-level high --ignore GHSA-3ppc-4f35-3m26` | clean | clean |
| `bun run typecheck` (turbo, all 36 packages) | clean | clean |
| `bun run lint` (oxlint, 1401 files) | 0 warnings, 0 errors | identical |
| `bun run check` (manypkg + 4 depcheck) | clean | clean |
| `bun run build` (turbo, 22 packages) | 22 / 22 successful | identical |
| `bunx turbo run test --filter='./packages/*'` | 3/3 packages pass | identical |
| ↳ `packages/one` | **459 / 459 pass**, 56 skipped (pre-existing fork-test placeholders) | identical |
| ↳ `packages/resolve` | **9 / 9 pass** | identical |
| ↳ `packages/vxrn` (newly wired into CI by this PR) | **33 / 33 pass** (broken pre-fix on every platform — see *Test-only fixes* below) | identical |
| 2 representative `tests/test-*` packages (post `setupTest.ts` refactor) | **test-deploy-flash 6/6, test-env 7/7** | identical |

End-to-end (Windows host):

| Endpoint | Vanilla 1.16.2 | Patched |
|---|---|---|
| `/time` SSR loader | `loaderData = undefined`, `ERR_MODULE_NOT_FOUND` for `dist\server\dist\server\…` | `loaderData:{time:"…"}` in server context, no log errors |
| `/dashboard` page + layout loader | both `undefined` | both populated |
| SSG `/`, `/about`, SPA `/spa`, API `/api/healthcheck` | already worked | still work |

Web HMR (edited `app/index.tsx`, change appears in next request) and native HMR (Android 16 emulator, change visible on screen ~25s after edit, captured via `adb screencap`) both verified on Windows host with `native.bundler: 'metro'`.

## Test plan

- [x] SSR `+ssr` page + layout loaders return real data on Windows
- [x] SSG / SPA / API still work on Windows
- [x] Native Metro bundler builds + APK + native HMR on emulator
- [x] `lint` / `typecheck` / `vitest` clean on Windows AND Linux Docker
- [x] Producer-side fix flows correctly through manifest into oneServe consumers
- [ ] Vercel deploy from Windows — not exercised. The `^${outDir}/` regex in `build.ts` and the `${outDir}/` literal in `createSsrServerlessFunction.ts` will match correctly because the producer is now forward-slash, but the deploy was not run.
- [ ] Cloudflare deploy from Windows — not exercised. `relative()` returns the bare filename for the current source layout, so the `normalizePath` call is a no-op today.
- [x] Vite-native bundler (`native.bundler: 'vite'`) — was blocked on Windows by an MSVC EBO layout bug in `fast-flow-transform`'s vendored llvh `simple_ilist` that surfaced as a phantom "null SMLoc" panic + downstream `STATUS_ACCESS_VIOLATION`. Root-caused and fixed at [`facebook/hermes#2012`](https://github.com/facebook/hermes/pull/2012) (upstream `LLVM_DECLARE_EMPTY_BASES` macro applied to `simple_ilist` and `ilist_node_traits` — merged 2026-05-11 at [`facebook/hermes@768bab2a`](https://github.com/facebook/hermes/commit/768bab2a5d3a4e0a5eae2793c09b908cce813ee3)) and [`jbroma/fast-flow-transform#18`](https://github.com/jbroma/fast-flow-transform/pull/18) (build-time stop-gap, inert once the fft submodule pin moves past the merge commit). With the rebuilt fft napi binding plugged into `node_modules/`, `curl http://localhost:8081/index.bundle?platform=android&dev=true` returns a complete ~5 MB React Native bundle in ~1.2 s on Windows; previously the bundler segfaulted on the first request. The earlier symptom-level fft#17 (`cvt_smloc` graceful fallback) is no longer needed once #18 lands. The createNativeDevEngine + dev.ts fixes in this PR are correctly exercised by the now-working Vite-native pipeline.

## Wires `packages/vxrn` into CI

Before this PR, `packages/vxrn` had no `test` script — its 33 vitest cases never ran in CI, which is how the broken `serverExtensions.test.ts` mocks (failing on every platform) and the `patches.test.ts` Windows EPERM (failing only on Windows) sat broken without anyone noticing. Added `"test": "vitest run --dir src"` to `packages/vxrn/package.json`, mirroring `@vxrn/resolve`. Now turbo picks it up via `bun run test` and the 33 cases run on every CI run. Verified locally on Windows host and Linux Docker — both report 33/33.

## Known coverage gap (out of scope for this PR)

`.github/workflows/checks.yml` currently runs `ubuntu-latest` only. The three Windows path bugs that prompted this work (#640; #695 cherry-picked as commit `61302c5`; the seed bug here) have all been discovered post-merge by users hitting them on their machines. A `windows-latest` entry on the `tests` job — or a `packages/one`-scoped Windows job — would catch the next one before it ships. The 19 `posixPathContract.test.ts` tests in this PR are explicitly designed to run on Windows and would lock in cross-platform parity. Recommended follow-up; not included here so the PR stays focused on the framework fixes themselves.

## CI status

Post-v1.17.0 refresh, the `checks` job (Security Audit + manypkg + lint + typecheck) is **green** on both this PR and the sibling #703 — the previously-failing `basic-ftp` audit gate is gone (cleared by upstream `e4b3c95c2 fix: bump 4 high-severity transitive deps to clear bun audit failures`), and the workflow has switched to `--audit-level high` so the moderate hono/yaml advisories don't block.





