### PR TITLE
fix(vxrn): inject TAMAGUI_TARGET into native rolldown bundle defines

### DIFF
--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { getNativeTransformConfig } from './createNativeDevEngine'
+
+// use a root with no .env files so only the platform defines are present
+const root = '/tmp/vxrn-native-env-define-test-nonexistent'
+
+describe('getNativeTransformConfig platform env defines', () => {
+  for (const platform of ['ios', 'android'] as const) {
+    for (const dev of [true, false]) {
+      it(`injects TAMAGUI_TARGET=native for ${platform} (dev=${dev})`, () => {
+        const { define } = getNativeTransformConfig(platform, dev, root)
+
+        // regression: TAMAGUI_TARGET was missing from the rolldown native defines,
+        // so import.meta.env.TAMAGUI_TARGET resolved to '' in prod (metro had it, rolldown didn't)
+        expect(define['import.meta.env.TAMAGUI_TARGET']).toBe('"native"')
+        expect(define['process.env.TAMAGUI_TARGET']).toBe('"native"')
+        expect(define['import.meta.env.TAMAGUI_ENVIRONMENT']).toBe(JSON.stringify(platform))
+
+        // sibling platform vars that already worked — guard against accidental removal
+        expect(define['import.meta.env.VITE_ENVIRONMENT']).toBe(JSON.stringify(platform))
+        expect(define['import.meta.env.VITE_NATIVE']).toBe('"1"')
+        expect(define['import.meta.env.EXPO_OS']).toBe(JSON.stringify(platform))
+
+        // the whole import.meta.env object (used by JSON.stringify(import.meta.env)) must carry it too
+        const envObject = JSON.parse(define['import.meta.env'] as string)
+        expect(envObject.TAMAGUI_TARGET).toBe('native')
+        expect(envObject.TAMAGUI_ENVIRONMENT).toBe(platform)
+      })
+    }
+  }
+})

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -54,7 +54,7 @@ function getNativeResolveConfig(platform: 'ios' | 'android') {
 }
 
 // shared rolldown transform config for native builds
-function getNativeTransformConfig(
+export function getNativeTransformConfig(
   platform: 'ios' | 'android',
   dev: boolean,
   root: string
@@ -124,6 +124,8 @@ function getNativeTransformConfig(
     VITE_ENVIRONMENT: platform,
     VITE_NATIVE: '1',
     EXPO_OS: platform,
+    TAMAGUI_TARGET: 'native',
+    TAMAGUI_ENVIRONMENT: platform,
   }
   // add VITE_* from .env files
   for (const [key, val] of Object.entries(envDefines)) {
@@ -149,6 +151,7 @@ function getNativeTransformConfig(
       'process.env.VITE_ENVIRONMENT': JSON.stringify(platform),
       'process.env.VITE_NATIVE': '"1"',
       'process.env.EXPO_OS': JSON.stringify(platform),
+      'process.env.TAMAGUI_TARGET': '"native"',
       'process.env.TAMAGUI_ENVIRONMENT': JSON.stringify(platform),
       __DEV__: dev ? 'true' : 'false',
       // import.meta.env as a whole object (for JSON.stringify(import.meta.env) etc.)
@@ -161,6 +164,8 @@ function getNativeTransformConfig(
       'import.meta.env.VITE_ENVIRONMENT': JSON.stringify(platform),
       'import.meta.env.VITE_NATIVE': '"1"',
       'import.meta.env.EXPO_OS': JSON.stringify(platform),
+      'import.meta.env.TAMAGUI_TARGET': '"native"',
+      'import.meta.env.TAMAGUI_ENVIRONMENT': JSON.stringify(platform),
       ...envDefines,
       ...setupFileDefines,
     },


### PR DESCRIPTION
## Problem

`Native iOS Tests (prod, rolldown)` fails on main:

```
FAIL tests/vite-features/import-meta-env.test.ios.ts > import.meta.env
AssertionError: expected '' to be 'native'
  ❯ import-meta-env.test.ios.ts:51  expect(tamaguiTarget).toBe('native')
```

The test page reads `import.meta.env.TAMAGUI_TARGET` directly. In the **rolldown** native build that identifier was never defined, so it resolved to `''`. The **metro** variants passed because metro's `getPlatformEnvDefine` (`vite-plugin-metro/src/env/platformEnv.ts`) injects the full `PlatformEnv` set — including `TAMAGUI_TARGET: 'native'`.

The shared rolldown native define-builder (`getNativeTransformConfig` in `vxrn/src/utils/createNativeDevEngine.ts`, used by both the dev engine and prod `buildNativeBundle`) injected `VITE_ENVIRONMENT`/`VITE_NATIVE`/`EXPO_OS` and `process.env.TAMAGUI_ENVIRONMENT`, but omitted `TAMAGUI_TARGET` entirely (both `process.env.*` and `import.meta.env.*`, and from the whole-object `import.meta.env` define).

## Fix

Add to the native define-builder, matching metro parity (native → `TAMAGUI_TARGET: 'native'`, `TAMAGUI_ENVIRONMENT: platform`):
- `envObject`: `TAMAGUI_TARGET`, `TAMAGUI_ENVIRONMENT`
- `process.env.TAMAGUI_TARGET`
- `import.meta.env.TAMAGUI_TARGET`, `import.meta.env.TAMAGUI_ENVIRONMENT`

## Verification

- New regression test `createNativeDevEngine.test.ts` (ios/android × dev/prod) asserting the defines — **passes**, and fails without the change (keys absent).
- Full vxrn suite: 37/37 pass · typecheck exit 0 · oxlint 0/0.
- Real iOS E2E validates on this PR's CI run.