### PR TITLE
fix(serve): honor build.outDir from vite.config.ts

### DIFF
--- a/packages/one/src/cli/build.ts
+++ b/packages/one/src/cli/build.ts
@@ -1290,6 +1290,18 @@ export async function build(args: {
 
   await writeJSON(toAbsolute(`${outDir}/buildInfo.json`), buildInfoForWriting)
 
+  // Write a marker that lets `one serve` locate the build output without
+  // loading vite.config at runtime (see serve.ts for the side-effect story).
+  // Use node_modules/.cache so it's auto-gitignored and follows the standard
+  // tool-cache convention (vite, esbuild, swc all live under .cache). Best-
+  // effort: if node_modules isn't writable (read-only deploy environment, no
+  // node_modules at all), skip — the user can still pass --outDir explicitly.
+  try {
+    const buildPointerDir = toAbsolute('node_modules/.cache/one')
+    await ensureDir(buildPointerDir)
+    await writeJSON(join(buildPointerDir, 'build-pointer.json'), { outDir })
+  } catch {}
+
   // emit version.json for skew protection polling
   await FSExtra.writeFile(
     join(clientDir, 'version.json'),

--- a/packages/one/src/serve.ts
+++ b/packages/one/src/serve.ts
@@ -191,8 +191,52 @@ async function serveWithCluster(args: Parameters<typeof serve>[0], numWorkers: n
 }
 
 async function startWorker(args: Parameters<typeof serve>[0]) {
-  const outDir =
-    args?.outDir || (FSExtra.existsSync('buildInfo.json') ? '.' : null) || 'dist'
+  // Resolve outDir without loading the user's vite.config at serve time.
+  //
+  //   1. --outDir CLI flag (highest precedence)
+  //   2. cwd has buildInfo.json — preserves the "cd into output dir then run" UX
+  //   3. build-pointer marker written by `one build` — locates the build output
+  //      when the user has a non-default `build.outDir` set in vite.config
+  //   4. 'dist' fallback (matches the historical behaviour)
+  //
+  // Why not call `loadConfigFromFile` here directly: loading vite.config inside
+  // `one serve` instantiates the One plugin chain (including `vxrnVitePlugin`
+  // on the non-`IS_VXRN_CLI` branch), which has side effects — `configResolved`
+  // hooks, file watchers, server middleware — that leak into the subsequent
+  // `vxrn/serve` startup and break SPA client-side routing (confirmed via
+  // diagnostic PR #710: removing this call made `test-spa-shell-routing` go
+  // from 4-of-5 fails → 27/27 pass on the same CI infrastructure).
+  let outDir = args?.outDir
+  if (!outDir && FSExtra.existsSync('buildInfo.json')) {
+    outDir = '.'
+  }
+  if (!outDir) {
+    try {
+      const pointer = (await FSExtra.readJSON(
+        'node_modules/.cache/one/build-pointer.json'
+      )) as { outDir?: string }
+      // Verify the pointed-to dir actually has buildInfo.json. Guards against a
+      // stale marker (e.g. user changed `build.outDir` and deleted the old
+      // output dir without rebuilding). If the marker is stale, fall back to
+      // 'dist' so the existing "buildInfo.json not found" error message at
+      // least references the conventional location instead of a phantom dir
+      // the user no longer recognises.
+      if (
+        pointer?.outDir &&
+        (await FSExtra.pathExists(`${pointer.outDir}/buildInfo.json`))
+      ) {
+        outDir = pointer.outDir
+      } else if (pointer?.outDir) {
+        console.warn(
+          `[one serve] build-pointer.json points to '${pointer.outDir}/' but no buildInfo.json there — falling back to 'dist'. Run \`one build\` to refresh the marker.`
+        )
+      }
+    } catch {
+      // No pointer (build hasn't been run yet, or built with an older `one`
+      // that predates the pointer write) — fall through to 'dist'.
+    }
+  }
+  outDir = outDir || 'dist'
   const buildInfo = (await FSExtra.readJSON(`${outDir}/buildInfo.json`)) as One.BuildInfo
   const { oneOptions } = buildInfo
 


### PR DESCRIPTION
> [!NOTE]
> **2026-05-19 redesign — marker file instead of runtime `loadConfigFromFile`.** The earlier shape of this PR called Vite's `loadConfigFromFile` from inside `one serve` to read `build.outDir`. That instantiates the One plugin chain on every startup (including `vxrnVitePlugin` on the non-`IS_VXRN_CLI` branch with `configResolved` hooks + file watchers + server middleware), and the side effects leak into the subsequent `vxrn/serve` boot — `test-spa-shell-routing > navigate from home to /dashboard/test-app` failed 5 of 5 stable CI runs. Diagnostic PR [#710](https://github.com/onejs/one/pull/710) confirmed the call was the cause by removing it: same test went from 5/5 fails → 27/27 pass on the same CI infrastructure. Tried isolating `IS_VXRN_CLI` + the three `globalThis` slots mirroring `loadUserOneOptions` — didn't help, the side effects go deeper (esbuild bundling state + Vite plugin lifecycle). Redesigned: `one build` already calls `loadConfigFromFile` (it has to) and knows the resolved `outDir`. Persist that answer as a tiny `node_modules/.cache/one/build-pointer.json` marker, and `one serve` reads it without ever touching vite.config. Final HEAD: `cbc3d1a67`.
>
> **2026-05-19 follow-up — stale-marker guard.** Added a `pathExists(${pointer.outDir}/buildInfo.json)` check before trusting the marker. Guards against the case where a user changes `build.outDir` in vite.config and deletes the old output dir without rebuilding — without the guard, `one serve` would have ENOENT'd on the phantom dir referenced by the stale marker. With the guard, it falls back to `'dist'` and emits a single-line warning telling the user to run `one build` to refresh the marker. Caught during pressure-test of the marker design.

## Summary

Fixes #701. `one serve` now honors `build.outDir` from `vite.config.ts`, matching what `one build` already does at [`packages/one/src/cli/build.ts`](https://github.com/onejs/one/blob/main/packages/one/src/cli/build.ts).

## Problem

```ts
// vite.config.ts
export default defineConfig({
  build: { outDir: 'build-out' },
  plugins: [one()],
})
```

```bash
one build       # writes to ./build-out/ as expected
one serve       # ENOENT: open './dist/buildInfo.json'  ← bug
```

`serve.ts:startWorker` resolved `outDir` from CLI args + a cwd-`buildInfo.json` check only:

```ts
const outDir = args?.outDir || (FSExtra.existsSync('buildInfo.json') ? '.' : null) || 'dist'
```

The vite config's `build.outDir` was never consulted, so projects with a non-default outDir had to pass `--outDir <dir>` explicitly to every `one serve` invocation.

## Fix

### `one build` writes a build-pointer marker

After `writeJSON(toAbsolute(\`${outDir}/buildInfo.json\`), buildInfoForWriting)` in `cli/build.ts`:

```ts
try {
  const buildPointerDir = toAbsolute('node_modules/.cache/one')
  await ensureDir(buildPointerDir)
  await writeJSON(join(buildPointerDir, 'build-pointer.json'), { outDir })
} catch {}
```

`node_modules/.cache/<tool>/` is the standard tool-cache location (vite, esbuild, swc all live there), is auto-gitignored, and survives across `serve` runs without modifying the project root. The write is wrapped in `try/catch` so read-only deploy environments that ship only the output directory still build cleanly.

### `one serve` reads the marker

Layered resolution in `serve.ts:startWorker`:

```ts
let outDir = args?.outDir
if (!outDir && FSExtra.existsSync('buildInfo.json')) {
  outDir = '.'
}
if (!outDir) {
  try {
    const pointer = (await FSExtra.readJSON(
      'node_modules/.cache/one/build-pointer.json'
    )) as { outDir?: string }
    // Verify the pointed-to dir actually has buildInfo.json. Guards against a
    // stale marker (e.g. user changed `build.outDir` and deleted the old
    // output dir without rebuilding).
    if (
      pointer?.outDir &&
      (await FSExtra.pathExists(`${pointer.outDir}/buildInfo.json`))
    ) {
      outDir = pointer.outDir
    } else if (pointer?.outDir) {
      console.warn(
        `[one serve] build-pointer.json points to '${pointer.outDir}/' but no buildInfo.json there — falling back to 'dist'. Run \`one build\` to refresh the marker.`
      )
    }
  } catch {
    // No pointer (build hasn't been run yet, or built with an older `one`
    // that predates the pointer write) — fall through to 'dist'.
  }
}
outDir = outDir || 'dist'
```

Precedence:

1. `--outDir` CLI flag (highest precedence — unchanged)
2. cwd has `buildInfo.json` — preserves the "cd into output dir then run" UX (unchanged)
3. `node_modules/.cache/one/build-pointer.json` (new)
4. `'dist'` fallback (unchanged)

### Why a marker file instead of loading vite.config at serve time

The first shape of this PR called Vite's `loadConfigFromFile` directly from `serve.ts`. That instantiates the One plugin chain, and `one()` has two branches keyed off `process.env.IS_VXRN_CLI`:

- The CLI branch (which `one build` enters by setting that env var) just stashes user options into globals and returns an empty plugin list — no side effects.
- The non-CLI branch pushes `vxrnVitePlugin` and runs the full Vite-native dev path with `configResolved` hooks, file watchers, and server middleware.

`one serve` doesn't set `IS_VXRN_CLI`, so the auxiliary `loadConfigFromFile` was instantiating the full Vite-native plugin chain on every startup. Even with an `IS_VXRN_CLI` + `globalThis` save/restore (mirroring what `loadUserOneOptions` already does), side effects from esbuild bundling and Vite's plugin lifecycle leaked into the subsequent `vxrn/serve` boot — `test-spa-shell-routing > navigate from home to /dashboard/test-app` failed 5 of 5 stable CI runs (timeout waiting for the SPA-routed `#dashboard-app-page` selector).

