### PR TITLE
fix(vxrn): include transform-classes in native dev bundles (Hermes)

### DIFF
--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getHermesSWCIncludes,
   getNativeTransformConfig,
   wrapNativeBundleModuleScope,
 } from './createNativeDevEngine'
@@ -64,5 +65,27 @@ describe('wrapNativeBundleModuleScope', () => {
   it('is a no-op when the runtime marker is absent (e.g. prod bundle)', () => {
     const input = 'var x = 1;\nconsole.log(x);\n'
     expect(wrapNativeBundleModuleScope(input)).toBe(input)
+  })
+})
+
+describe('getHermesSWCIncludes', () => {
+  const CLASS_SET = [
+    'transform-classes',
+    'transform-class-properties',
+    'transform-class-static-block',
+    'transform-private-methods',
+    'transform-private-property-in-object',
+  ]
+
+  it('always includes the full Hermes class-transform set (dev and prod)', () => {
+    // regression: transform-classes was missing in dev, leaving a half-transpiled
+    // class hierarchy Hermes crashes on at `new Subclass()`
+    expect(getHermesSWCIncludes(true)).toEqual(expect.arrayContaining(CLASS_SET))
+    expect(getHermesSWCIncludes(false)).toEqual(expect.arrayContaining(CLASS_SET))
+  })
+
+  it('adds transform-async-to-generator only in production', () => {
+    expect(getHermesSWCIncludes(true)).not.toContain('transform-async-to-generator')
+    expect(getHermesSWCIncludes(false)).toContain('transform-async-to-generator')
   })
 })

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -334,6 +334,7 @@ async function downlevelClassFieldsInBundle(code: string): Promise<string> {
       env: {
         targets: { node: 9999 },
         include: [
+          'transform-classes',
           'transform-class-properties',
           'transform-class-static-block',
           'transform-private-methods',
@@ -1024,14 +1025,20 @@ function hermesCompatSWCPlugin(dev: boolean): Plugin {
       try {
         if (!swc) swc = await import('@swc/core')
 
-        // hermes needs class properties downleveled; prod also needs
-        // classes and async-to-generator for bytecode compilation
+        // hermes needs classes fully downleveled. Downleveling only the class
+        // *fields* while leaving `class ... extends` as modern ES6 (the previous
+        // dev-only behavior) produces a half-transpiled class hierarchy Hermes
+        // chokes on at `new Subclass()` (TypeError: Cannot read property
+        // 'prototype' of undefined) — so `transform-classes` must be
+        // unconditional, matching the fully-classed production bundle. Only
+        // async-to-generator stays prod-only (bytecode compilation).
         const envIncludes = [
+          'transform-classes',
           'transform-class-properties',
           'transform-class-static-block',
           'transform-private-methods',
           'transform-private-property-in-object',
-          ...(!dev ? ['transform-classes', 'transform-async-to-generator'] : []),
+          ...(!dev ? ['transform-async-to-generator'] : []),
         ]
 
         const result = await swc.transform(code, {

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -17,6 +17,29 @@ import { getNativePrelude } from '../runtime/native-prelude'
 // files that contain Flow syntax and need stripping
 const FLOW_FILE_PATTERN = /node_modules[\\/](?:react-native|@react-native)[\\/].*\.js$/
 
+// Hermes needs the whole class shape lowered *together*. Downleveling only the
+// class fields while leaving `class ... extends` as modern ES6 produces a
+// half-transpiled hierarchy Hermes crashes on at `new Subclass()` (TypeError:
+// Cannot read property 'prototype' of undefined). These must stay atomic across
+// both SWC call sites and dev/prod — defining them once makes that a fact, not a
+// convention (the original bug was `transform-classes` missing from one of two
+// hand-copied include lists).
+const HERMES_CLASS_TRANSFORMS = [
+  'transform-classes',
+  'transform-class-properties',
+  'transform-class-static-block',
+  'transform-private-methods',
+  'transform-private-property-in-object',
+] as const
+
+// prod-only: needed for hermesc bytecode AOT compilation, not the dev interpreter
+const HERMES_PROD_TRANSFORMS = ['transform-async-to-generator'] as const
+
+/** SWC `env.include` for Hermes-compatible downleveling — see HERMES_CLASS_TRANSFORMS. */
+export function getHermesSWCIncludes(dev: boolean): string[] {
+  return [...HERMES_CLASS_TRANSFORMS, ...(dev ? [] : HERMES_PROD_TRANSFORMS)]
+}
+
 interface NativeDevEngineOptions {
   root: string
   port: number
@@ -333,13 +356,8 @@ async function downlevelClassFieldsInBundle(code: string): Promise<string> {
       isModule: false,
       env: {
         targets: { node: 9999 },
-        include: [
-          'transform-classes',
-          'transform-class-properties',
-          'transform-class-static-block',
-          'transform-private-methods',
-          'transform-private-property-in-object',
-        ],
+        // dev-only runtime prelude: the class set only, no prod bytecode transforms
+        include: [...HERMES_CLASS_TRANSFORMS],
       },
       jsc: {
         parser: { syntax: 'ecmascript' },
@@ -1025,21 +1043,9 @@ function hermesCompatSWCPlugin(dev: boolean): Plugin {
       try {
         if (!swc) swc = await import('@swc/core')
 
-        // hermes needs classes fully downleveled. Downleveling only the class
-        // *fields* while leaving `class ... extends` as modern ES6 (the previous
-        // dev-only behavior) produces a half-transpiled class hierarchy Hermes
-        // chokes on at `new Subclass()` (TypeError: Cannot read property
-        // 'prototype' of undefined) — so `transform-classes` must be
-        // unconditional, matching the fully-classed production bundle. Only
-        // async-to-generator stays prod-only (bytecode compilation).
-        const envIncludes = [
-          'transform-classes',
-          'transform-class-properties',
-          'transform-class-static-block',
-          'transform-private-methods',
-          'transform-private-property-in-object',
-          ...(!dev ? ['transform-async-to-generator'] : []),
-        ]
+        // app modules: the Hermes class set (unconditional), plus async-to-generator
+        // in prod only (see HERMES_CLASS_TRANSFORMS / HERMES_PROD_TRANSFORMS)
+        const envIncludes = getHermesSWCIncludes(dev)
 
         const result = await swc.transform(code, {
           filename: id,


### PR DESCRIPTION
## Summary

With `native.bundler: 'vite'`, a **dev** native build compiles, installs, and launches, then Hermes **red-screens at init**, before React mounts:

```
[runtime not ready]: TypeError: Cannot read property 'prototype' of undefined
  anonymous@461:59   ← new ReactNativeDevRuntime() in the injected dev runtime
```

The app never renders. **Production** (`one build android`) is unaffected. The same JS runs clean under Node/JSC — it is **Hermes-specific**.

## Root cause

vxrn downlevels the dev bundle for Hermes with SWC, but **gates `transform-classes` behind `!dev`** in *two* places (`packages/vxrn/src/utils/createNativeDevEngine.ts`), so dev builds transpile class **fields** while leaving `class extends` as modern ES6 — an inconsistent, **half-transpiled** class hierarchy Hermes chokes on when constructing the class:

1. `downlevelClassFieldsInBundle` (the injected runtime prelude) — `include` had `transform-class-properties`/`-static-block`/`-private-*` but **no** `transform-classes`.
2. `hermesCompatSWCPlugin` (app modules) — `...(!dev ? ['transform-classes', 'transform-async-to-generator'] : [])`, i.e. `transform-classes` only in production.

Bisected on device: adding `transform-classes` to (1) advanced the crash from vxrn's own runtime into RN's modules (`BatchedBridge`/`MessageQueue`); adding it to (2) cleared those too — pinpointing the `!dev` gate as the whole cause.

## Fix

Make `transform-classes` unconditional in both spots so the entire native dev bundle is consistently ES5-classed and Hermes-safe (matching the fully-classed production bundle); `transform-async-to-generator` stays production-only.

The two include lists were **hand-copied** — which is exactly how `transform-classes` came to be missing from one of them — so this also extracts the shared set into a single named constant (`HERMES_CLASS_TRANSFORMS`) plus the prod-only addend (`HERMES_PROD_TRANSFORMS`), both consumed through `getHermesSWCIncludes(dev)`. The "these class transforms move together" invariant is now a compile-time fact instead of two lists that can silently drift apart again.

## Test plan

- **Unit test** (`createNativeDevEngine.test.ts`): `getHermesSWCIncludes` always contains the full class-transform set for **both** dev and prod (the regression guard — `transform-classes` was the missing member) and adds `transform-async-to-generator` only in prod.
- **Transform (deterministic):** running vxrn's exact SWC options, the dev `include` (without `transform-classes`) keeps `class X extends Y` as ES6 while lowering the fields (half-transpile); adding `transform-classes` emits full ES5 (`_inherits`/`_call_super`/`_class_call_check`).
- **Hermes toolchain:** the half-transpiled (ES6-`class`) output is **rejected** by the Hermes compiler (`invalid statement encountered`), while the fully-lowered ES5 output compiles to valid bytecode.
- **Node/V8:** runs both outputs fine (confirms the defect is Hermes-specific).
- **On device (Android emulator, Hermes, new arch):** app went red-screen (`prototype of undefined` at `new ReactNativeDevRuntime()`) → **renders**; `e2e-check.sh` `native-render` FAIL→PASS. Durable across the whole session.

## Notes

Not Windows-specific — this is a Hermes + dev-mode issue; any `bundler: 'vite'` native dev target hits it. The `!dev` gate reads like a dev-speed optimization (skip the heavier class transform in dev), but a half-transpiled class hierarchy is not Hermes-safe, so keeping `transform-classes` unconditional is the correct trade-off.
