### PR TITLE
fix(vxrn): alias RN's Metro HMR client to a no-op on native dev (new arch)

### DIFF
--- a/packages/vxrn/src/runtime/native-prelude.ts
+++ b/packages/vxrn/src/runtime/native-prelude.ts
@@ -75,20 +75,6 @@ if (typeof globalThis.URLSearchParams === 'undefined') {
   };
 }
 
-// suppress HMRClient.setup() error from native side
-// native calls HMRClient.setup() during bundle load but we don't use Metro HMR
-// this intercept catches the error and prevents the red screen
-var __origErrorHandler = globalThis.ErrorUtils && globalThis.ErrorUtils.getGlobalHandler && globalThis.ErrorUtils.getGlobalHandler();
-if (globalThis.ErrorUtils && globalThis.ErrorUtils.setGlobalHandler) {
-  globalThis.ErrorUtils.setGlobalHandler(function(error, isFatal) {
-    if (error && error.message && error.message.indexOf('HMRClient') !== -1) {
-      // suppress HMRClient errors silently
-      return;
-    }
-    if (__origErrorHandler) __origErrorHandler(error, isFatal);
-  });
-}
-
 // ensure console exists before any library prelude touches it in release bundles
 globalThis.console = globalThis.console || {};
 var console = globalThis.console;

--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getNativeTransformConfig,
+  hmrClientNoopPlugin,
   wrapNativeBundleModuleScope,
 } from './createNativeDevEngine'
 