Diagnostic PR #710 confirmed: removing the call made the same test pass 27/27 on the same CI infrastructure. The marker-file approach avoids the problem at its root — the build already calls `loadConfigFromFile` (it has to), so persist the answer.

## Test plan

Validated on Windows 11 / Bun 1.3.13 / Node 25 against `onejs/one@v1.17.6`:

- [x] `bun audit --audit-level high --ignore GHSA-3ppc-4f35-3m26`: clean
- [x] `bun run lint` (oxlint, 1403 files): 0 warnings / 0 errors
- [x] `bun run format:check`: 1525 files clean
- [x] `bun run typecheck` (turbo, 36 packages): clean
- [x] `bun run test:one` (vitest): 441 pass / 1 fail / 56 skipped — the 1 fail is `sourceInspectorPlugin.test.ts`, the pre-existing Windows-only upstream failure that PR #702 fixes; not in this PR's scope
- [x] End-to-end against the [`curex/one`](https://github.com/onejs/one) downstream consumer with `vite.config.ts` setting `build: { outDir: 'build-out' }`: `one build` writes both `./build-out/buildInfo.json` AND `./node_modules/.cache/one/build-pointer.json`; subsequent `one serve` (no `--outDir`) reads the pointer, loads `./build-out/buildInfo.json`, serves correctly
- [x] `--outDir build-out` flag still wins (highest precedence)
- [x] `cd build-out && one serve` UX preserved (cwd-`buildInfo.json` branch)
- [x] Default project with no custom outDir: pointer says `{outDir: "dist"}` → resolves to `'dist'` → matches historical behavior

## Notes

- Found while validating the Windows path-fix PR (#702). Not Windows-specific; pure CLI ergonomics across all platforms.
- The marker is `{outDir: <resolved-outDir>}` — a single field, room to extend later if other build state needs to surface to `serve` (e.g., `bundler`, `mode`).
- See the diag-PR (#710) for the experimental evidence that prompted this redesign.
