### PR TITLE
fix(test): target the actual bound port when a dev/prod server rebinds

### DIFF
--- a/packages/test/src/setupTest.ts
+++ b/packages/test/src/setupTest.ts
@@ -142,6 +142,29 @@ function spawnServer(
   }
 }
 
+/**
+ * vxrn/vite rebind to a different port when the requested one is already taken
+ * (a check-then-bind race when many test packages start concurrently under turbo).
+ * Parse the actual bound port from the server's output so the readiness check —
+ * and ONE_SERVER_URL, which is built from the returned port — target the live
+ * server instead of the requested-but-vacated port.
+ */
+export function resolveBoundServerUrl(requestedUrl: string, output: string): string {
+  const requested = requestedUrl.replace(/\/+$/, '')
+  const requestedPort = requested.match(/:(\d+)(?:\/|$)/)?.[1]
+  // only deviate when the server actually reported the requested port was taken,
+  // so the common case (no move) is byte-for-byte unchanged
+  if (!requestedPort || !output.includes(`Port ${requestedPort} is in use`)) {
+    return requested
+  }
+  const seen = [...output.matchAll(/https?:\/\/localhost:(\d+)/g)].map((m) => m[1])
+  const boundPort = seen[seen.length - 1]
+  if (boundPort && boundPort !== requestedPort) {
+    return requested.replace(`:${requestedPort}`, `:${boundPort}`)
+  }
+  return requested
+}
+
 const waitForServer = (
   url: string,
   {
@@ -156,7 +179,7 @@ const waitForServer = (
     // if provided, reject immediately when the server process exits
     serverExited?: Promise<number | null>
   }
-): Promise<void> => {
+): Promise<string> => {
   const startedAt = performance.now()
   return new Promise((resolve, reject) => {
     let done = false
@@ -179,16 +202,19 @@ const waitForServer = (
     let retries = 0
     const checkServer = async () => {
       if (done) return
+      // the server may have rebound to a different port than requested; poll the
+      // actual bound port parsed from its output
+      const target = resolveBoundServerUrl(url, getServerOutput())
       try {
-        const response = await fetch(url)
+        const response = await fetch(target)
         if (response.ok) {
           done = true
           console.info(
-            `Server at ${url} is ready after ${Math.round(performance.now() - startedAt)}ms`
+            `Server at ${target} is ready after ${Math.round(performance.now() - startedAt)}ms`
           )
           // warmup: make a few more requests to ensure server is stable
-          await warmupServer(url)
-          resolve()
+          await warmupServer(target)
+          resolve(target)
         } else {
           throw new Error('Server not ready')
         }
@@ -361,7 +387,7 @@ export async function setupTestServers({
     }
 
     // wait for both servers to be ready
-    await Promise.all([
+    const [prodServerUrl, devServerUrl] = await Promise.all([
       shouldStartProdServer
         ? waitForServer(`http://localhost:${prodPort}`, {
             getServerOutput: prodServerGetOutput,
@@ -376,11 +402,20 @@ export async function setupTestServers({
         : null,
     ])
 
+    // a server may have rebound to a different port than requested; use the
+    // actual bound port so ONE_SERVER_URL (built from these) targets the live server
+    const actualProdPort = prodServerUrl
+      ? Number(new URL(prodServerUrl).port) || prodPort
+      : prodPort
+    const actualDevPort = devServerUrl
+      ? Number(new URL(devServerUrl).port) || devPort
+      : devPort
+
     console.info('Servers are running.\n')
 
     return {
-      testProdPort: prodPort,
-      testDevPort: devPort,
+      testProdPort: actualProdPort,
+      testDevPort: actualDevPort,
       devServerPid: devServer?.pid,
       prodServerPid: prodServer?.pid,
       buildPid: null,


### PR DESCRIPTION
## Problem

Intermittent `tests`-job flake (seen on PR #715's first run): `tests/test-loaders` setup timed out —

```
Starting a dev server on http://localhost:53414
Still waiting for http://localhost:53414... (30s) ... (242s)
Setup error: Server at http://localhost:53414 did not start within ... 242721ms
  Logs: ... Port 53414 is in use, trying another one... Server running on http://localhost:<other>/
```

vxrn/vite **rebind to a different port** when the requested one is taken — a check-then-bind race when many test packages start concurrently under turbo (the existing random-port-base + `killProcessOnPort` mitigations reduce but don't eliminate it). When it happens, both the readiness check **and** `ONE_SERVER_URL` (built from `testDevPort`/`testProdPort` in `setup.ts`) keep pointing at the requested-but-vacated port → 242s timeout. Native iOS tests are unaffected (fixed ports).

## Fix

`resolveBoundServerUrl(requestedUrl, output)` parses the actual bound port from the server's stdout and `waitForServer` polls/returns it; the caller uses it for `testDevPort`/`testProdPort`. **Conservative**: only deviates when the server reports `Port <n> is in use`, so the common no-move path is byte-for-byte unchanged.

## Verification (local)

- `resolveBoundServerUrl` exercised across happy / trailing-slash / moved-port / move-without-new-url cases → all correct.
- **Happy path e2e**: `test-loaders` test:dev → **35 passed, 8 skipped**, readiness check fired normally (`Server at http://localhost:51982 is ready after 7854ms`).
- typecheck (`@vxrn/test`) exit 0 · oxlint 0/0.
- (`@vxrn/test` exports from `src`, so no build step; the PR's own `tests` job re-runs the full web suite as the safety gate.)