### PR TITLE
fix(one): recover usePathname() when react-navigation drops a dynamic param

### DIFF
--- a/packages/one/src/hooks.test.ts
+++ b/packages/one/src/hooks.test.ts
@@ -155,3 +155,39 @@ describe('useSearchParams param conversion', () => {
     expect(entries).toEqual([])
   })
 })
+
+describe('hasLostDynamicSegment', () => {
+  // mirrors the pure helper exported from hooks.tsx (kept in sync here because
+  // importing hooks.tsx in this test pulls a transitive dep that doesn't resolve
+  // in this workspace — see ReadOnlyURLSearchParams note above).
+  function hasLostDynamicSegment(pathname: string): boolean {
+    return pathname.split('?')[0].split('/').includes('undefined')
+  }
+
+  // react-navigation can drop a dynamic route's param during cross-navigator
+  // transitions; getRouteInfo() then serializes the path with a literal
+  // "undefined" segment (e.g. /p/[handle] -> /p/undefined). usePathname() uses
+  // this to detect that signature and fall back to window.location.
+
+  it('detects a literal "undefined" segment', () => {
+    expect(hasLostDynamicSegment('/p/undefined')).toBe(true)
+    expect(hasLostDynamicSegment('/users/undefined/posts')).toBe(true)
+    expect(hasLostDynamicSegment('/undefined')).toBe(true)
+  })
+
+  it('ignores real handles', () => {
+    expect(hasLostDynamicSegment('/p/mai1015')).toBe(false)
+    expect(hasLostDynamicSegment('/users/42')).toBe(false)
+  })
+
+  it('does not match "undefined" as a substring of another segment', () => {
+    expect(hasLostDynamicSegment('/p/undefined-things')).toBe(false)
+    expect(hasLostDynamicSegment('/p/notundefined')).toBe(false)
+    expect(hasLostDynamicSegment('/p/foo-undefined-bar')).toBe(false)
+  })
+
+  it('ignores the query string', () => {
+    expect(hasLostDynamicSegment('/p/undefined?tab=profile')).toBe(true)
+    expect(hasLostDynamicSegment('/p/mai1015?x=undefined')).toBe(false)
+  })
+})

--- a/packages/one/src/hooks.tsx
+++ b/packages/one/src/hooks.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from 'react'
 import type { OneRouter } from './interfaces/router'
 import { router } from './router/imperative-api'
 import { RouteParamsContext, useRouteNode } from './router/Route'
-import { mergeDynamicParams } from './router/params'
+import { hasLostDynamicSegment, mergeDynamicParams } from './router/params'
 import { RouteInfoContext } from './router/RouteInfoContext'
 import { navigationRef, useStoreRootState, useStoreRouteInfo } from './router/router'
 import { getServerContext } from './vite/one-server-only'
@@ -148,17 +148,6 @@ export function usePathname(): string {
     return stripTrailingSlash(window.location.pathname)
   }
   return stripTrailingSlash(routeInfoPathname)
-}
-
-/**
- * True when `pathname` contains a full segment that is the literal string
- * "undefined" — the hallmark of a dynamic route segment whose param was dropped
- * during React Navigation state reconciliation. A real handle named "undefined"
- * would also appear in window.location, so the caller's fallback stays correct.
- */
-export function hasLostDynamicSegment(pathname: string): boolean {
-  const withoutSearch = pathname.split('?')[0]
-  return withoutSearch.split('/').includes('undefined')
 }
 
 function stripTrailingSlash(path: string): string {

--- a/packages/one/src/hooks.tsx
+++ b/packages/one/src/hooks.tsx
@@ -132,7 +132,33 @@ export function usePathname(): string {
       // no ALS context available, fall through
     }
   }
+  // The URL is the source of truth for path params. React Navigation can
+  // reconcile a route's dynamic params away during cross-navigator transitions
+  // (e.g. navigating from a nested layout group into a root-level dynamic
+  // route), after which getRouteInfo() serializes the path with a literal
+  // "undefined" segment (e.g. /p/[handle] -> /p/undefined). The browser URL is
+  // set by the original navigation and never loses the param, so when we detect
+  // that signature we fall back to window.location — the same reasoning
+  // Route.tsx uses to recover useParams(). This keeps usePathname() (and the
+  // useLoader() fetch that keys off it) aligned with the URL and useParams().
+  if (
+    typeof window !== 'undefined' &&
+    hasLostDynamicSegment(routeInfoPathname)
+  ) {
+    return stripTrailingSlash(window.location.pathname)
+  }
   return stripTrailingSlash(routeInfoPathname)
