### PR TITLE
fix(test-warm-routes): start dev server via run.mjs so the test runs on Windows

### DIFF
--- a/tests/test-warm-routes/tests/warm-routes.test.ts
+++ b/tests/test-warm-routes/tests/warm-routes.test.ts
@@ -1,10 +1,18 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
 
 const testDir = join(import.meta.dirname, '..')
 const cacheFile = join(testDir, 'node_modules', '.vite', 'one-warm-deps.json')
-const oneBin = join(testDir, '..', '..', 'node_modules', '.bin', 'one')
+// Resolve one's JS entry (run.mjs) instead of node_modules/.bin/one: on Windows
+// the .bin shim is a .cmd/.ps1/.exe wrapper that `node <path>` can't load
+// (MODULE_NOT_FOUND), so the dev server never starts. Resolving via package.json
+// gives the real JS file on every platform (mirrors packages/test/src/setupTest.ts).
+const oneRunEntry = join(
+  dirname(createRequire(import.meta.url).resolve('one/package.json')),
+  'run.mjs'
+)
 
 function cleanup() {
   // clear .vite cache so we start fresh
@@ -22,10 +30,13 @@ function startDevServer(port: number): {
 } {
   const output: string[] = []
 
-  const proc = spawn('node', [oneBin, 'dev', '--port', port.toString()], {
+  const proc = spawn('node', [oneRunEntry, 'dev', '--port', port.toString()], {
     cwd: testDir,
     env: { ...process.env },
     stdio: ['ignore', 'pipe', 'pipe'],
+    // detached so the whole process group can be killed on POSIX (one dev spawns
+    // child workers); on Windows the tree is killed via taskkill /T in kill().
+    detached: process.platform !== 'win32',
   })
 
   proc.stdout?.on('data', (data) => {
@@ -76,12 +87,20 @@ function startDevServer(port: number): {
   }
 
   function kill() {
-    try {
-      process.kill(-proc.pid!, 'SIGKILL')
-    } catch {
+    if (!proc.pid) return
+    if (process.platform === 'win32') {
+      // node cannot signal a process group on Windows; taskkill /T kills the tree.
       try {
-        proc.kill('SIGKILL')
+        spawn('taskkill', ['/F', '/T', '/PID', String(proc.pid)], { stdio: 'ignore' })
       } catch {}
+    } else {
+      try {
+        process.kill(-proc.pid, 'SIGKILL')
+      } catch {
+        try {
+          proc.kill('SIGKILL')
+        } catch {}
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`tests/test-warm-routes/tests/warm-routes.test.ts` starts the dev server with:

```ts
const oneBin = join(testDir, '..', '..', 'node_modules', '.bin', 'one')
spawn('node', [oneBin, 'dev', '--port', port.toString()], { ... })
```

On Windows, `node_modules/.bin/one` is a `.cmd`/`.ps1`/`.exe` shim — not a JS file — so `node <shim>` fails with `MODULE_NOT_FOUND`, the dev server never starts, and `waitFor('Server running')` times out after 60s. This is the **lone failure in the otherwise-green Windows test suite** (the same `.bin/<pkg>` class that `packages/test/src/setupTest.ts` already fixed via `ONE_RUN_ENTRY`; this standalone script was missed).

There's also a latent cleanup bug on every platform: `process.kill(-proc.pid, 'SIGKILL')` signals a *process group*, which doesn't exist on Windows (throws) and wasn't actually enabled on POSIX either (the spawn wasn't `detached`) — so the dev server was orphaned on teardown.

## Changes

- Resolve one's real JS entry via `createRequire(import.meta.url).resolve('one/package.json')` → `run.mjs` (mirrors `setupTest.ts`'s `ONE_RUN_ENTRY`), and spawn `node run.mjs dev` — correct on every platform.
- Spawn `detached` on POSIX so the existing process-group kill actually works; on Windows kill the tree via `taskkill /F /T /PID` so the dev server isn't orphaned.

## Test plan

Validated on v1.21.0 (Windows 11, Node 25):

- [x] Run 1 — cold: dev server boots via `run.mjs`, cache file written (`Cached deps count: 19`, `✅ Run 1 PASSED`) — a hard `MODULE_NOT_FOUND` + 60s timeout failure before this change
- [x] Run 2 — restart: `[one] loading 19 cached warm deps` on startup (`✅ Run 2 PASSED`), exit 0; re-ran the whole script twice back-to-back, both green
- [x] `oxlint` — 0 warnings / 0 errors; `oxfmt --check` — file clean
- [x] POSIX behavior unchanged: `run.mjs` is the exact file the `.bin/one` shim dispatches to, and the kill path now uses an actually-detached process group

## Notes

With this fixed, `turbo test` proceeds past `test-warm-routes` on Windows and the bulk of the suite runs green. A full `--continue` pass then surfaced the remaining Windows gaps — all pre-existing and unrelated to this change:

- the same `node node_modules/.bin/one` spawn pattern in three `tests/test` files (`metro-compiler.test.ts`, `metro-startup-order.test.ts`, `process-cleanup.test.ts`) — swept in the follow-up #722, using the same `run.mjs` resolution;
- a Windows asset-filename issue affecting dynamic routes in prod builds, filed with a full diagnosis as #718 (fix in #721).

Longer term this is what makes a `windows-latest` CI job viable; glad to help with that if you want the coverage.

