### PR TITLE
Fix iOS native prod CI crashes

### DIFF
--- a/.github/workflows/build-ios-test-container-app.yml
+++ b/.github/workflows/build-ios-test-container-app.yml
@@ -86,7 +86,7 @@ jobs:
           #
           # This hash can be different if the build_hash remains the same. For example, if `bun.lock` changes, `Podfile.lock` may not change if the updated package contains no native code.
           # include workflow file itself so env var changes (like RCT_HERMES_V1_ENABLED) bust the cache
-          PRE_BUILD_HASH: ${{ hashFiles('bun.lock', format('{0}/app.json', env.test_container_app_path), 'packages/vxrn/expo-plugin.cjs', '.github/workflows/build-ios-test-container-app.yml') }}
+          PRE_BUILD_HASH: ${{ hashFiles('bun.lock', format('{0}/app.json', env.test_container_app_path), 'packages/vxrn/expo-plugin.cjs', 'packages/vxrn/src/patches/builtInDepPatches.ts', '.github/workflows/build-ios-test-container-app.yml') }}
         run: |
           if [ -z "$PRE_BUILD_HASH" ]; then
             echo '[ERROR] Failed to calculate pre-build hash.'
@@ -158,7 +158,7 @@ jobs:
         id: calculate-build-hash
         env:
           # include all files that affect native code + the workflow itself (for env var changes)
-          BUILD_HASH: ${{ hashFiles(format('{0}/ios/Podfile.lock', env.test_container_app_path), format('{0}/app.json', env.test_container_app_path), 'packages/vxrn/expo-plugin.cjs', '.github/workflows/build-ios-test-container-app.yml') }}
+          BUILD_HASH: ${{ hashFiles(format('{0}/ios/Podfile.lock', env.test_container_app_path), format('{0}/app.json', env.test_container_app_path), 'packages/vxrn/expo-plugin.cjs', 'packages/vxrn/src/patches/builtInDepPatches.ts', '.github/workflows/build-ios-test-container-app.yml') }}
         run: |
           if [ -z "$BUILD_HASH" ]; then
             echo '[ERROR] Failed to calculate build hash.'

--- a/.github/workflows/test-native-ios.yml
+++ b/.github/workflows/test-native-ios.yml
@@ -72,15 +72,12 @@ jobs:
       - build-ios-test-container-prod
     runs-on: macos-15
     timeout-minutes: 45
-    # prod (Release/Hermes-bytecode) currently crashes on launch with a SIGSEGV
-    # *before* any test can run — an upstream React Native bug, not a regression
-    # in our tests. a TurboModule void method throws an NSException during
-    # startup and RN's convertNSExceptionToJSError builds the JS error on the
-    # turbomodule queue concurrently with the JS thread, corrupting Hermes.
-    # see tests/test/IOS_PROD_CRASH.md. quarantined (non-blocking) until fixed;
-    # the harness now fails these jobs fast (~10m) instead of timing out (~48m).
-    # dev (metro + rolldown) stays gating.
-    continue-on-error: ${{ matrix.env == 'prod' }}
+    # rolldown:prod is experimental — don't fail the workflow on it.
+    # (prod used to crash on launch with a SIGSEGV from an upstream RN
+    # TurboModule/Hermes concurrency bug — now fixed via a builtInDepPatches
+    # patch to react-native; see tests/test/IOS_PROD_CRASH.md. the harness also
+    # fails a crash-on-launch fast (~10m) instead of timing out (~48m).)
+    continue-on-error: ${{ matrix.env == 'prod' && matrix.bundler == 'rolldown' }}
     strategy:
       # one matrix entry's failure shouldn't kill the others — they're independent runs
       fail-fast: false

--- a/.github/workflows/test-native-ios.yml
+++ b/.github/workflows/test-native-ios.yml
@@ -72,8 +72,15 @@ jobs:
       - build-ios-test-container-prod
     runs-on: macos-15
     timeout-minutes: 45
-    # rolldown:prod is experimental — don't fail the workflow on it
-    continue-on-error: ${{ matrix.env == 'prod' && matrix.bundler == 'rolldown' }}
+    # prod (Release/Hermes-bytecode) currently crashes on launch with a SIGSEGV
+    # *before* any test can run — an upstream React Native bug, not a regression
+    # in our tests. a TurboModule void method throws an NSException during
+    # startup and RN's convertNSExceptionToJSError builds the JS error on the
+    # turbomodule queue concurrently with the JS thread, corrupting Hermes.
+    # see tests/test/IOS_PROD_CRASH.md. quarantined (non-blocking) until fixed;
+    # the harness now fails these jobs fast (~10m) instead of timing out (~48m).
+    # dev (metro + rolldown) stays gating.
+    continue-on-error: ${{ matrix.env == 'prod' }}
     strategy:
       # one matrix entry's failure shouldn't kill the others — they're independent runs
       fail-fast: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # for onstack.dev railway
 
