### PR TITLE
fix: encode NTFS-reserved characters in route-derived artifact filenames

### DIFF
--- a/packages/one/src/cli/buildPage.ts
+++ b/packages/one/src/cli/buildPage.ts
@@ -4,7 +4,12 @@ import { normalizePath } from 'vite'
 import * as constants from '../constants'
 import { LOADER_JS_POSTFIX_UNCACHED } from '../constants'
 import type { LoaderProps } from '../types'
-import { getLoaderPath, getPreloadCSSPath, getPreloadPath } from '../utils/cleanUrl'
+import {
+  encodeReservedFilenameChars,
+  getLoaderPath,
+  getPreloadCSSPath,
+  getPreloadPath,
+} from '../utils/cleanUrl'
 import { isResponse } from '../utils/isResponse'
 import { toAbsolute, toAbsoluteUrl } from '../utils/toAbsolute'
 import { replaceLoader } from '../vite/replaceLoader'
@@ -64,7 +69,12 @@ export async function buildPage(
   const render = await getRender(serverEntry)
   recordTiming('getRender', performance.now() - t0)
 
-  const htmlPath = `${path.endsWith('/') ? `${removeTrailingSlash(path)}/index` : path}.html`
+  // encode NTFS-reserved characters (`:` from `/:param` patterns, `*` from
+  // catch-alls, hostile param values) so the artifact is writable on Windows;
+  // routeMap stores this same string, so serve-side lookups stay consistent
+  const htmlPath = encodeReservedFilenameChars(
+    `${path.endsWith('/') ? `${removeTrailingSlash(path)}/index` : path}.html`
+  )
   // forward-slash for cross-platform manifest hygiene (matches serverJsPath)
   const clientJsPath = clientManifestEntry
     ? normalizePath(join(clientDir, clientManifestEntry.file))

--- a/packages/one/src/utils/cleanUrl.test.ts
+++ b/packages/one/src/utils/cleanUrl.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getLoaderPath, getPathFromLoaderPath } from './cleanUrl'
+import {
+  encodeReservedFilenameChars,
+  getLoaderPath,
+  getPathFromLoaderPath,
+  getPreloadPath,
+} from './cleanUrl'
 
 /**
  * tests the cleanUrl encode/decode roundtrip used for loader URLs.
@@ -88,6 +93,63 @@ describe('getLoaderPath format', () => {
   it('includes cache bust segment', () => {
     const result = getLoaderPath('/docs/intro', false, '12345')
     expect(result).toContain('_refetch_12345_')
+  })
+})
+
+describe('NTFS-reserved characters in route-derived names', () => {
+  // route patterns reach these functions verbatim when a dynamic route has no
+  // generateStaticParams (every dynamic +ssr/+spa route at build time)
+  it('roundtrips a root dynamic route pattern', () => {
+    expect(roundtrip('/:param')).toBe('/:param')
+  })
+
+  it('roundtrips a nested dynamic route pattern', () => {
+    expect(roundtrip('/dashboard/:appId')).toBe('/dashboard/:appId')
+  })
+
+  it('roundtrips a catch-all pattern', () => {
+    expect(roundtrip('/*')).toBe('/*')
+  })
+
+  it('roundtrips hostile concrete param values (chars that survive URL parsing raw)', () => {
+    // getLoaderPath URL-parses its input; WHATWG URL percent-encodes " < > |
+    // in pathnames but passes : and * through raw — those two are the ones
+    // that reach generated filenames verbatim (and are the NTFS killers)
+    expect(roundtrip('/blog/a:b*c')).toBe('/blog/a:b*c')
+  })
+
+  it('emits filesystem-legal names for the full reserved set via preload paths', () => {
+    // getPreloadPath does not URL-parse, so every reserved char reaches the
+    // encoder raw — assert none survive into the filename
+    expect(getPreloadPath('/blog/a:b*c"d<e>f|g?h')).not.toMatch(/[<>:"|?*]/)
+  })
+
+  it('roundtrips literal equals signs (self-escape)', () => {
+    expect(roundtrip('/foo=bar')).toBe('/foo=bar')
+  })
+
+  it('roundtrips equals followed by hex-looking characters', () => {
+    expect(roundtrip('/x=3ay')).toBe('/x=3ay')
+  })
+
+  it('emits no NTFS-reserved characters in loader filenames', () => {
+    expect(getLoaderPath('/dashboard/:appId', false)).not.toMatch(/[<>:"|?*]/)
+  })
+
+  it('emits no NTFS-reserved characters in preload filenames', () => {
+    expect(getPreloadPath('/:param')).not.toMatch(/[<>:"|?*]/)
+    expect(getPreloadPath('/*')).not.toMatch(/[<>:"|?*]/)
+  })
+
+  it('encodeReservedFilenameChars is identity for clean paths', () => {
+    expect(encodeReservedFilenameChars('/blog/my-slug.html')).toBe('/blog/my-slug.html')
+  })
+
+  it('encodes the html artifact path for non-prerendered dynamic routes', () => {
+    expect(encodeReservedFilenameChars('/dashboard/:appId.html')).toBe(
+      '/dashboard/=3aappId.html'
+    )
+    expect(encodeReservedFilenameChars('/*.html')).toBe('/=2a.html')
   })
 })
 

--- a/packages/one/src/utils/cleanUrl.ts
+++ b/packages/one/src/utils/cleanUrl.ts
@@ -8,9 +8,31 @@ import {
 import { getURL } from '../getURL'
 import { removeSearch } from './removeSearch'
 
+// Route patterns (`/:param`, `/*`) and concrete param values flow into
+// generated artifact filenames. `< > : " | ? *` are reserved on Windows
+// filesystems — a leading `:` segment fails outright and a mid-name `:`
+// silently writes an NTFS alternate data stream — so encode them as `=hh`
+// (hex char code), with literal `=` self-escaped first so decoding is
+// unambiguous. Identity for paths without reserved characters.
+export function encodeReservedFilenameChars(path: string) {
+  return path
+    .replaceAll('=', '=3d')
+    .replace(
+      /[<>:"|?*]/g,
+      (char) => `=${char.charCodeAt(0).toString(16).padStart(2, '0')}`
+    )
+}
+
+export function decodeReservedFilenameChars(path: string) {
+  return path.replace(/=([0-9a-f]{2})/g, (_match, hexCode) =>
+    String.fromCharCode(Number.parseInt(hexCode, 16))
+  )
+}
+
 function cleanUrl(path: string) {
-  return removeSearch(path)
-    .replace(/\/$/, '') // remove trailing slash before encoding
+  return encodeReservedFilenameChars(
+    removeSearch(path).replace(/\/$/, '') // remove trailing slash before encoding
+  )
     .replaceAll('_', '__') // escape existing underscores
     .replaceAll('/', '_') // use underscore as path separator
 }
@@ -43,7 +65,7 @@ export function getLoaderPath(
 }
 
 export function getPathFromLoaderPath(loaderPath: string) {
-  return (
+  return decodeReservedFilenameChars(
     loaderPath
       .replace(LOADER_JS_POSTFIX_REGEX, '')
       .replace(/^(\/_one)?\/assets/, '')

--- a/packages/one/types/utils/cleanUrl.d.ts
+++ b/packages/one/types/utils/cleanUrl.d.ts
@@ -1,3 +1,5 @@
+export declare function encodeReservedFilenameChars(path: string): string;
+export declare function decodeReservedFilenameChars(path: string): string;
 export declare function getPreloadPath(currentPath: string): string;
 export declare function getPreloadCSSPath(currentPath: string): string;
 export declare function getLoaderPath(currentPath: string, includeUrl?: boolean, cacheBust?: string): string;


### PR DESCRIPTION
Fixes #718.

## Summary

Fixes the Windows build bug where **dynamic routes silently disappear from prod builds** (and `one serve` then 404s them). Route patterns (`/:param`, `/*`) and concrete `generateStaticParams` values flow into generated artifact filenames — preload/loader assets via `cleanUrl()` and the static HTML path in `buildPage` — and `< > : " | ? *` are reserved on Windows filesystems:

- a **colon-led segment** fails the write → `build.ts` catches it per-page, warns `⚠ skipping page …: ENOENT`, and **exits 0** → the route is missing from `routeToBuildInfo` → bare 404 in prod. This hits every root-level (or route-group-rooted, e.g. `(group)/[param]`) dynamic route, every non-SSR dynamic route at any depth (via `…/:param.html`), and every catch-all (via `*`).
- a **mid-name colon** "succeeds" into an NTFS **alternate data stream** → the preload bytes live on an invisible zero-byte stub (`blog_` + hidden stream), vanishing from any copied/deployed dist.

Two of the repo's own test packages catch this on Windows: `test-app-cases` (dynamic-at-root + catch-all prod phases) and `test-spa-shell-routing` (8 prod reload failures — exactly the four dropped routes). It's been masked because `turbo test` without `--continue` cancelled everything behind the first Windows failure.

## Changes

- `cleanUrl()` encodes reserved characters as `=hh` (hex char code; literal `=` self-escaped first so decoding is unambiguous), and `getPathFromLoaderPath()` decodes them — same module, so build naming, client fetch URLs, and server-side request decoding stay symmetric.
- `buildPage`'s `htmlPath` artifact gets the same encoding (the manifest stores the encoded name, so serve-side lookups are consistent by construction).
- **Identity for clean paths**: artifact names for every currently-working route are byte-identical, and serve-side postfix matching (`PRELOAD_JS_POSTFIX_REGEX` etc.) is untouched.
- 11 new tests in `cleanUrl.test.ts`: roundtrips for patterns/catch-alls/hostile param values/literal `=`/hex-lookalikes, plus no-reserved-chars-emitted assertions.

## Test plan

Windows 11 — integration repro at v1.18.0; `packages/one` + CI re-validated on v1.21.0 (current base):

- [x] `tests/test-app-cases` — `dynamic-route-at-root-with-assets` and `catch-all-route-at-root-with-assets` prod phases go **404 → 200** (routes restored to `routeToBuildInfo`, zero `skipping page` warnings); full package green in dev **and** prod
- [x] `tests/test-spa-shell-routing` — **8 failed prod tests → 27/27 in both phases**; all four previously-dropped routes (`dashboard/[appId]`, `thread/[id]`, `(chat)/[serverId]`, `(chat)/[serverId]/[channelId]`) registered again
- [x] `packages/one` vitest — **548 passed / 0 failed** (incl. the 11 new tests; re-run at v1.21.0, `cleanUrl.test.ts` 29/29)
- [x] `oxlint` 0/0, `oxfmt --check` clean, `tsc --noEmit` clean

On Linux/macOS, output is unchanged for clean paths — and pattern-named artifacts become portable as a bonus (no more literal `:`/`*` in `dist/` filenames for deploy tooling to reject).

## Notes

Detailed diagnosis (NTFS ADS forensics, per-face scoping matrix, masking analysis) is in the linked issue. The behavioral question worth a maintainer call: pattern-built artifacts for non-prerendered dynamic routes now get stable encoded names — if you'd rather skip emitting those artifacts entirely for pattern paths, happy to rework in that direction instead.

