### PR TITLE
fix(one): use FSExtra.remove for static-dir teardown (rm not promise-safe across fs-extra versions)

### DIFF
--- a/packages/one/src/cli/build.ts
+++ b/packages/one/src/cli/build.ts
@@ -1251,7 +1251,7 @@ export async function build(args: {
 
   // once done building static we can move it to client dir:
   await moveAllFiles(staticDir, clientDir)
-  await FSExtra.rm(staticDir, { force: true, recursive: true })
+  await FSExtra.remove(staticDir)
 
   // write out the static paths (pathname => html) for the server
   const routeMap: Record<string, string> = {}


### PR DESCRIPTION
## Summary

Small consistency + robustness fix to `one build`'s teardown. `build.ts` deletes the temp static dir with `FSExtra.rm(...)` — the file's only `.rm` call; every other temp-path teardown here already uses `FSExtra.remove(...)`. Beyond the inconsistency, `FSExtra.rm` isn't promise-safe across every `fs-extra` a consumer's tree can resolve, so under a shadowed install it can crash teardown (exit 1) *after* `dist/` is already written.

## Root cause

`build.ts` removes the temp `staticDir` with:

```ts
await FSExtra.rm(staticDir, { force: true, recursive: true })
```

`fs-extra` only universalifies (callback-or-promise) the methods in its `lib/fs/index.js` `api` list, and that list changed across majors: **fs-extra ≥ 11 universalifies `rm`** (promise-safe), but **fs-extra 8/9/10 do not** — there `FSExtra.rm` is the raw graceful-fs `fs.rm` passthrough. Awaiting that with no callback lets the threadpool completion invoke an `undefined` callback → `TypeError: callback is not a function` thrown asynchronously in `node:internal/fs/rimraf` → escapes the awaited chain → uncaught → `process.exit(1)`, after `dist/` is already written.

`one` declares `fs-extra: ^11.2.0`, so a **normal** install resolves a safe 11.x for `one` and this never fires — which is why CI is green. The crash requires an install where an **older `fs-extra` shadows one's copy** (e.g. `@react-native-community/cli` pins `fs-extra@8`; in a layout where that resolves ahead of one's nested 11.x, `one` loads the 8.x `rm`). So it isn't universal — but `one` can't guarantee its own resolution in a consumer's tree, and shouldn't need to for a plain recursive delete.

## Fix

Use `FSExtra.remove`, which is **already this file's idiom** for temp-path teardown (e.g. `FSExtra.remove(workerSrcPath)` / `FSExtra.remove(wranglerInputPath)` later in the same file) — this aligns the lone `.rm` outlier:

```ts
await FSExtra.remove(staticDir)
```

Semantically identical — fs-extra `remove` is `fs.rm(path, { recursive: true, force: true })` under the hood — and unconditionally promise-safe on **every** fs-extra major, so teardown no longer depends on which `fs-extra` a consumer resolves.

## Test plan

- `build:web` (static output) exit code **1 → 0** on a tree resolving fs-extra 8.x; `dist/` complete in both cases (the crash is post-write).
- Deterministic mechanism check (both fs-extra shapes): `FSExtra.rm(dir, { force, recursive })` crashes on 8.1.0, ok on 11.3.x; `FSExtra.remove(dir)` ok on both.

## Notes

Primary value is consistency (aligning the lone `.rm` outlier to the file's `remove` idiom); the cross-version robustness is the secondary win. Not OS-specific — it's fs-extra-version-specific — though it surfaced on a Windows RN install. This is **not** "fs-extra doesn't promisify `rm`" (11.x does); it's "`FSExtra.rm` isn't promise-safe across all *resolvable* fs-extra installs, and `FSExtra.remove` already is."
