### PR TITLE
fix(compiler): make the reanimated ignore-list regex separator-agnostic (Windows)

### DIFF
--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -301,7 +301,9 @@ ${rootJS.code}
       enforce: 'pre',
 
       config: () => {
-        const nodeModulesFilter = /node_modules\/.*\.(tsx?|jsx?|mjs|cjs)$/
+        // accept either separator: optimizeDeps hands OS-native ids, so a
+        // forward-slash-only match dropped every node_modules file on Windows
+        const nodeModulesFilter = /node_modules[/\\].*\.(tsx?|jsx?|mjs|cjs)$/
 
         const createEnvironmentConfig = (environment: Environment) => {
           // init stats for this environment

--- a/packages/compiler/src/transformBabel.ts
+++ b/packages/compiler/src/transformBabel.ts
@@ -1,6 +1,7 @@
 import { extname, relative } from 'node:path'
 import babel from '@babel/core'
 import { resolvePath } from '@vxrn/utils'
+import { normalizePath } from 'vite'
 import { configuration } from './configure'
 import { asyncGeneratorRegex, debug } from './constants'
 import type { GetTransformProps, GetTransformResponse } from './types'
@@ -10,6 +11,12 @@ type Props = GetTransformProps & {
 }
 
 export function getBabelOptions(props: Props): babel.TransformOptions | null {
+  // Unify caller contracts (the Vite plugin hands POSIX ids; the native/patches
+  // path hands OS-native ids) so every path matcher below can assume forward
+  // slashes. Mirrors transformSWC.ts, which normalizes at its entry for the same
+  // reason — without it, RN's own files aren't matched on Windows.
+  props = { ...props, id: normalizePath(props.id.split('?')[0]) }
+
   if (props.userSetting === 'babel') {
     return getOptions(props, true)
   }
@@ -309,14 +316,11 @@ const REANIMATED_IGNORED_PATHS = [
   'node_modules/react-native-web/',
 ]
 
-// Accept either path separator: module `id`s are forward-slash from Vite but
-// backslash on native Windows. `replace(/\//g, '/')` was a no-op, so on Windows
-// the ignore list never matched react-native's own files and they were pushed
-// through the reanimated babel pass (which has no JSX/TS syntax) -> transform
-// errors. Mirrors SPEC_FILE_RE below, which already handles both separators.
-const REANIMATED_IGNORED_PATHS_REGEX = new RegExp(
-  REANIMATED_IGNORED_PATHS.map((s) => s.replace(/\//g, '[/\\\\]')).join('|')
-)
+// `id`s are normalized to forward slashes at getBabelOptions' entry, so these
+// plain forward-slash paths match on every OS. (Before that normalization the
+// backslash `id`s Windows hands us slipped past this list, pushing react-native's
+// own files through the reanimated babel pass — which has no JSX/TS parser.)
+const REANIMATED_IGNORED_PATHS_REGEX = new RegExp(REANIMATED_IGNORED_PATHS.join('|'))
 
 function shouldBabelReanimated({ code, id }: Props) {
   if (!configuration.enableReanimated) {

--- a/packages/compiler/src/transformBabel.ts
+++ b/packages/compiler/src/transformBabel.ts
@@ -309,8 +309,13 @@ const REANIMATED_IGNORED_PATHS = [
   'node_modules/react-native-web/',
 ]
 
+// Accept either path separator: module `id`s are forward-slash from Vite but
+// backslash on native Windows. `replace(/\//g, '/')` was a no-op, so on Windows
+// the ignore list never matched react-native's own files and they were pushed
+// through the reanimated babel pass (which has no JSX/TS syntax) -> transform
+// errors. Mirrors SPEC_FILE_RE below, which already handles both separators.
 const REANIMATED_IGNORED_PATHS_REGEX = new RegExp(
-  REANIMATED_IGNORED_PATHS.map((s) => s.replace(/\//g, '/')).join('|')
+  REANIMATED_IGNORED_PATHS.map((s) => s.replace(/\//g, '[/\\\\]')).join('|')
 )
 
 function shouldBabelReanimated({ code, id }: Props) {


### PR DESCRIPTION
## Summary

On Windows, the native dev server logs babel transform errors on react-native's own Animated files:

```
[vxrn:compiler] babel transform error SyntaxError:
  node_modules/react-native/Libraries/Animated/components/AnimatedScrollView.js:
  Support for the experimental syntax 'jsx' isn't currently enabled (14:12)
```

Non-fatal (it's caught and falls back), but it's wasted work + log noise on every Windows native dev run — and a symptom of a broader issue: `@vxrn/compiler` receives OS-native module ids while its path matchers assume forward slashes.

## Root cause — the compiler reads un-normalized ids

`getBabelOptions` decides which babel passes apply by matching the module `id` against several path patterns. The Vite plugin hands POSIX ids, but the native/patches path hands **backslash** ids (`…node_modules\react-native\…`) — and the matchers only understand `/`. So on Windows `REANIMATED_IGNORED_PATHS_REGEX` (built from forward-slash entries) never matches react-native's own files → they're pushed through the isolated reanimated babel pass (which has no JSX/TS parser) → the `SyntaxError` above.

The sibling transform in the same package already solved this — it normalizes the id **once at entry**, with documented intent (`packages/compiler/src/transformSWC.ts`):

```ts
// unify caller contracts (Vite plugin: POSIX id; patches.ts: native id)
id = normalizePath(id.split('?')[0]).replace(normalizePath(process.cwd()), '')
```

`transformBabel` never adopted that convention, so each of its regexes was left to cope on its own — and the reanimated one didn't.

## Fix — normalize once at the entry (adopt the sibling convention)

Normalize `id` at the top of `getBabelOptions`, mirroring `transformSWC`, so every downstream matcher (reanimated ignore-list, codegen spec/component, nativewind, compiler filters) can assume forward slashes:

```ts
props = { ...props, id: normalizePath(props.id.split('?')[0]) }
```

The reanimated regex then reverts to a plain forward-slash join — the separator handling is *removed*, not duplicated per-regex.

This also fixes a **same-class sibling bug** a narrow per-regex patch would leave behind: `packages/compiler/src/index.ts`'s optimizeDeps filter `/node_modules\/.*\.(tsx?|jsx?|mjs|cjs)$/` is likewise forward-slash-only, so on Windows it rejected **every** node_modules file and silently disabled the pre-bundle babel transform. Made separator-tolerant (`node_modules[/\\]`).

## Test plan

- **On device** (`one dev --clean`, Windows, Android emulator): **0** babel transform errors on RN's Animated files (was 2 per build); native still renders. This is behavior-changing (it changes which ids the matchers see), so a re-smoke on both OSes is worthwhile.
- The normalization is deterministic and OS-independent: afterward the ignore-list matches react-native's files for both `…/react-native/…` and `…\react-native\…` ids, while user code with worklet keywords still gets the reanimated pass.

## Notes

Structural, not a per-regex patch: it fixes the disease (the compiler read un-normalized ids) at the single funnel every matcher flows through, unifying the babel path with the SWC path's already-shipping convention. POSIX-safe on every host (POSIX ids are unaffected). No unit test: `@vxrn/compiler` has no test harness today and this entry pulls unbuilt workspace deps, so testing it would need new infrastructure plus a build-before-test step CI doesn't run — out of scope here; the behavior is covered on-device and mirrors the tested `transformSWC` normalization.