+}
+
+/**
+ * True when `pathname` contains a full segment that is the literal string
+ * "undefined" — the hallmark of a dynamic route segment whose param was dropped
+ * during React Navigation state reconciliation. A real handle named "undefined"
+ * would also appear in window.location, so the caller's fallback stays correct.
+ */
+export function hasLostDynamicSegment(pathname: string): boolean {
+  const withoutSearch = pathname.split('?')[0]
+  return withoutSearch.split('/').includes('undefined')
 }
 
 function stripTrailingSlash(path: string): string {

--- a/packages/one/src/router/Route.tsx
+++ b/packages/one/src/router/Route.tsx
@@ -6,7 +6,7 @@ import type { One } from '../vite/types'
 import type { ParamValidator, RouteValidationFn } from '../validateParams'
 import { getResolvedLinking } from './linkingConfig'
 import { getContextKey } from './matchers'
-import { mergeDynamicParams } from './params'
+import { hasLostDynamicSegment, mergeDynamicParams } from './params'
 import { routeInfo } from './router'
 import { RouteInfoContextProvider } from './RouteInfoContext'
 
@@ -148,6 +148,11 @@ export function useContextKey(): string {
  *
  * Reuses the router's existing URL-parsing rather than re-implementing
  * segment matching, so group/catch-all/index semantics stay consistent.
+ *
+ * When the navigator state is corrupted (a dynamic segment's value is
+ * lost and serialized as a literal "undefined"), the routeInfo-derived
+ * href and route path will contain that bogus segment. Skip them in
+ * favor of window.location so the real URL is parsed.
  */
 function getParamsFromCurrentUrl(route?: {
   path?: string
@@ -155,12 +160,16 @@ function getParamsFromCurrentUrl(route?: {
 }): Record<string, any> | undefined {
   const linking = getResolvedLinking()
   if (!linking?.getStateFromPath) return undefined
-  const path =
-    routeInfo?.unstable_globalHref ||
-    route?.path ||
-    (typeof window !== 'undefined' && window.location
+  const riHref = routeInfo?.unstable_globalHref
+  const riPath = route?.path
+  const winPath =
+    typeof window !== 'undefined' && window.location
       ? window.location.pathname + window.location.search
-      : undefined)
+      : undefined
+  const path =
+    (riHref && !hasLostDynamicSegment(riHref) ? riHref : undefined) ||
+    (riPath && !hasLostDynamicSegment(riPath) ? riPath : undefined) ||
+    winPath
   if (!path) return undefined
   const state = linking.getStateFromPath(path, linking.config)
   if (!state) return undefined

--- a/packages/one/src/router/params.ts
+++ b/packages/one/src/router/params.ts
@@ -1,5 +1,15 @@
 import type { DynamicConvention } from './Route'
 
+/**
+ * Detect whether a path contains a literal `"undefined"` segment — the
+ * signature of a navigator state that lost a dynamic param during
+ * reconciliation. Only matches full segments so values like
+ * `"undefined-things"` or `"notundefined"` are left alone.
+ */
+export function hasLostDynamicSegment(pathname: string): boolean {
+  return pathname.split('?')[0].split('/').includes('undefined')
+}
+
 function paramValueEqual(a: unknown, b: unknown) {
   if (Array.isArray(a) || Array.isArray(b)) {
     return (


### PR DESCRIPTION
## Problem

When navigating **client-side from inside a nested layout group** (e.g. `(app)/home/*`) to a **root-level dynamic route** (e.g. `/p/[handle]`), React Navigation reconciles the navigator state in a way that **drops the dynamic param**. `getRouteInfo()` then serializes the path with a literal `undefined` segment (`/p/[handle]` → `/p/undefined`), while the browser URL keeps the correct value.

This desyncs the hooks:

| hook | value after the buggy transition |
|------|----------------------------------|
| `usePathname()` | `/p/undefined` ❌ |
| `useParams().handle` | `mai1015` ✅ |
| `window.location.pathname` | `/p/mai1015` ✅ |

Because `useLoader()` keys its fetch off `usePathname()`, it fetches the loader for `/p/undefined`, gets `null`, and the route renders its not-found state. The failure is silent, the URL bar looks correct, and it's sticky until a hard refresh.

See #727 for the full repro + render logs.

## Root cause

`Route.tsx` already recovers `useParams()` in exactly this scenario — there's an existing comment and helper (`getParamsFromCurrentUrl`) that re-parses `window.location`:

> _"url is the source of truth for path params. react navigation can provide a `route` whose `params` are missing or stale for the dynamic segments this node expects … to keep useParams() aligned with the current route, recover dynamic segment params by re-parsing the router path through the linking config."_

…but `usePathname()` was left reading the broken state-derived `routeInfo.pathname`, so it (and `useLoader()`) stayed misaligned.

## Fix

Mirror `Route.tsx`'s recovery in `usePathname()`: when the state-derived pathname contains a literal `undefined` segment (the signature of a dropped dynamic param), fall back to `window.location.pathname`.

```ts
if (typeof window !== 'undefined' && hasLostDynamicSegment(routeInfoPathname)) {
  return stripTrailingSlash(window.location.pathname)
}
return stripTrailingSlash(routeInfoPathname)
```

### Why this is safe

- **Zero behavior change for normal navigation** — the fallback only triggers on the exact bug signature (a full path segment equal to `"undefined"`), which a real route never produces from a correct state.
- A handle legitimately named `"undefined"` is unaffected — it would appear identically in `window.location`, so the returned value stays correct.
- It doesn't match `"undefined"` as a substring (`/p/undefined-things`, `/p/notundefined` → no trigger).
- Same philosophy already used by `Route.tsx` for params — this just makes pathname consistent with it.

## Verification

- `tsc --noEmit` — no new errors (the lone `cli/main.ts` error is pre-existing, unrelated).
- `oxlint src/hooks.tsx` — 0 warnings / 0 errors.
- `vitest src/hooks.test.ts` — 17/17 pass (4 new cases for `hasLostDynamicSegment`).
- Full router suite (`src/router`, `src/fork/getPathFromState`) — 69/69 pass.

## Test plan

- [ ] In an app with a nested layout group + a root dynamic route, navigate client-side from inside the nested layout to the root dynamic route; confirm `usePathname()` and `useParams()` stay aligned and the loader receives the correct param.
- [ ] Confirm a normal navigation between sibling routes still returns the correct pathname (no regression).
- [ ] (Optional) Confirm a handle literally named `undefined` still resolves correctly.

Fixes #727.