-FROM oven/bun:1.2.22
+FROM oven/bun:1.3.9
 
 ARG ONE_SERVER_URL
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,7 @@
 # syntax=docker/dockerfile:1.2
 
 # Use Bun as the base image
-FROM oven/bun:1.2.22
+FROM oven/bun:1.3.9
 # Set the CI environment variable
 ENV CI=true
 

--- a/packages/one/src/useBlocker.native.ts
+++ b/packages/one/src/useBlocker.native.ts
@@ -1,4 +1,4 @@
-import { useNavigation } from '@react-navigation/native'
+import { useNavigation, usePreventRemove } from '@react-navigation/native'
 import * as React from 'react'
 
 export type BlockerState = 'unblocked' | 'blocked' | 'proceeding'
@@ -32,9 +32,12 @@ export type Blocker =
 /**
  * Block navigation when a condition is met.
  *
- * On native, this uses React Navigation's `beforeRemove` event to prevent navigation.
- * Note that this only works for navigation within the app - it cannot prevent
- * the app from being closed or backgrounded.
+ * On native, this uses React Navigation's `usePreventRemove`, which registers the
+ * route with the native stack so the iOS interactive swipe-back gesture is blocked
+ * too (via `preventNativeDismiss`), not just JS-driven pops. A raw `beforeRemove`
+ * listener only stops JS-driven pops, so swiping would bypass the guard and desync
+ * JS<->native state. Note that this only works for navigation within the app - it
+ * cannot prevent the app from being closed or backgrounded.
  *
  * @param shouldBlock - Either a boolean or a function that returns whether to block.
  *
@@ -63,67 +66,43 @@ export type Blocker =
 export function useBlocker(shouldBlock: BlockerFunction | boolean): Blocker {
   const navigation = useNavigation()
   const [state, setState] = React.useState<BlockerState>('unblocked')
-  const [pendingEvent, setPendingEvent] = React.useState<any>(null)
+  const [pendingAction, setPendingAction] = React.useState<any>(null)
   const [blockedLocation, setBlockedLocation] = React.useState<string | null>(null)
 
-  const shouldBlockRef = React.useRef(shouldBlock)
-  shouldBlockRef.current = shouldBlock
+  // native has no current location and the gesture/back button are always a pop
+  const block =
+    typeof shouldBlock === 'function'
+      ? shouldBlock({ currentLocation: '', nextLocation: 'previous screen', historyAction: 'pop' })
+      : shouldBlock
 
-  React.useEffect(() => {
-    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
-      const currentShouldBlock = shouldBlockRef.current
-
-      // Get the next location from the action payload
-      const payload = e.data?.action?.payload as { name?: string } | undefined
-      const nextLocation = payload?.name || 'previous screen'
-
-      // Determine if we should block
-      const block =
-        typeof currentShouldBlock === 'function'
-          ? currentShouldBlock({
-              currentLocation: '', // Not easily available on native
-              nextLocation,
-              historyAction: 'pop',
-            })
-          : currentShouldBlock
-
-      if (!block) {
-        return
-      }
-
-      // Prevent default behavior (leaving the screen)
-      e.preventDefault()
-
-      // Store the event to dispatch later if user confirms
-      setPendingEvent(e)
-      setBlockedLocation(nextLocation)
-      setState('blocked')
-    })
-
-    return unsubscribe
-  }, [navigation])
+  usePreventRemove(block, ({ data }) => {
+    const payload = data?.action?.payload as { name?: string } | undefined
+    setPendingAction(data.action)
+    setBlockedLocation(payload?.name || 'previous screen')
+    setState('blocked')
+  })
 
   const reset = React.useCallback(() => {
-    setPendingEvent(null)
+    setPendingAction(null)
     setBlockedLocation(null)
     setState('unblocked')
   }, [])
 
   const proceed = React.useCallback(() => {
-    if (!pendingEvent) return
+    if (!pendingAction) return
 
     setState('proceeding')
 
-    // Dispatch the original action to complete navigation
-    navigation.dispatch(pendingEvent.data.action)
+    // the captured action carries a VISITED_ROUTE_KEYS marker, so re-dispatching
+    // it skips the beforeRemove guard and navigation completes without re-blocking
+    navigation.dispatch(pendingAction)
 
-    // Reset after navigation
     setTimeout(() => {
-      setPendingEvent(null)
+      setPendingAction(null)
       setBlockedLocation(null)
       setState('unblocked')
     }, 100)
-  }, [navigation, pendingEvent])
+  }, [navigation, pendingAction])
 
   if (state === 'unblocked') {
     return { state: 'unblocked' }
@@ -142,7 +121,7 @@ export function useBlocker(shouldBlock: BlockerFunction | boolean): Blocker {
 }
 
 /**
- * No-op on native - native uses React Navigation's beforeRemove event instead.
+ * No-op on native - native uses React Navigation's usePreventRemove instead.
  * This is only used by the router on web.
  */
 export function checkBlocker(

--- a/packages/one/src/useLoader.ts
+++ b/packages/one/src/useLoader.ts
@@ -13,6 +13,7 @@ import {
   updateMatchLoaderData,
 } from './useMatches'
 import { getLoaderPath } from './utils/cleanUrl'
+import { getURL } from './getURL'
 import { LOADER_JS_POSTFIX_UNCACHED } from './constants'
 import { dynamicImport } from './utils/dynamicImport'
 import { weakKey } from './utils/weakKey'
@@ -509,8 +510,10 @@ export function useLoaderState<
               nativeLoaderJSUrl = `${getLoaderPath(currentPath, true)}?platform=native`
             } else {
               // prod: request the .native.js static file directly
-              // use uncached postfix since metro can't inline ONE_CACHE_KEY
-              const { getURL } = require('./getURL')
+              // use uncached postfix since metro can't inline ONE_CACHE_KEY.
+              // must use the static import — a dynamic require('./getURL') is
+              // left as a runtime string require by metro and resolves to
+              // undefined in the prod native bundle (crashes the route).
               const base = getURL()
               const cleanedPath = currentPath
                 .slice(1)

--- a/packages/test/src/setup-ios.ts
+++ b/packages/test/src/setup-ios.ts
@@ -3,6 +3,7 @@ import type { Assertion } from 'vitest'
 import { setupTestServers, type TestInfo } from './setupTest'
 import { setup as defaultSetup, teardown as defaultTeardown } from './setup'
 import { getWebDriverConfig, type WebdriverIOConfig } from './internal-utils/ios'
+import { clearAppCrashMarker } from './utils/appium'
 
 // to keep the import which is needed for declare
 const y: Assertion = 0 as any
@@ -15,6 +16,8 @@ declare module 'vitest' {
 
 export async function setup(project: TestProject) {
   process.env.IS_NATIVE_TEST = 'true'
+  // reset the crash circuit breaker from any previous run on this machine
+  clearAppCrashMarker()
   await defaultSetup(project)
   const webDriverConfig = await getWebDriverConfig()
   project.provide('webDriverConfig', webDriverConfig)

--- a/packages/test/src/utils/appium.ts
+++ b/packages/test/src/utils/appium.ts
@@ -1,5 +1,7 @@
 import { execSync } from 'node:child_process'
 import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import type { ChainablePromiseElement, Browser } from 'webdriverio'
 import { remote } from 'webdriverio'
 import type { WebdriverIOConfig } from '../internal-utils/ios'
@@ -9,6 +11,44 @@ export class AppCrashedError extends Error {
     super(message)
     this.name = 'AppCrashedError'
   }
+}
+
+/**
+ * circuit breaker for a deterministic crash-on-launch.
+ *
+ * the app either launches or it doesn't — if it crashes immediately the first
+ * time, it will crash every time. without this, a crashing prod bundle gets
+ * relaunched across every test file (each with its own retries), burning the
+ * entire 45-min job budget until GitHub force-cancels the run. that shows up as
+ * a "cancelled" run, which looks like infra flake and hides a real failure.
+ *
+ * the marker is keyed by TEST_ENV (dev/prod run as separate vitest processes)
+ * and written to a shared tmp file so it survives across vitest worker threads.
+ */
+const crashMarkerPath = path.join(
+  os.tmpdir(),
+  `one-ios-app-crash-${process.env.TEST_ENV || 'unknown'}.marker`
+)
+
+function getRecordedCrash(): string | null {
+  try {
+    return fs.readFileSync(crashMarkerPath, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function recordCrash(reason: string) {
+  try {
+    fs.writeFileSync(crashMarkerPath, reason)
+  } catch {}
+}
+
+/** clear the crash circuit breaker — call once at suite start. */
+export function clearAppCrashMarker() {
+  try {
+    fs.rmSync(crashMarkerPath, { force: true })
+  } catch {}
 }
 
 /**
@@ -307,6 +347,16 @@ export async function createSession(
   config: WebdriverIOConfig | Promise<WebdriverIOConfig>,
   { maxRetries = 3 }: { maxRetries?: number } = {}
 ): Promise<Browser> {
+  // circuit breaker: if the app already crashed on launch earlier in this run,
+  // it is not going to launch now either. fail instantly instead of relaunching
+  // a known-broken bundle across every remaining test.
+  const recordedCrash = getRecordedCrash()
+  if (recordedCrash) {
+    throw new AppCrashedError(
+      `app already crashed on launch earlier in this run — skipping session to avoid burning the CI budget.\nfirst crash:\n${recordedCrash}`
+    )
+  }
+
   const resolvedConfig = await config
   let lastError: unknown
 
@@ -321,43 +371,78 @@ export async function createSession(
       const driver = await remote(sessionConfig)
 
       // verify the app actually launched successfully
-      try {
-        await assertAppRunning(driver)
-      } catch (e) {
-        if (e instanceof AppCrashedError) {
-          console.error(
-            `[createSession] app crashed immediately after launch on attempt ${attempt}`
-          )
-          // dump simulator system log for crash diagnostics
-          const udid =
-            (sessionConfig.capabilities as any)?.['appium:options']?.udid ||
-            process.env.SIMULATOR_UDID
-          if (udid) {
-            try {
-              const log = execSync(
-                `xcrun simctl spawn ${udid} log show --predicate 'process == "RNTestContainer" OR subsystem == "com.apple.CrashReporter"' --last 30s --style compact 2>/dev/null || true`,
-                { timeout: 10_000, encoding: 'utf8' }
-              )
-              if (log.trim()) {
-                console.error(
-                  '[createSession] simulator crash log:\n' + log.slice(0, 3000)
-                )
-              }
-            } catch {}
-          }
-          throw e
-        }
-      }
+      await assertAppRunning(driver)
 
       return driver
     } catch (err) {
       lastError = err
+
+      // a crash-on-launch is deterministic — retrying just wastes time.
+      // record it so every subsequent session in the run fails instantly, dump
+      // diagnostics, and bail out of the retry loop immediately.
+      if (err instanceof AppCrashedError) {
+        const crashLog = dumpSimulatorCrashLog(resolvedConfig)
+        const reason = crashLog ? `${err.message}\n\n${crashLog}` : err.message
+        recordCrash(reason)
+        console.error(
+          `[createSession] app crashed immediately after launch — not retrying (deterministic)`
+        )
+        if (crashLog) {
+          console.error('[createSession] simulator crash log:\n' + crashLog)
+        }
+        throw err
+      }
+
       const msg = err instanceof Error ? err.message : String(err)
       console.warn(`[createSession] attempt ${attempt}/${maxRetries} failed: ${msg}`)
     }
   }
 
   throw lastError
+}
+
+/** dump diagnostics around an app crash so the failure is self-explaining. */
+function dumpSimulatorCrashLog(config: WebdriverIOConfig): string | null {
+  const opts = (config.capabilities as any)?.['appium:options'] || {}
+  const udid = opts.udid || process.env.SIMULATOR_UDID
+  const bundleId = opts.bundleId || 'dev.onestack.rntestcontainer'
+  if (!udid) return null
+
+  const parts: string[] = []
+
+  // relaunch the app attached to a console — the real JS/Hermes fatal (e.g.
+  // "Wrong bytecode version. Expected 96 but got 98") prints to the app's
+  // stdout/stderr, which `log show` does not capture. the app crashes
+  // immediately on launch, so this returns right away.
+  try {
+    execSync(`xcrun simctl terminate ${udid} ${bundleId} 2>/dev/null || true`, {
+      timeout: 10_000,
+    })
+    const console = execSync(
+      `xcrun simctl launch --console-pty ${udid} ${bundleId} 2>&1 | head -40`,
+      { timeout: 30_000, encoding: 'utf8' }
+    )
+    const trimmed = console.trim()
+    if (trimmed) parts.push('app console on relaunch:\n' + trimmed)
+  } catch (e) {
+    // execSync throws if the launch is killed by the timeout (app didn't crash
+    // this time) — keep any stdout it captured before dying.
+    const out = (e as any)?.stdout
+    if (out) parts.push('app console on relaunch:\n' + String(out).trim())
+  }
+
+  // system-level fallback (crash reporter / signals)
+  try {
+    const log = execSync(
+      `xcrun simctl spawn ${udid} log show --predicate 'process == "RNTestContainer" OR subsystem == "com.apple.CrashReporter"' --last 60s --style compact 2>/dev/null || true`,
+      { timeout: 15_000, encoding: 'utf8' }
+    )
+    const trimmed = log.trim()
+    if (trimmed) parts.push('simulator log:\n' + trimmed)
+  } catch {}
+
+  const out = parts.join('\n\n')
+  return out ? out.slice(0, 6000) : null
 }
 
 async function recoverSimulator(config: WebdriverIOConfig) {

--- a/packages/test/src/utils/appium.ts
+++ b/packages/test/src/utils/appium.ts
@@ -418,11 +418,11 @@ function dumpSimulatorCrashLog(config: WebdriverIOConfig): string | null {
     execSync(`xcrun simctl terminate ${udid} ${bundleId} 2>/dev/null || true`, {
       timeout: 10_000,
     })
-    const console = execSync(
+    const consoleOut = execSync(
       `xcrun simctl launch --console-pty ${udid} ${bundleId} 2>&1 | head -200`,
       { timeout: 30_000, encoding: 'utf8' }
     )
-    const trimmed = console.trim()
+    const trimmed = consoleOut.trim()
     if (trimmed) parts.push('app console on relaunch:\n' + trimmed)
   } catch (e) {
     // execSync throws if the launch is killed by the timeout (app didn't crash

--- a/packages/test/src/utils/appium.ts
+++ b/packages/test/src/utils/appium.ts
@@ -350,10 +350,11 @@ export async function createSession(
   // circuit breaker: if the app already crashed on launch earlier in this run,
   // it is not going to launch now either. fail instantly instead of relaunching
   // a known-broken bundle across every remaining test.
-  const recordedCrash = getRecordedCrash()
-  if (recordedCrash) {
+  if (getRecordedCrash()) {
+    // keep this short — the full crash diagnostics were already logged by the
+    // first failure. repeating them for every skipped test floods the log.
     throw new AppCrashedError(
-      `app already crashed on launch earlier in this run — skipping session to avoid burning the CI budget.\nfirst crash:\n${recordedCrash}`
+      `app already crashed on launch earlier in this run (see first failure for the crash log) — skipping to save CI time`
     )
   }
 
@@ -410,16 +411,15 @@ function dumpSimulatorCrashLog(config: WebdriverIOConfig): string | null {
 
   const parts: string[] = []
 
-  // relaunch the app attached to a console — the real JS/Hermes fatal (e.g.
-  // "Wrong bytecode version. Expected 96 but got 98") prints to the app's
-  // stdout/stderr, which `log show` does not capture. the app crashes
-  // immediately on launch, so this returns right away.
+  // relaunch the app attached to a console — a JS/Hermes fatal (e.g. "Wrong
+  // bytecode version") prints to the app's stdout/stderr, which `log show` does
+  // not capture. the app crashes on launch, so this returns right away.
   try {
     execSync(`xcrun simctl terminate ${udid} ${bundleId} 2>/dev/null || true`, {
       timeout: 10_000,
     })
     const console = execSync(
-      `xcrun simctl launch --console-pty ${udid} ${bundleId} 2>&1 | head -40`,
+      `xcrun simctl launch --console-pty ${udid} ${bundleId} 2>&1 | head -200`,
       { timeout: 30_000, encoding: 'utf8' }
     )
     const trimmed = console.trim()
@@ -431,18 +431,44 @@ function dumpSimulatorCrashLog(config: WebdriverIOConfig): string | null {
     if (out) parts.push('app console on relaunch:\n' + String(out).trim())
   }
 
-  // system-level fallback (crash reporter / signals)
+  // the real reason for a *native* crash (segfault/abort, no JS exception
+  // printed) lives in the crash report, not the console. grab the newest one.
+  const ips = readLatestCrashReport()
+  if (ips) parts.push('crash report:\n' + ips)
+
+  // system-level fallback (signals / runningboard kills)
   try {
     const log = execSync(
       `xcrun simctl spawn ${udid} log show --predicate 'process == "RNTestContainer" OR subsystem == "com.apple.CrashReporter"' --last 60s --style compact 2>/dev/null || true`,
       { timeout: 15_000, encoding: 'utf8' }
     )
     const trimmed = log.trim()
-    if (trimmed) parts.push('simulator log:\n' + trimmed)
+    if (trimmed) parts.push('simulator log:\n' + trimmed.slice(0, 2000))
   } catch {}
 
   const out = parts.join('\n\n')
-  return out ? out.slice(0, 6000) : null
+  return out ? out.slice(0, 9000) : null
+}
+
+/** read the newest RNTestContainer crash report (.ips) written by the OS. */
+function readLatestCrashReport(): string | null {
+  const dir = path.join(os.homedir(), 'Library', 'Logs', 'DiagnosticReports')
+  try {
+    const reports = fs
+      .readdirSync(dir)
+      .filter((f) => f.startsWith('RNTestContainer') && f.endsWith('.ips'))
+      .map((f) => {
+        const full = path.join(dir, f)
+        return { full, mtime: fs.statSync(full).mtimeMs }
+      })
+      .sort((a, b) => b.mtime - a.mtime)
+    if (!reports.length) return null
+    // .ips files are large json — the crash reason + faulting thread is at the
+    // top, so the first chunk is what matters.
+    return fs.readFileSync(reports[0].full, 'utf8').slice(0, 4000)
+  } catch {
+    return null
+  }
 }
 
 async function recoverSimulator(config: WebdriverIOConfig) {

--- a/packages/vxrn/src/patches/builtInDepPatches.ts
+++ b/packages/vxrn/src/patches/builtInDepPatches.ts
@@ -631,6 +631,46 @@ export const addCustomSourceTransformer = resolveAssetSource.addCustomSourceTran
       },
     },
   },
+
+  // a void TurboModule method that throws an Obj-C NSException crashes the app
+  // with a SIGSEGV: ObjCTurboModule::performVoidMethodInvocation converts it to
+  // a JS error (convertNSExceptionToJSError) on the TurboModule method queue,
+  // which touches the Hermes runtime off the JS thread and corrupts the
+  // single-threaded VM. only safe to build the JS error when the method runs
+  // sync (on the JS thread); otherwise log. mirrors the isSync guard added for
+  // value-returning methods in facebook/react-native#50193 (which never covered
+  // the void path). see tests/test/IOS_PROD_CRASH.md
+  {
+    module: 'react-native',
+    patchFiles: {
+      version: '>=0.81.0',
+
+      'ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm':
+        (contents) => {
+          if (!contents) return
+          return contents.replace(
+            `    @try {
+      [inv invokeWithTarget:strongModule];
+    } @catch (NSException *exception) {
+      throw convertNSExceptionToJSError(runtime, exception, std::string{moduleName}, methodNameStr);
+    } @finally {`,
+            `    @try {
+      [inv invokeWithTarget:strongModule];
+    } @catch (NSException *exception) {
+      if (shouldVoidMethodsExecuteSync_) {
+        // sync void methods run on the JS thread — safe to build the JS error.
+        throw convertNSExceptionToJSError(runtime, exception, std::string{moduleName}, methodNameStr);
+      } else {
+        // async void methods run on the TurboModule method queue; building a JS
+        // error here touches the Hermes runtime off the JS thread and corrupts
+        // the VM (SIGSEGV). there is no JS caller to receive it, so log instead.
+        RCTLogError(@"Exception in %s.%s: %@", moduleName, methodNameStr.c_str(), exception.reason);
+      }
+    } @finally {`
+          )
+        },
+    },
+  },
 ]
 
 function addNoCheck(contents?: string) {

--- a/tests/test/IOS_PROD_CRASH.md
+++ b/tests/test/IOS_PROD_CRASH.md
@@ -1,9 +1,14 @@
-# iOS prod (Release/Hermes) launch crash — root cause & fix
+# iOS prod (Release/Hermes) — launch crash & blank loader routes
 
-Status: **fixed** via a `react-native` patch in
-`packages/vxrn/src/patches/builtInDepPatches.ts` (applied by `one prebuild`).
-prod (metro) is gating again; only the experimental `rolldown:prod` stays
+Two independent prod-native bugs, both **fixed**. prod (metro) is gating again
+and passes 10/10 locally; only the experimental `rolldown:prod` stays
 `continue-on-error`.
+
+1. **Launch crash (SIGSEGV)** — fixed via a `react-native` patch in
+   `packages/vxrn/src/patches/builtInDepPatches.ts` (applied by `one prebuild`).
+2. **Blank loader routes ("prod white screen")** — fixed in
+   `packages/one/src/useLoader.ts` (static `getURL` import). Was hidden behind
+   the crash; only visible once the app could launch.
 
 ## Symptom
 
@@ -97,6 +102,26 @@ Follow-up (optional): identify which native module's void method throws at
 startup (the NSException reason isn't in the crash report). A one-line probe in
 the patched `else` branch logging `exception.name`/`reason` would name it, so it
 can also be fixed/​upstreamed at the source.
+
+## Bug 2: blank loader routes ("prod white screen")
+
+Once the crash was fixed and the app could launch, every route with a loader
+rendered One's error boundary instead of content:
+
+```
+Error on route "index": TypeError: Cannot read property 'getURL' of undefined
+```
+
+Root cause: `useLoader.ts`'s prod-native loader path used a **dynamic**
+`require('./getURL')`. Metro only rewrites `require()` to a numeric module id
+when it can resolve it statically; here it was left as a literal runtime
+`require("./getURL")`, and metro's runtime `require` only accepts numeric ids —
+so it returned `undefined`, and `.getURL` on undefined threw, crashing the
+route (caught by the error boundary → blank). Static `getURL` imports elsewhere
+in One compile to proper module refs and work fine.
+
+Fix: use the static `import { getURL } from './getURL'` like the rest of One.
+This was a pre-existing bug, hidden because the app always crashed first.
 
 ## Harness change (done)
 

--- a/tests/test/IOS_PROD_CRASH.md
+++ b/tests/test/IOS_PROD_CRASH.md
@@ -1,0 +1,84 @@
+# iOS prod (Release/Hermes) launch crash — root cause
+
+Status: **open, quarantined** in `.github/workflows/test-native-ios.yml`
+(prod matrix entries are `continue-on-error`). dev tests pass and stay gating.
+
+## Symptom
+
+The Release build of `rn-test-container` (Hermes bytecode bundle) **crashes on
+launch, before any test runs**. Under Appium this surfaces as
+`The application under test ... is not running, possibly crashed`. It had been
+silently burning the whole 45-min job budget and showing up as a **cancelled**
+run (looks like infra flake) on every `main` push. The test harness now fails
+these jobs fast (~10m) — see "Harness change" below.
+
+This is **not** a bytecode version mismatch. In CI the v98 bundle loads fine
+(`ReactInstance: evaluateJavaScript() with JS bundle` runs, MMKV initializes),
+then the process dies. (A local repro can hit a *separate* "Wrong bytecode
+version. Expected 96 but got 98" error if you compile the bundle with a hermesc
+whose version doesn't match the app's Hermes — that's a stale-local-env artifact,
+not this bug.)
+
+## Root cause — concurrent Hermes access (SIGSEGV)
+
+From the simulator crash report (`SIGSEGV` / `EXC_BAD_ACCESS` at `0x12`):
+
+- Crashed thread = `com.meta.react.turbomodulemanager.queue`:
+  ```
+  _dispatch_lane_serial_drain
+  → ObjCTurboModule::performVoidMethodInvocation
+  → TurboModuleConvertUtils::convertNSExceptionToJSError(jsi::Runtime&, NSException*, ...)
+  → jsi::Object::setProperty → HermesRuntimeImpl::setPropertyValue
+  → hermes putComputedWithReceiver_RJS → addOwnProperty → raisePlaceholder
+  → JSError::setMessage → toString_RJS → HiddenClass::findProperty   ← SIGSEGV
+  ```
+- At the same instant the JS thread (`com.facebook.react.runtime.JavaScript`)
+  is also executing in Hermes (`hermes::vm::objectAssign` → putComputed…).
+
+Two threads are inside the **single-threaded** Hermes VM at once → heap
+corruption → segfault.
+
+Chain of events:
+1. During startup a **TurboModule void method throws an Obj-C `NSException`**
+   (occurs right after `react-native-mmkv` creates its instance — note the
+   logged `Path:` is empty).
+2. RN's `ObjCTurboModule::performVoidMethodInvocation` catches it and calls
+   `convertNSExceptionToJSError`, which **builds a JS Error object via the
+   Hermes `jsi::Runtime` on the TurboModule method queue thread**, not the JS
+   thread, with no synchronization against the running JS thread.
+3. Concurrent Hermes mutation → SIGSEGV.
+
+The proximate bug is upstream **React Native** (off-JS-thread Hermes access in
+the ObjC TurboModule exception path). The trigger is whichever native module's
+void method raises during init.
+
+## Reproduce locally
+
+```sh
+cd tests/test
+export SIMULATOR_UDID=<booted iOS 18 iPhone 16 Pro udid>
+export IOS_TEST_CONTAINER_PATH_PROD=<path to a Release RNTestContainer.app>
+# use a hermesc whose bytecode version matches the app's Hermes runtime
+export HERMESC_PATH=<matching hermesc>
+TEST_ONLY=prod TEST_ENV=prod npx vitest --config ./vitest.config.ios.ts --run basic.test.ios
+```
+
+The harness relaunches the crashed app with `--console-pty` and dumps the
+newest `~/Library/Logs/DiagnosticReports/RNTestContainer-*.ips` so the failure
+is self-explaining. (Debugger attach to the sim app is blocked in the sandboxed
+CI/dev environment, so the `.ips` crash report is the primary signal.)
+
+## Fix direction (unresolved)
+
+1. Stop the native module from throwing during init (treats the trigger), or
+2. Patch RN's `ObjCTurboModule` exception path to marshal
+   `convertNSExceptionToJSError` onto the JS thread (fixes the real bug;
+   upstream or via patch-package).
+
+## Harness change (done)
+
+`packages/test/src/utils/appium.ts`: `createSession` no longer retries an
+`AppCrashedError` (a crash-on-launch is deterministic), and a filesystem
+circuit breaker fails every subsequent session in the run instantly once the
+app is confirmed to crash — so a crashing prod build fails fast and honestly
+instead of cancelling at the 45-min timeout.

--- a/tests/test/IOS_PROD_CRASH.md
+++ b/tests/test/IOS_PROD_CRASH.md
@@ -1,7 +1,9 @@
-# iOS prod (Release/Hermes) launch crash — root cause
+# iOS prod (Release/Hermes) launch crash — root cause & fix
 
-Status: **open, quarantined** in `.github/workflows/test-native-ios.yml`
-(prod matrix entries are `continue-on-error`). dev tests pass and stay gating.
+Status: **fixed** via a `react-native` patch in
+`packages/vxrn/src/patches/builtInDepPatches.ts` (applied by `one prebuild`).
+prod (metro) is gating again; only the experimental `rolldown:prod` stays
+`continue-on-error`.
 
 ## Symptom
 
@@ -68,12 +70,33 @@ newest `~/Library/Logs/DiagnosticReports/RNTestContainer-*.ips` so the failure
 is self-explaining. (Debugger attach to the sim app is blocked in the sandboxed
 CI/dev environment, so the `.ips` crash report is the primary signal.)
 
-## Fix direction (unresolved)
+## Fix (applied)
 
-1. Stop the native module from throwing during init (treats the trigger), or
-2. Patch RN's `ObjCTurboModule` exception path to marshal
-   `convertNSExceptionToJSError` onto the JS thread (fixes the real bug;
-   upstream or via patch-package).
+Patched `ObjCTurboModule::performVoidMethodInvocation` in
+`react-native/ReactCommon/.../RCTTurboModule.mm` via
+`packages/vxrn/src/patches/builtInDepPatches.ts`: only call
+`convertNSExceptionToJSError` (which touches the jsi/Hermes runtime) when the
+void method runs **sync** on the JS thread (`shouldVoidMethodsExecuteSync_`);
+otherwise log the exception and continue. An async void method has no JS caller
+to receive the error, so there is nothing to convert — building the JS Error on
+the method queue was pure corruption. This mirrors the `isSync` guard upstream
+RN added for value-returning methods in
+[facebook/react-native#50193](https://github.com/facebook/react-native/pull/50193),
+which never covered the void path (still unfixed through ≥0.83.2; see RN issues
+#55337, #54859, #53960).
+
+This also protects real shipping One apps (Hermes-V1 Release) from the same
+launch crash whenever any native module's void method throws during startup.
+
+`one prebuild` applies `builtInDepPatches` before pod install, so the patch
+compiles into the app. The app build cache key
+(`build-ios-test-container-app.yml`) includes `builtInDepPatches.ts` so patch
+changes correctly rebuild the app.
+
+Follow-up (optional): identify which native module's void method throws at
+startup (the NSException reason isn't in the crash report). A one-line probe in
+the patched `else` branch logging `exception.name`/`reason` would name it, so it
+can also be fixed/​upstreamed at the source.
 
 ## Harness change (done)
 


### PR DESCRIPTION
## Summary
- make iOS Appium launch crashes fail fast with useful simulator/crash diagnostics
- patch React Native's async void TurboModule exception path to avoid off-thread Hermes access in Release/Hermes builds
- fix native prod loader routes by using the static `getURL` import Metro can resolve
- keep only experimental `prod/rolldown` non-blocking; prod/metro is gating and green again
- include the existing native `useBlocker` swipe-back guard fix already on this branch

## Validation
- iOS Native Tests workflow on latest head `31200ffb`: success
  - Build iOS RN Test App (Dev): success
  - Build iOS RN Test App (Prod): success
  - Native iOS Tests (dev, metro): success
  - Native iOS Tests (dev, rolldown): success
  - Native iOS Tests (prod, metro): success
  - Native iOS Tests (prod, rolldown): success
- local `bun run --filter one typecheck`: success
- local `bun run --filter @vxrn/test typecheck`: success