@@ -64,5 +65,57 @@ describe('wrapNativeBundleModuleScope', () => {
   it('is a no-op when the runtime marker is absent (e.g. prod bundle)', () => {
     const input = 'var x = 1;\nconsole.log(x);\n'
     expect(wrapNativeBundleModuleScope(input)).toBe(input)
+  })
+})
+
+describe('hmrClientNoopPlugin', () => {
+  const plugin = hmrClientNoopPlugin()
+  const resolveId = plugin.resolveId as unknown as (source: string) => any
+  const load = plugin.load as unknown as (id: string) => any
+  const VIRTUAL_ID = '\0vxrn-hmr-client-noop'
+
+  it.each([
+    'react-native/Libraries/Utilities/HMRClient',
+    '../Utilities/HMRClient',
+    '../../Utilities/HMRClient.js',
+    // native Windows ids use backslashes
+    '..\\Utilities\\HMRClient.js',
+    '../Utilities/HMRClient.ts',
+    '../Utilities/HMRClient.tsx',
+    '../Utilities/HMRClient.cjs',
+  ])('aliases RN HMRClient specifier %j to the no-op virtual module', (source) => {
+    expect(resolveId(source)).toEqual({ id: VIRTUAL_ID, external: false })
+  })
+
+  it.each([
+    // trailing letters (no boundary) must not match
+    'react-native/Libraries/Utilities/HMRClientRegistry',
+    // Utilities must sit at a path boundary
+    'some/MyUtilities/HMRClient',
+    // unrelated RN modules
+    'react-native/Libraries/Core/setUpDeveloperTools',
+    'react',
+  ])('does not touch unrelated specifier %j', (source) => {
+    expect(resolveId(source)).toBeUndefined()
+  })
+
+  it('loads a no-op module exposing every HMRClient method RN calls', () => {
+    const result = load(VIRTUAL_ID)
+    expect(result?.moduleType).toBe('js')
+    for (const method of [
+      'setup',
+      'enable',
+      'disable',
+      'registerBundle',
+      'log',
+      'isEnabled',
+    ]) {
+      expect(result!.code).toContain(method)
+    }
+    expect(result!.code).toContain('export default HMRClient')
+  })
+
+  it('does not load unrelated ids', () => {
+    expect(load('\0some-other-virtual')).toBeUndefined()
   })
 })

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -806,7 +806,7 @@ function environmentGuardPlugin(): Plugin {
  * (`setup`/`enable`/`disable`/`registerBundle`/`log`/`isEnabled`) mirrors the
  * methods RN calls on it.
  */
-function hmrClientNoopPlugin(): Plugin {
+export function hmrClientNoopPlugin(): Plugin {
   // Match RN's HMRClient by module path, tolerating either separator (native
   // Windows ids use `\`) and an optional js/ts extension.
   const RN_HMR_CLIENT_RE = /(^|[\\/])Utilities[\\/]HMRClient(\.[cm]?[jt]sx?)?$/

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -191,6 +191,10 @@ function getNativePlugins(
     serverFileExclusionPlugin(),
     // guard server-only / client-only / web-only / native-only imports
     environmentGuardPlugin(),
+    // alias RN's Metro HMR client to a no-op — vxrn drives HMR itself (the
+    // rolldown-runtime WebSocket); RN's client otherwise opens a /hot socket and
+    // red-boxes "unknown-message [object Object]" on every edit (new arch)
+    hmrClientNoopPlugin(),
     // stub CSS imports — native doesn't support CSS and rolldown removed CSS bundling
     cssStubPlugin(),
     // handle import.meta.glob (used by One's route system)
@@ -469,14 +473,6 @@ try {
         // downlevel class fields from the rolldown runtime (virtual module
         // skipped by the per-file SWC plugin) so old Hermes can parse them
         code = await downlevelClassFieldsInBundle(code)
-
-        // register a no-op HMRClient so RN's native side doesn't error when calling HMRClient.setup()
-        // our actual HMR is handled via the outro WebSocket connection
-        const hmrClientStub = `registerCallableModule("HMRClient",{setup:function(){},enable:function(){},disable:function(){},registerBundle:function(){},log:function(){}})`
-        code = code.replace(
-          /registerCallableModule\s*\(\s*["']AppRegistry["']/,
-          (match) => hmrClientStub + ',' + match
-        )
 
         // wrap module code in a function scope so top-level `var`s (e.g. RN
         // fetch.js's `Headers`/`Request`) don't leak as non-configurable
@@ -788,6 +784,45 @@ function environmentGuardPlugin(): Plugin {
         }
       }
       if (id.startsWith('\0env-guard-noop:')) return { code: '', moduleType: 'js' as any }
+    },
+  }
+}
+
+/**
+ * Alias react-native's Metro HMR client (`Libraries/Utilities/HMRClient`) to a
+ * no-op module.
+ *
+ * vxrn drives Fast Refresh itself over the rolldown-runtime WebSocket and never
+ * speaks Metro's `/hot` protocol. On the new architecture, react-native
+ * `registerCallableModule('HMRClient', require('./HMRClient'))`s its real client
+ * eagerly at startup — before vxrn's late override runs — and `emplace` keeps
+ * that first registration. RN's client then opens a `MetroHMRClient` socket that
+ * receives vxrn's `hmr:*` frames it can't parse and red-boxes
+ * `unknown-message [object Object]` on every edit.
+ *
+ * Neutralizing the module at its source means RN registers *this* no-op as the
+ * one-and-only `HMRClient` (working WITH `emplace`, so it's arch-agnostic) and
+ * the stray socket is never opened. The class-shaped surface
+ * (`setup`/`enable`/`disable`/`registerBundle`/`log`/`isEnabled`) mirrors the
+ * methods RN calls on it.
+ */
+function hmrClientNoopPlugin(): Plugin {
+  // Match RN's HMRClient by module path, tolerating either separator (native
+  // Windows ids use `\`) and an optional js/ts extension.
+  const RN_HMR_CLIENT_RE = /(^|[\\/])Utilities[\\/]HMRClient(\.[cm]?[jt]sx?)?$/
+  return {
+    name: 'vxrn:hmr-client-noop',
+    resolveId(source) {
+      if (RN_HMR_CLIENT_RE.test(source))
+        return { id: '\0vxrn-hmr-client-noop', external: false }
+    },
+    load(id) {
+      if (id === '\0vxrn-hmr-client-noop') {
+        return {
+          code: `const HMRClient = { setup() {}, enable() {}, disable() {}, registerBundle() {}, log() {}, isEnabled() { return false } }\nexport default HMRClient`,
+          moduleType: 'js' as any,
+        }
+      }
     },
   }
 }


### PR DESCRIPTION
## Summary

On a **native dev** build (`bundler: 'vite'`), the **new architecture / bridgeless**, every source edit pops a red LogBox:

```
unknown-message [object Object]
```

It's non-fatal (the app keeps rendering and vxrn's own Fast Refresh still runs), but it fires on **every** change and papers over the dev experience. It's React Native's built-in **Metro** HMR client choking on vxrn's `hmr:*` WebSocket protocol — a client vxrn *believes* it has disabled, but hasn't on the new arch.

## Root cause — the no-op stub loses an `emplace` race

vxrn drives Fast Refresh itself over the rolldown-runtime WebSocket and never speaks Metro's `/hot` protocol. To keep RN's Metro `HMRClient` out of the way, it splices a no-op `registerCallableModule("HMRClient", …)` into the bundle right before `registerCallableModule("AppRegistry", …)`. On the new arch that registration is silently dropped:

1. **RN registers the real HMRClient first.** `Libraries/Core/setUpBatchedBridge.js` does `registerCallableModule('HMRClient', () => require('../Utilities/HMRClient').default)`, which runs during `setUpBatchedBridge` — **before** the `AppRegistry` registration the stub is spliced in front of.
2. **On the new arch, registration routes to a C++ map that does not overwrite.** `registerCallableModule` → `global.RN$registerCallableModule` → `ReactInstance.cpp` `callableModules_.emplace(...)`. `std::unordered_map::emplace` is a **no-op when the key already exists** — first registration wins. (On the *old* arch, `MessageQueue` assigns `this._lazyCallableModules[name] = …` — last-wins — which is why the splice worked there.)
3. **So the late stub is discarded and RN's real `HMRClient.setup()` survives.** `setup()` unconditionally opens a `MetroHMRClient` socket to `/hot` (the `enable`/`disable`/`isEnabled` flags only gate whether refreshes are *applied*, not whether the socket opens).
4. **vxrn broadcasts `hmr:*` to every `/hot` client**, including the Metro one. metro-runtime's `WebSocketHMRClient` can't parse `hmr:*`, hits its `default` branch, and RN's handler formats `` `${data.type} ${data.message}` `` = `"unknown-message [object Object]"` and throws it → the red LogBox.

## Fix

Alias `react-native/…/Utilities/HMRClient` to a no-op module via a resolver plugin (`hmrClientNoopPlugin`), instead of the emplace-order-dependent bundle-regex splice. RN's own `require('../Utilities/HMRClient')` then resolves to the no-op, so RN registers **the no-op** as the first-and-only `HMRClient` — working *with* `emplace`, arch-agnostically. `MetroHMRClient` is never constructed (and tree-shakes out of the bundle), so it never connects to `/hot` and the error cannot occur. vxrn's real HMR path (the rolldown-runtime WebSocket) is untouched.

This also lets two now-dead workarounds go, both of which only ever chased the symptom:

- **The bundle-regex splice** (`createNativeDevEngine.ts`) — this is the registration that loses the `emplace` race, i.e. the root cause itself. Redundant once RN registers the no-op directly.
- **A global `ErrorUtils` handler** in `native-prelude.ts` that swallowed any error whose message contained `'HMRClient'`. The thrown text is `unknown-message [object Object]` — it contains no `'HMRClient'`, so this never caught *this* error; all it did was risk hiding unrelated errors that happen to mention HMRClient. With the alias, no HMRClient error is thrown at all.

### Why alias the module (vs. the alternatives)

- **Separate socket paths** (move vxrn HMR off `/hot`) would stop the cross-talk, but leaves RN's real HMRClient instantiated and an idle `/hot` socket open — it routes *around* the Metro client instead of removing it, and stays fragile to any future RN/metro that expects a `/hot` handshake.
- **Server-side filtering** *can* distinguish the clients (vxrn's client sends `hmr:*` on connect; Metro's sends `register-entrypoints`) — so it's not impossible — but it's racy (a broadcast before the first frame leaks) and still symptom-level: the Metro client stays alive.
- **Aliasing the module** removes the Metro client at its source — it never instantiates, never opens the socket, arch-agnostically. The no-op is interface-complete for RN's actual call sites (`setup`/`enable`/`disable`/`registerBundle`/`log`), verified against RN's whole HMRClient import graph (`setUpBatchedBridge`, `loadBundleFromServer`, `setUpDeveloperTools`).

## Test plan

- **On device (Android emulator, Hermes, new arch):** the `unknown-message [object Object]` LogBox that appeared on **every** edit is **gone**; the app still renders and vxrn's own Fast Refresh still applies.
- **Served bundle inspection:** with the alias, the `unknown-message` string count goes **2 → 0** and `new MetroHMRClient` **→ 0** (MetroHMRClient is no longer reachable and tree-shakes out — bundle ~21KB smaller).
- Reproduced the source: broadcasting a `hmr:*` frame to a metro `WebSocketHMRClient` yields exactly `{type:'unknown-message', message: …}` → `"unknown-message [object Object]"`.
- **Unit test** (`createNativeDevEngine.test.ts`): `hmrClientNoopPlugin` aliases every RN HMRClient specifier (both separators, optional `.js`/`.ts`/`.cjs` ext) to the virtual no-op and leaves near-misses alone (`HMRClientRegistry`, `MyUtilities/HMRClient`, `setUpDeveloperTools`); the loaded module exposes every method RN calls.

## Notes

- **New-arch / bridgeless specific** — the old arch's last-wins `MessageQueue` path made the original splice work, which is likely why this regressed silently as the ecosystem moved to bridgeless.
- Cross-platform — the fix is a resolver alias with no OS-specific logic (the path regex tolerates either separator so native Windows module ids match too).
- Independent of the "Fast Refresh isn't *applied* on native" issue (different defect on the same `/hot` socket): this one is purely why a red error *appears*.
- Adjacent cleanup worth flagging: vxrn ships a full drop-in HMR client at `runtime/hmr-client.ts` that is now dead (nothing imports it) and incompatible with the current outro-driven runtime (its `hmr:update` handler is a no-op) — a separate deletion, not part of this PR.
