### PR TITLE
fix(one): run +not-found middleware for static-looking probes

### DIFF
--- a/packages/one/src/createHandleRequest.ts
+++ b/packages/one/src/createHandleRequest.ts
@@ -489,18 +489,27 @@ export function createHandleRequest(
             continue
           }
 
-          // static asset requests belong to vite/static middleware. skip
-          // dynamic routes and +not-found handlers so missing sourcemaps,
-          // favicons, fonts, etc. do not render an app document.
+          // static asset requests (sourcemaps, favicons, fonts, …) should not
+          // SSR the user's +not-found page or hijack a dynamic route. for
+          // +not-found we still run middleware so it can intercept, then
+          // short-circuit to a bare 404 instead of rendering the page tree.
           const isDynamicRoute = Object.keys(route.routeKeys).length > 0
           const isNotFoundRoute = route.page.endsWith('/+not-found')
           if (looksLikeStaticFile && isNotFoundRoute) {
             if (debugRouter) {
               console.info(
-                `[one] ⚡ ${pathname} → skipping not-found route for static asset`
+                `[one] ⚡ ${pathname} → bare 404 for static probe on ${route.page}`
               )
             }
-            return null
+            if (!route.middlewares?.length) {
+              return null
+            }
+            return await runMiddlewares(handlers, request, route, async () => {
+              return new Response(null, {
+                status: 404,
+                headers: { 'Content-Type': 'text/plain' },
+              })
+            })
           }
           if (looksLikeStaticFile && isDynamicRoute) {
             if (debugRouter) {


### PR DESCRIPTION
## Summary
- CI failure on main (`tests/middleware.test.ts > Middleware > middleware runs even on not found routes`) was caused by the previous +not-found static-probe shortcut bailing to `null` before middleware ran.
- Now the shortcut still bypasses the page render, but routes through `runMiddlewares` first when the matched +not-found has middleware — middleware can intercept (e.g. JSON 404), otherwise we return a bare 404 instead of SSR'ing the not-found page.
- Routes with no middleware still get the cheap `return null` path so the unit test for sourcemap probes is unaffected.

## Test plan
- [x] `packages/one` vitest passes (20/20 in createHandleRequest, 518/574 overall)
- [ ] CI: full `tests/test` dev + prod suites green (the integration middleware test was the failure)