### PR TITLE
fix(one): keep layout loaderData in spa-shell + add react-test-renderer dep

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -405,6 +405,7 @@
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
         "react-native-worklets": "~0.7.4",
+        "react-test-renderer": "^19.2.0",
         "rolldown": "^1.0.1",
         "sharp": "^0.34.5",
         "typescript": "^5.7.3",

--- a/packages/one/package.json
+++ b/packages/one/package.json
@@ -280,6 +280,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
+    "react-test-renderer": "^19.2.0",
     "rolldown": "^1.0.1",
     "sharp": "^0.34.5",
     "typescript": "^5.7.3",

--- a/packages/one/src/server/ServerContextScript.tsx
+++ b/packages/one/src/server/ServerContextScript.tsx
@@ -25,18 +25,19 @@ export function ServerContextScript() {
     // strip cssContents - read from DOM instead (CSSPrehydrateScript)
     const { cssContents, ...restContext } = context || {}
 
-    // strip page loaderData from matches to avoid double-serialization.
-    // we always strip the leaf (its data lives in restContext.loaderData and
-    // gets restored client-side onto matches[last]). reference equality on
-    // restContext.loaderData was too aggressive — if a layout's loaderData
-    // happened to ref-equal the page's (e.g. both `null`), the layout would
-    // permanently lose its data after hydration.
+    // strip leaf loaderData from matches to avoid double-serialization when
+    // the same data is already in restContext.loaderData (restored client-side
+    // onto matches[last]). only strip when restContext.loaderData exists —
+    // in spa-shell mode the page is not server-rendered so loaderData is
+    // undefined and the leaf in matches is actually a layout whose data
+    // exists nowhere else.
+    const hasLeafLoaderData = restContext.loaderData !== undefined
     const lastMatchIndex = (restContext.matches?.length ?? 0) - 1
     const compactMatches = restContext.matches?.map((m: any, i: number) => ({
       routeId: m.routeId,
       pathname: m.pathname,
       params: m.params,
-      ...(i === lastMatchIndex ? {} : { loaderData: m.loaderData }),
+      ...(hasLeafLoaderData && i === lastMatchIndex ? {} : { loaderData: m.loaderData }),
     }))
 
     const clientContext = {


### PR DESCRIPTION
## Summary

Fixes both failures of `Checks and Tests` on the canary 1.17.10 release commit.

### 1. `checks` job — depcheck failure

`packages/one/src/router/web/__tests__/WebStackView.runtime.test.tsx` (added in 41ed7ff6b) imports `react-test-renderer` but it was not declared in `packages/one`'s devDependencies. Added `react-test-renderer@^19.2.0`.

### 2. `tests` job — `layout-render-modes` spa-shell regression

Commit 4daaa609e switched `ServerContextScript`'s leaf-stripping from reference-equality (vs `restContext.loaderData`) to index-based (`i === lastMatchIndex`), to keep two layouts with primitive-equal loaderData from both losing their data.

The new logic breaks **spa-shell** mode: SPA pages are not server-rendered, so `restContext.loaderData` is `undefined` and the last item in `restContext.matches` is the last *layout* — its data exists nowhere else. The new code stripped that layout's `loaderData`, leaving `useMatch(layoutRouteId)` undefined after hydration.

Fix: only strip the leaf's `loaderData` when `restContext.loaderData !== undefined` — i.e., only when there's actually a leaf page loader value to be restored client-side onto `matches[last]`. This preserves the original fix's intent (no false-positive primitive-equal stripping) while not stripping layouts in spa-shell.

Failing tests that now pass:
- `SSR Shell + SPA Content > client navigation preserves ssr shell loader data`
- `Deeply Nested Layouts (SSG → SSR → SPA) > spa leaf inside ssr section hydrates with full match chain`

## Test plan
- [x] `cd packages/one && bun run check` — depcheck clean
- [x] `cd tests/test-layout-render-modes && bun run test:dev` — 47/47 pass
- [x] `cd tests/test-layout-render-modes && bun run test:prod` — 47/47 pass
- [x] `cd packages/one && bun run test` — 516/516 pass
- [ ] CI green on this branch