### PR TITLE
fix(vxrn): wrap dev native bundle in function scope to stop global var leaks

### DIFF
--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { getNativeTransformConfig } from './createNativeDevEngine'
+import {
+  getNativeTransformConfig,
+  wrapNativeBundleModuleScope,
+} from './createNativeDevEngine'
 
 // use a root with no .env files so only the platform defines are present
 const root = '/tmp/vxrn-native-env-define-test-nonexistent'
@@ -28,4 +31,36 @@ describe('getNativeTransformConfig platform env defines', () => {
       })
     }
   }
+})
+
+describe('wrapNativeBundleModuleScope', () => {
+  // matches the marker rolldown dev() emits at the start of the runtime region
+  const RUNTIME_MARKER = '//#region \\0rolldown/runtime.js'
+
+  it('wraps module code after the prelude so top-level vars do not leak to global', () => {
+    const prelude = 'globalThis.global = globalThis;\nglobalThis.__DEV__ = true;\n'
+    // a top-level `var Headers` in a script becomes a non-configurable global,
+    // which is the exact leak that breaks RN's polyfillGlobal in dev
+    const body = `${RUNTIME_MARKER}\nvar fetch_hot, fetch$1, Headers, Request, Response$1;\nglobalThis.__rolldown_runtime__ = {};\n`
+    const sourcemap = '\n//# sourceMappingURL=x.js.map'
+
+    const out = wrapNativeBundleModuleScope(prelude + body + sourcemap)
+
+    const openIdx = out.indexOf(';(function() {')
+    expect(openIdx).toBeGreaterThan(-1)
+    // prelude (global setup) stays at script scope, before the wrap opens
+    expect(out.indexOf('globalThis.__DEV__')).toBeLessThan(openIdx)
+    // the leaking declaration is now inside the function scope
+    expect(out.indexOf('var fetch_hot')).toBeGreaterThan(openIdx)
+    // the wrap closes before the sourceMappingURL, which must remain the last line
+    expect(out.indexOf('})();')).toBeLessThan(out.indexOf('//# sourceMappingURL'))
+    expect(out.trimEnd().endsWith('//# sourceMappingURL=x.js.map')).toBe(true)
+    // and the result must still be syntactically valid (balanced wrap)
+    expect(() => new Function(out)).not.toThrow()
+  })
+
+  it('is a no-op when the runtime marker is absent (e.g. prod bundle)', () => {
+    const input = 'var x = 1;\nconsole.log(x);\n'
+    expect(wrapNativeBundleModuleScope(input)).toBe(input)
+  })
 })

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -262,6 +262,48 @@ function postProcessNativeBundle(code: string): string {
 }
 
 /**
+ * Wrap the dev bundle body in a function scope so module top-level
+ * `var`/`function` declarations don't leak onto the global object.
+ *
+ * rolldown's dev() emits the bundle as a *script*. A top-level `var` in a
+ * script creates a NON-configurable property on the global object. RN's
+ * `Libraries/Network/fetch.js` declares `var ... Headers, Request, ...`, so
+ * `global.Headers`/`global.Request` become non-configurable. RN's `setUpXHR`
+ * then calls `polyfillGlobal('Headers', ...)`, whose `polyfillObjectProperty`
+ * does `Object.defineProperty(global, 'Headers', { configurable: true, ... })`
+ * — which throws "Cannot redefine property" and RN converts to
+ * `console.error('Failed to set polyfill. Headers is not configurable.')`.
+ * In dev that console.error becomes a blocking LogBox redbox, so the app never
+ * mounts (every appium navigation then times out). The prod build is immune:
+ * its modules are wrapped in closures (no global leak) and it has no LogBox.
+ *
+ * Wrapping everything after the prelude in an IIFE makes those module vars
+ * function-scoped, matching prod, so `polyfillGlobal` succeeds. The prelude
+ * stays at script scope because it intentionally installs globals
+ * (`globalThis.global`/`__DEV__`/`process`/...). Intentional globals survive:
+ * the runtime is assigned via `globalThis.__rolldown_runtime__ = ...`, and HMR
+ * updates run through a *direct* `eval` inside this scope, so they still see
+ * the closure's `__esmMin`/`__toCommonJS`/module bindings.
+ */
+export function wrapNativeBundleModuleScope(code: string): string {
+  // the prelude (intro) ends right before the rolldown runtime region
+  const marker = '//#region \\0rolldown/runtime.js'
+  const idx = code.indexOf(marker)
+  if (idx === -1) return code
+
+  const open = ';(function() {\n'
+  const close = '\n})();\n'
+
+  // keep the sourceMappingURL comment as the final line if present
+  const sm = code.match(/\n\/\/# sourceMappingURL=[^\n]*\s*$/)
+  if (sm) {
+    const smIdx = code.lastIndexOf(sm[0])
+    return code.slice(0, idx) + open + code.slice(idx, smIdx) + close + code.slice(smIdx)
+  }
+  return code.slice(0, idx) + open + code.slice(idx) + close
+}
+
+/**
  * Downlevel class fields in the rolldown runtime for Hermes compatibility.
  * The runtime (\0rolldown/runtime.js) is injected directly into the output,
  * bypassing hermesCompatSWCPlugin. We extract just that section (~5KB) and
@@ -435,6 +477,11 @@ try {
           /registerCallableModule\s*\(\s*["']AppRegistry["']/,
           (match) => hmrClientStub + ',' + match
         )
+
+        // wrap module code in a function scope so top-level `var`s (e.g. RN
+        // fetch.js's `Headers`/`Request`) don't leak as non-configurable
+        // globals and break RN's polyfillGlobal (dev-only redbox). see fn doc.
+        code = wrapNativeBundleModuleScope(code)
 
         currentBundle = {
           code,


### PR DESCRIPTION
## Problem

`Native iOS Tests (dev, rolldown)` times out (45-min job limit → run cancelled). Root-caused from the cancelled run's failure screenshots: the dev app is stuck on a LogBox redbox **`Failed to set polyfill. Headers is not configurable.`**, so `quick-navigate-pixel` never mounts and every appium navigation waits the full 120s before falling back → the suite blows the timeout.

### Mechanism (verified against the actual dev bundle)

rolldown's `dev()` emits the native bundle as a **script**. RN's `Libraries/Network/fetch.js` declares `var fetch_hot, fetch$1, Headers, Request, Response$1;` at top level — and a top-level `var` in a script creates a **non-configurable** property on the global object. So `global.Headers`/`global.Request` become non-configurable. RN's `setUpXHR` then runs `polyfillGlobal('Headers')` → `polyfillObjectProperty` does `Object.defineProperty(global, 'Headers', { configurable: true, … })`, which throws `Cannot redefine property` → RN turns that into `console.error('Failed to set polyfill. Headers is not configurable.')`. In **dev** that becomes a blocking redbox.

**prod is immune**: its modules are wrapped in closures (no global leak) and it has no LogBox — which is why `prod, rolldown` passes.

Proven in isolation:
```
script-scope  var Headers → descriptor { configurable: false }  → defineProperty throws (the bug)
wrapped (IIFE) var Headers → no global own prop                 → defineProperty succeeds
```

## Fix

Wrap everything **after the prelude** in an IIFE (`wrapNativeBundleModuleScope`, dev path only) so module top-level `var`s stay function-scoped, matching the prod build. The prelude stays at script scope (it deliberately installs `globalThis.global`/`__DEV__`/`process`/…). Intentional globals survive: the runtime is assigned via `globalThis.__rolldown_runtime__`, and HMR updates run through a **direct** `eval` inside the wrap, so they still see the closure's helpers/module bindings.

## Verification

- Rebuilt vxrn, re-fetched the real dev bundle: `;(function() {` is inserted right after the prelude, the leaking `var … Headers` decl is now **inside** the wrap, `})();` closes before the (preserved) sourceMappingURL, and `node --check` parses it.
- New regression test `wrapNativeBundleModuleScope` (wrap structure + no-op without marker + syntactic validity). vxrn suite 39/39, typecheck 0, oxlint 0/0.
- Real iOS E2E validated on a `workflow_dispatch` run of this branch (below).