### PR TITLE
fix(vxrn): fail fast on Expo SDK mismatch at prebuild

### DIFF
--- a/packages/vxrn/expo-plugin.cjs
+++ b/packages/vxrn/expo-plugin.cjs
@@ -19,6 +19,13 @@ function getPodfilePropsOptOut(propsPath, key) {
 }
 
 const plugin = (config, options = {}) => {
+  // fail fast on an Expo SDK mismatch before any native project is generated:
+  // one/vxrn pin expo-linking to a single SDK, and its native module is
+  // compiled against that SDK's expo-modules-core ABI. When the app's expo
+  // brings a newer expo-modules-core, the build/install/launch pipeline all
+  // succeed and the app then dies at ReactInstance creation with
+  // NoSuchMethodError in ExpoLinkingModule — invisible until runtime.
+  assertExpoModulesCoreMatchesExpoLinking(process.cwd())
   return withPlugins(config, [
     // auto-inject swift 6 workaround for expo-modules-core into Podfile (version-gated, opt-out-able)
     [
@@ -693,14 +700,56 @@ function addReactNativeScreensFix(input) {
 }
 
 function getExpoModulesCoreVersion(projectRoot) {
+  return getInstalledPackageVersion('expo-modules-core', projectRoot)
+}
+
+function getInstalledPackageVersion(packageName, projectRoot) {
   try {
-    const pkgPath = require.resolve('expo-modules-core/package.json', {
+    const pkgPath = require.resolve(`${packageName}/package.json`, {
       paths: [projectRoot],
     })
     return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version
   } catch {
     return null
   }
+}
+
+/**
+ * expo-linking (pinned by one/vxrn to a single Expo SDK) calls into
+ * expo-modules-core's Kotlin/Swift ABI; mixing majors compiles and installs
+ * fine but crashes at ReactInstance creation (NoSuchMethodError in
+ * ExpoLinkingModule). The project-root resolution sees the copy native
+ * autolinking will actually compile, so comparing the two majors here turns
+ * an opaque runtime crash into an actionable prebuild error.
+ *
+ * Escape hatch: ONE_SKIP_EXPO_SDK_CHECK=1 (e.g. for intentionally patched
+ * setups). Silently passes when either package isn't resolvable (web-only
+ * projects never reach this plugin anyway).
+ */
+function assertExpoModulesCoreMatchesExpoLinking(projectRoot) {
+  if (process.env.ONE_SKIP_EXPO_SDK_CHECK === '1') return
+
+  const expoModulesCoreVersion = getInstalledPackageVersion(
+    'expo-modules-core',
+    projectRoot
+  )
+  const expoLinkingVersion = getInstalledPackageVersion('expo-linking', projectRoot)
+  if (!expoModulesCoreVersion || !expoLinkingVersion) return
+
+  const coreMajor = semverMajor(expoModulesCoreVersion)
+  const linkingMajor = semverMajor(expoLinkingVersion)
+  if (coreMajor === linkingMajor) return
+
+  throw new Error(
+    `[vxrn/one] Expo SDK mismatch: expo-modules-core@${expoModulesCoreVersion} is installed, ` +
+      `but the bundled native modules (expo-linking@${expoLinkingVersion}) are built against ` +
+      `expo-modules-core ${linkingMajor}.\n` +
+      `The app would build and launch, then crash at startup ` +
+      `(NoSuchMethodError in ExpoLinkingModule).\n` +
+      `Fix: align your expo SDK with the one this version of one targets (expo-modules-core ${linkingMajor}), ` +
+      `or upgrade one to a release targeting your SDK.\n` +
+      `To bypass intentionally: set ONE_SKIP_EXPO_SDK_CHECK=1`
+  )
 }
 
 function semverMajor(version) {
@@ -851,6 +900,8 @@ function injectExpoUpdatesIosResourcesPatchIntoPodfile(podfile) {
 }
 
 module.exports = plugin
+module.exports.assertExpoModulesCoreMatchesExpoLinking =
+  assertExpoModulesCoreMatchesExpoLinking
 module.exports.addReactNativeScreensFix = addReactNativeScreensFix
 module.exports.addSetCliPathToBundleReactNativeShellScript =
   addSetCliPathToBundleReactNativeShellScript

--- a/packages/vxrn/expo-plugin.test.mjs
+++ b/packages/vxrn/expo-plugin.test.mjs
@@ -1,7 +1,11 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   addPodHermescToBundleReactNativeShellScript,
   addSetCliPathToBundleReactNativeShellScript,
+  assertExpoModulesCoreMatchesExpoLinking,
   injectExpoUpdatesIosResourcesPatchIntoPodfile,
   injectFmtCxx17FixIntoPodfile,
   injectHermesMinificationPatchIntoPodfile,
@@ -34,6 +38,73 @@ target 'MyApp' do
   end
 end
 `
+
+describe('assertExpoModulesCoreMatchesExpoLinking', () => {
+  function makeProjectRoot(expoModulesCoreVersion, expoLinkingVersion) {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'one-sdk-check-'))
+    const packages = [
+      ['expo-modules-core', expoModulesCoreVersion],
+      ['expo-linking', expoLinkingVersion],
+    ]
+    for (const [packageName, version] of packages) {
+      if (!version) continue
+      const packageDir = join(projectRoot, 'node_modules', packageName)
+      mkdirSync(packageDir, { recursive: true })
+      writeFileSync(
+        join(packageDir, 'package.json'),
+        JSON.stringify({ name: packageName, version })
+      )
+    }
+    return projectRoot
+  }
+
+  it('passes when expo-modules-core and expo-linking majors match', () => {
+    const projectRoot = makeProjectRoot('55.0.16', '55.0.7')
+    expect(() => assertExpoModulesCoreMatchesExpoLinking(projectRoot)).not.toThrow()
+  })
+
+  it('throws an actionable error on a major mismatch', () => {
+    const projectRoot = makeProjectRoot('56.0.16', '55.0.14')
+    expect(() => assertExpoModulesCoreMatchesExpoLinking(projectRoot)).toThrow(
+      /Expo SDK mismatch/
+    )
+    try {
+      assertExpoModulesCoreMatchesExpoLinking(projectRoot)
+    } catch (error) {
+      expect(error.message).toContain('expo-modules-core@56.0.16')
+      expect(error.message).toContain('expo-linking@55.0.14')
+      expect(error.message).toContain('NoSuchMethodError')
+      expect(error.message).toContain('ONE_SKIP_EXPO_SDK_CHECK')
+    }
+  })
+
+  it('passes silently when either package is not resolvable', () => {
+    expect(() =>
+      assertExpoModulesCoreMatchesExpoLinking(makeProjectRoot('56.0.16', null))
+    ).not.toThrow()
+    expect(() =>
+      assertExpoModulesCoreMatchesExpoLinking(makeProjectRoot(null, '55.0.14'))
+    ).not.toThrow()
+    expect(() =>
+      assertExpoModulesCoreMatchesExpoLinking(makeProjectRoot(null, null))
+    ).not.toThrow()
+  })
+
+  it('honors the ONE_SKIP_EXPO_SDK_CHECK escape hatch', () => {
+    const projectRoot = makeProjectRoot('56.0.16', '55.0.14')
+    const original = process.env.ONE_SKIP_EXPO_SDK_CHECK
+    process.env.ONE_SKIP_EXPO_SDK_CHECK = '1'
+    try {
+      expect(() => assertExpoModulesCoreMatchesExpoLinking(projectRoot)).not.toThrow()
+    } finally {
+      if (original === undefined) {
+        delete process.env.ONE_SKIP_EXPO_SDK_CHECK
+      } else {
+        process.env.ONE_SKIP_EXPO_SDK_CHECK = original
+      }
+    }
+  })
+})
 
 describe('injectHermesMinificationPatchIntoPodfile', () => {
   it('injects the marker and patches the bundle phase', () => {


### PR DESCRIPTION
## Summary

`one`/`vxrn` pin `expo-linking` to a single Expo SDK, and its native module is compiled against that SDK's `expo-modules-core` ABI. When an app's `expo` brings a newer `expo-modules-core` (e.g. expo 56 with one@1.18, which targets SDK 55), everything **builds, installs, bundles, and launches** — then dies at ReactInstance creation:

```
java.lang.NoSuchMethodError: No direct method <init>(Lkotlin/reflect/KClass;)V
  in class expo.modules.kotlin.types.ReturnType
  at expo.modules.linking.ExpoLinkingModule.definition(ExpoLinkingModule.kt:49)
```

The mismatch is invisible until that runtime trace (reproduced on emulator against one@1.18.0 + expo 56.0.11 / RN 0.86). This adds a fail-fast check at the top of the expo config plugin — it runs on every prebuild, never on web-only flows — comparing the resolved `expo-modules-core` major against the resolved `expo-linking` major (the exact pair that crashes) and failing with an actionable message before any native project is generated:

```
[vxrn/one] Expo SDK mismatch: expo-modules-core@56.0.16 is installed, but the bundled
native modules (expo-linking@55.0.14) are built against expo-modules-core 55.
The app would build and launch, then crash at startup (NoSuchMethodError in ExpoLinkingModule).
Fix: align your expo SDK with the one this version of one targets (expo-modules-core 55),
or upgrade one to a release targeting your SDK.
To bypass intentionally: set ONE_SKIP_EXPO_SDK_CHECK=1
```

## Why not peerDependencies?

I tried that first (CONTRIBUTING's single-instance guideline points that way) and rejected it with evidence. An 8-combo install matrix (npm/pnpm/yarn/bun × expo 55/56), with the stock published package as control, shows:

- **npm hard-fails ERESOLVE on the currently-supported expo 55** the moment the peer exists — required *or* `peerDependenciesMeta.optional` (stock: exit 0; with peer: exit 1). A present peer makes npm strictly enforce `expo-modules-core`'s own optional-peer tree against the `react-native-worklets` version that one's `react-native-css-interop` chain auto-installs.
- bun/pnpm warn nicely on the 56-mismatch, but yarn classic false-positives "unmet" even on the happy path (it doesn't credit transitively-provided peers).
- A manifest peer also warns web-only users, who are unaffected by the ABI issue.

The prebuild guard fails exactly the affected surface (native), with a better message, and zero package-resolver blast radius. Happy to share the full matrix output if useful.

## Test plan

- [x] `expo-plugin.test.mjs` — 18/18 (4 new: majors match → passes; mismatch → throws with both versions + remediation + bypass hint; either package missing → silent pass; `ONE_SKIP_EXPO_SDK_CHECK=1` honored)
- [x] e2e negative — real expo 56 app: `one prebuild --platform android` exits 1 with the message above (previously: clean prebuild + gradle + install + launch, then the runtime crash)
- [x] e2e escape hatch — same app with `ONE_SKIP_EXPO_SDK_CHECK=1`: prebuild completes
- [x] e2e positive — `examples/one-basic` (expo 55): prebuild completes cleanly, no new output

## Notes

The check models the ABI contract directly (`expo-linking` major == `expo-modules-core` major) rather than hardcoding an SDK number, so it stays correct across SDK bumps with no maintenance. If you'd prefer a warning instead of a hard error, it's a one-line change — but given the failure mode is a startup crash that survives the whole build pipeline, erroring felt right.

