### PR TITLE
Pin patched shell-quote

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1357,6 +1357,7 @@
     "react-native": "0.83.2",
     "react-native-reanimated": "4.2.1",
     "rolldown": "1.0.1",
+    "shell-quote": "1.8.4",
     "tar": "7.5.11",
     "tmp": "0.2.7",
     "undici": "7.24.3",
@@ -4573,7 +4574,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "shellwords-ts": ["shellwords-ts@3.0.1", "", {}, "sha512-GabK4ApLMqHFRGlpgNqg8dmtHTnYHt0WUUJkIeMd3QaDrUUBEDXHSSNi3I0PzMimg8W+I0EN4TshQxsnHv1cwg=="],
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "minimatch": "3.1.5",
     "node-forge": "1.4.0",
     "picomatch": "^4.0.4",
+    "shell-quote": "1.8.4",
     "cross-spawn": "7.0.6",
     "got": "11.8.5",
     "hono": "4.12.5",


### PR DESCRIPTION
## Summary
- pin shell-quote to 1.8.4 via the existing root resolutions block
- regenerate bun.lock so transitive consumers resolve outside GHSA-w7jw-789q-3m8p

## Validation
- bun install --frozen-lockfile
- bun run build
- bun audit --audit-level high --ignore GHSA-3ppc-4f35-3m26
- bun run check
- bun run lint
- bun run typecheck

Note: I also tried a local full bun run test before switching to PR-based iteration; it failed in test-loaders due a dev-server/browser-context issue unrelated to this lockfile audit change. Per follow-up direction, I stopped full-suite local iteration and will use branch CI for the broader suite.