### PR TITLE
DIAG (do not merge): bypass loadViteBuildOutDir to isolate #703 CI failure

### DIFF
--- a/packages/one/src/serve.ts
+++ b/packages/one/src/serve.ts
@@ -203,17 +203,9 @@ async function startWorker(args: Parameters<typeof serve>[0]) {
   if (!outDir && FSExtra.existsSync('buildInfo.json')) {
     outDir = '.'
   }
-  if (!outDir) {
-    // Read `build.outDir` from vite.config. Lives in `./vite/loadConfig` so the
-    // `vite` import is in a file the build tool compiles cleanly (the same
-    // bare-package rewrite affects this file but not loadConfig).
-    try {
-      const { loadViteBuildOutDir } = await import('./vite/loadConfig')
-      outDir = await loadViteBuildOutDir()
-    } catch {
-      // No vite.config (or it failed to load); fall through to default.
-    }
-  }
+  // DIAG #703-A: bypass loadViteBuildOutDir entirely to isolate whether this
+  // call (even with IS_VXRN_CLI + globalThis isolation) is what's breaking the
+  // spa-shell-routing CI test.
   outDir = outDir || 'dist'
   const buildInfo = (await FSExtra.readJSON(`${outDir}/buildInfo.json`)) as One.BuildInfo
   const { oneOptions } = buildInfo

--- a/packages/one/src/serve.ts
+++ b/packages/one/src/serve.ts
@@ -191,8 +191,30 @@ async function serveWithCluster(args: Parameters<typeof serve>[0], numWorkers: n
 }
 
 async function startWorker(args: Parameters<typeof serve>[0]) {
-  const outDir =
-    args?.outDir || (FSExtra.existsSync('buildInfo.json') ? '.' : null) || 'dist'
+  // Resolve outDir with the same precedence chain the `build` command uses
+  // (matching cli/build.ts:370 — `viteLoadedConfig?.config?.build?.outDir ?? 'dist'`):
+  //   1. --outDir CLI flag
+  //   2. cwd has buildInfo.json — preserves the "cd into output dir then run" UX
+  //   3. vite.config's build.outDir
+  //   4. 'dist' fallback
+  // Step (3) only runs when (1)-(2) miss; loading vite.config is non-trivial
+  // and not worth it for the common case where the cwd already has buildInfo.json.
+  let outDir = args?.outDir
+  if (!outDir && FSExtra.existsSync('buildInfo.json')) {
+    outDir = '.'
+  }
+  if (!outDir) {
+    // Read `build.outDir` from vite.config. Lives in `./vite/loadConfig` so the
+    // `vite` import is in a file the build tool compiles cleanly (the same
+    // bare-package rewrite affects this file but not loadConfig).
+    try {
+      const { loadViteBuildOutDir } = await import('./vite/loadConfig')
+      outDir = await loadViteBuildOutDir()
+    } catch {
+      // No vite.config (or it failed to load); fall through to default.
+    }
+  }
+  outDir = outDir || 'dist'
   const buildInfo = (await FSExtra.readJSON(`${outDir}/buildInfo.json`)) as One.BuildInfo
   const { oneOptions } = buildInfo
 

--- a/packages/one/src/vite/__fixtures__/with-outdir/vite.config.ts
+++ b/packages/one/src/vite/__fixtures__/with-outdir/vite.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from 'vite'
+export default defineConfig({ build: { outDir: 'build-out' } })

--- a/packages/one/src/vite/__fixtures__/without-outdir/vite.config.ts
+++ b/packages/one/src/vite/__fixtures__/without-outdir/vite.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from 'vite'
+export default defineConfig({})

--- a/packages/one/src/vite/loadConfig.test.ts
+++ b/packages/one/src/vite/loadConfig.test.ts
@@ -1,0 +1,37 @@
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { loadViteBuildOutDir } from './loadConfig'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixture = (name: string) => join(here, '__fixtures__', name)
+
+describe('loadViteBuildOutDir', () => {
+  it("returns vite.config's build.outDir when set", async () => {
+    expect(await loadViteBuildOutDir(fixture('with-outdir'))).toBe('build-out')
+  })
+
+  it('returns undefined when build.outDir is not set', async () => {
+    expect(await loadViteBuildOutDir(fixture('without-outdir'))).toBeUndefined()
+  })
+
+  // Regression guard for the side-effect bug that broke spa-shell-routing
+  // on CI: `loadConfigFromFile` runs the plugin chain, and `one()` has two
+  // branches keyed off `IS_VXRN_CLI`. Without the env-var + globalThis save/
+  // restore, the helper used to leak `__oneOptions` / `__vxrnPluginConfig__`
+  // into the next `vxrn/serve` startup. Verify the helper is a no-op on the
+  // ambient state.
+  it('restores process.env.IS_VXRN_CLI + __oneOptions globals after the call', async () => {
+    const previousEnv = process.env.IS_VXRN_CLI
+    const previousOneOptions = globalThis['__oneOptions']
+    const previousVxrnPluginConfig = globalThis['__vxrnPluginConfig__']
+    const previousVxrnMetroOptions = globalThis['__vxrnMetroOptions__']
+
+    await loadViteBuildOutDir(fixture('with-outdir'))
+
+    expect(process.env.IS_VXRN_CLI).toBe(previousEnv)
+    expect(globalThis['__oneOptions']).toBe(previousOneOptions)
+    expect(globalThis['__vxrnPluginConfig__']).toBe(previousVxrnPluginConfig)
+    expect(globalThis['__vxrnMetroOptions__']).toBe(previousVxrnMetroOptions)
+  })
+})

--- a/packages/one/src/vite/loadConfig.ts
+++ b/packages/one/src/vite/loadConfig.ts
@@ -2,6 +2,59 @@ import { loadConfigFromFile } from 'vite'
 import '../polyfills-server'
 import type { One } from './types'
 
+/// Read `build.outDir` from the user's `vite.config.ts` without instantiating
+/// the full One plugin chain. Used by `serve.ts` to resolve where
+/// `buildInfo.json` lives when `--outDir` and the cwd-`buildInfo.json` UX both
+/// miss. Returns `undefined` when there's no vite.config or `build.outDir`
+/// isn't set.
+///
+/// Why the `IS_VXRN_CLI` + `globalThis` isolation: `one()` (the plugin) has
+/// two branches keyed off `process.env.IS_VXRN_CLI`. In the CLI branch (which
+/// `one build` enters by setting that env var) the plugin just stashes user
+/// options into globals and returns an empty plugin list. In the non-CLI
+/// branch it pushes `vxrnVitePlugin` and runs the full Vite-native dev path —
+/// `configResolved` hooks, file watchers, server middleware. `one serve` does
+/// NOT set `IS_VXRN_CLI`, so a naïve `loadConfigFromFile` call inside `serve`
+/// would instantiate the full plugin chain, leak watchers / globals, and break
+/// the subsequent `vxrn/serve` startup (manifests as flaking SPA navigation
+/// tests in CI). Mirror the isolation `loadUserOneOptions` already uses: set
+/// the env var + clear stale globals before the call, restore in `finally`.
+///
+/// The optional `configRoot` lets tests target a fixture directory without
+/// having to `chdir` the whole vitest worker. Defaults to `process.cwd()`,
+/// matching the production call site in `serve.ts`.
+export async function loadViteBuildOutDir(
+  configRoot?: string
+): Promise<string | undefined> {
+  const previousIsVxrnCli = process.env.IS_VXRN_CLI
+  const previousOneOptions = globalThis['__oneOptions']
+  const previousVxrnPluginConfig = globalThis['__vxrnPluginConfig__']
+  const previousVxrnMetroOptions = globalThis['__vxrnMetroOptions__']
+
+  try {
+    process.env.IS_VXRN_CLI = 'true'
+    delete globalThis['__oneOptions']
+    delete globalThis['__vxrnPluginConfig__']
+    delete globalThis['__vxrnMetroOptions__']
+
+    const loaded = await loadConfigFromFile(
+      { command: 'serve', mode: 'production' },
+      undefined,
+      configRoot
+    )
+    return loaded?.config?.build?.outDir as string | undefined
+  } finally {
+    if (previousIsVxrnCli === undefined) {
+      delete process.env.IS_VXRN_CLI
+    } else {
+      process.env.IS_VXRN_CLI = previousIsVxrnCli
+    }
+    globalThis['__oneOptions'] = previousOneOptions
+    globalThis['__vxrnPluginConfig__'] = previousVxrnPluginConfig
+    globalThis['__vxrnMetroOptions__'] = previousVxrnMetroOptions
+  }
+}
+
 // globalThis, otherwise we get issues with duplicates due to however vite calls loadConfigFromFile
 
 export function setOneOptions(next: One.PluginOptions) {

--- a/packages/one/types/vite/__fixtures__/with-outdir/vite.config.d.ts
+++ b/packages/one/types/vite/__fixtures__/with-outdir/vite.config.d.ts
@@ -1,0 +1,3 @@
+declare const _default: import("vite").UserConfig;
+export default _default;
+//# sourceMappingURL=vite.config.d.ts.map

--- a/packages/one/types/vite/__fixtures__/without-outdir/vite.config.d.ts
+++ b/packages/one/types/vite/__fixtures__/without-outdir/vite.config.d.ts
@@ -1,0 +1,3 @@
+declare const _default: import("vite").UserConfig;
+export default _default;
+//# sourceMappingURL=vite.config.d.ts.map

--- a/packages/one/types/vite/loadConfig.d.ts
+++ b/packages/one/types/vite/loadConfig.d.ts
@@ -1,5 +1,6 @@
 import '../polyfills-server';
 import type { One } from './types';
+export declare function loadViteBuildOutDir(configRoot?: string): Promise<string | undefined>;
 export declare function setOneOptions(next: One.PluginOptions): void;
 export declare function loadUserOneOptions(command: 'serve' | 'build', silent?: boolean): Promise<{
     config: {

--- a/packages/one/types/vite/loadConfig.test.d.ts
+++ b/packages/one/types/vite/loadConfig.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=loadConfig.test.d.ts.map


### PR DESCRIPTION
> [!WARNING]
> **Diagnostic-only draft PR — do not merge.** Will close as soon as CI tells me what I need.

Companion to #703. The serve outDir fix in #703 has been failing the `spa-shell-routing` test in 4 of 5 stable CI runs (audited the history during today's v1.17.6 refresh). My first guess was that `loadConfigFromFile` was leaking plugin globals into the subsequent `vxrn/serve` startup; I shipped an isolation fix (save/clear/restore `IS_VXRN_CLI` + 3 `globalThis` slots) and it didn't change the result. This draft removes the `loadViteBuildOutDir` call entirely (`outDir` falls straight through to `'dist'` when `--outDir` is missing and `buildInfo.json` is absent) to isolate whether the call itself is the cause.

If this draft's `tests` job is green, then the call is the cause and the fix has to take a different shape (e.g., reading vite.config as text, doing the resolution in a child process, or scoping the feature behind opt-in). If it still fails, the cause is elsewhere — investigating from a wrong premise on #703.

Will close this PR + the diag branch once we have the signal.