### PR TITLE
fix(one): use a named pipe for the daemon IPC socket on Windows

### DIFF
--- a/packages/one/src/daemon/ipc.ts
+++ b/packages/one/src/daemon/ipc.ts
@@ -4,6 +4,7 @@ import * as net from 'node:net'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import { createHash } from 'node:crypto'
 import type { IPCMessage, IPCResponse, DaemonState } from './types'
 import {
   registerServer,
@@ -18,8 +19,31 @@ import {
 } from './registry'
 
 const SOCKET_DIR = path.join(os.homedir(), '.one')
-const SOCKET_PATH = path.join(SOCKET_DIR, 'daemon.sock')
 const SERVERS_FILE = path.join(SOCKET_DIR, 'servers.json')
+
+/**
+ * Resolve the daemon IPC endpoint for the current platform.
+ *
+ * Node's `net` implements local IPC as a Unix domain socket on POSIX and a named
+ * pipe on Windows — the same `listen(path)`/`connect(path)` API, but on Windows
+ * the name must live under `\\.\pipe\` (a flat, machine-global namespace) rather
+ * than the filesystem. So we select each platform's native primitive: an AF_UNIX
+ * socket file inside the owner-only `~/.one` dir on POSIX, a named pipe on
+ * Windows. The Windows name is a deterministic per-user hash so the daemon and
+ * the CLI derive the same pipe independently, and so distinct users on one
+ * machine don't collide in the shared pipe namespace.
+ *
+ * @see https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections
+ */
+function resolveSocketPath(): string {
+  if (process.platform === 'win32') {
+    const scope = createHash('sha256').update(SOCKET_DIR).digest('hex').slice(0, 8)
+    return path.win32.join(String.raw`\\.\pipe`, `one-daemon-${scope}`)
+  }
+  return path.join(SOCKET_DIR, 'daemon.sock')
+}
+
+const SOCKET_PATH = resolveSocketPath()
 
 export function getSocketPath(): string {
   return SOCKET_PATH
@@ -124,9 +148,24 @@ export function createIPCServer(
     })
   })
 
+  // surface a bind failure as an actionable message rather than an uncaught
+  // 'error' event that crashes the process (e.g. another daemon already owns the
+  // socket/pipe).
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`[daemon] Another daemon is already listening at ${SOCKET_PATH}`)
+    } else {
+      console.error('[daemon] IPC server error:', err.message)
+    }
+    process.exit(1)
+  })
+
   server.listen(SOCKET_PATH, () => {
-    // owner-only permissions for security
-    fs.chmodSync(SOCKET_PATH, 0o600)
+    // owner-only permissions on POSIX; the Windows named pipe is not a filesystem
+    // entry, so chmod does not apply there (and would throw).
+    if (process.platform !== 'win32') {
+      fs.chmodSync(SOCKET_PATH, 0o600)
+    }
   })
 
   return server
@@ -205,7 +244,10 @@ function handleMessage(
 
 export async function isDaemonRunning(): Promise<boolean> {
   return new Promise((resolve) => {
-    if (!fs.existsSync(SOCKET_PATH)) {
+    // On POSIX a stale socket file may linger, so a cheap existence check avoids a
+    // needless connect. On Windows the endpoint is a named pipe — not a filesystem
+    // entry — so existsSync is always false there; probe by connecting instead.
+    if (process.platform !== 'win32' && !fs.existsSync(SOCKET_PATH)) {
       resolve(false)
       return
     }


### PR DESCRIPTION
## Summary

`one daemon` crashes immediately on Windows. The CLI↔daemon control channel binds a local socket with `net.Server.listen(SOCKET_PATH)`, where `SOCKET_PATH` is `~/.one/daemon.sock`. On Windows, Node implements local-domain sockets as **named pipes**, and the path must live under `\\.\pipe\` — so a filesystem `.sock` path is rejected with `EACCES`. Because `createIPCServer` had no `server.on('error')` handler, that surfaced as an uncaught `'error'` event and crashed the command on start:

```
Error: listen EACCES: permission denied C:\Users\…\.one\daemon.sock
    at createIPCServer (packages/one/src/daemon/ipc.ts)
    at startDaemon       (packages/one/src/daemon/server.ts)
    code: 'EACCES', syscall: 'listen'
```

## Fix

Select each platform's native local-IPC primitive behind one helper, keeping the existing hand-rolled `net` server and the owner-only model:

```ts
function resolveSocketPath(): string {
  if (process.platform === 'win32') {
    const scope = createHash('sha256').update(SOCKET_DIR).digest('hex').slice(0, 8)
    return path.win32.join(String.raw`\\.\pipe`, `one-daemon-${scope}`)
  }
  return path.join(SOCKET_DIR, 'daemon.sock')
}
```

- **POSIX is unchanged** — the AF_UNIX socket at `~/.one/daemon.sock`, still `chmod 0600` (now guarded, since `chmod` doesn't apply to a Windows pipe). The `else` branch is the original code path.
- **Windows** uses a named pipe. The name is a deterministic per-user hash so the daemon and the independently-launched CLI derive the same pipe, and distinct users don't collide in the machine-global pipe namespace.
- `isDaemonRunning` no longer pre-checks `fs.existsSync(SOCKET_PATH)` on Windows (a named pipe is not a filesystem entry, so the check always returned false and the daemon read as "not running"); it probes by connecting.
- Added a `server.on('error')` handler so a bind failure reports an actionable message instead of crashing.

This is the standard approach for a fixed-name local daemon socket — keep the socket, pick the OS-native primitive. It matches Node's own `net` docs ("On Windows, the local domain is implemented using a named pipe … the path must refer to an entry in `\\?\pipe\` or `\\.\pipe\`"), Nuxt (`packages/vite/src/plugins/vite-node.ts`), the OpenSSH agent (`$SSH_AUTH_SOCK` ↔ `\\.\pipe\openssh-ssh-agent`), VS Code (`createStaticIPCHandle`), Nx, and pm2.

## Test plan

Validated on Windows 11 (Node 25):

- **Before:** `one daemon` → uncaught `EACCES` on `listen ~/.one/daemon.sock`.
- **After:** the named-pipe endpoint binds and round-trips (the daemon's `ping`/`pong`) where the `.sock` path failed.
- `oxlint` and `oxfmt --check` clean on the changed file; `tsc --noEmit` reports no errors in it.
- POSIX behaviour is unchanged by construction — its branch is the original path, and on Linux the resolved endpoint and permissions are identical to before this change.

## CI

Both the `checks` and `tests` jobs pass on `main` (v1.21.0). (An earlier revision of this note flagged a repo-wide `hono <4.12.25` advisory reddening `checks`; that was cleared upstream by the `hono` → 4.12.25 bump.)

