### PR TITLE
fix(vxrn,one): apply native Fast Refresh to One route components

### DIFF
--- a/packages/one/src/router/hmrImport.native.test.ts
+++ b/packages/one/src/router/hmrImport.native.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hmrImport } from './hmrImport.native'
+
+const realRuntime = (globalThis as any).__rolldown_runtime__
+afterEach(() => {
+  ;(globalThis as any).__rolldown_runtime__ = realRuntime
+  vi.restoreAllMocks()
+})
+const setRuntime = (runtime: unknown) => {
+  ;(globalThis as any).__rolldown_runtime__ = runtime
+}
+
+describe('hmrImport (native)', () => {
+  it('rejects when no runtime is present', async () => {
+    setRuntime(undefined)
+    await expect(hmrImport('foo.tsx')).rejects.toThrow(
+      'HMR import not supported on native'
+    )
+  })
+
+  it('rejects when loadExports is missing', async () => {
+    setRuntime({})
+    await expect(hmrImport('foo.tsx')).rejects.toThrow(
+      'HMR import not supported on native'
+    )
+  })
+
+  it('resolves with the runtime exports and strips ./ and / prefixes', async () => {
+    const exports = { default: () => null }
+    const loadExports = vi.fn(() => exports)
+    setRuntime({ loadExports })
+
+    await expect(hmrImport('./foo.tsx')).resolves.toBe(exports)
+    await expect(hmrImport('/foo.tsx')).resolves.toBe(exports)
+    await expect(hmrImport('foo.tsx')).resolves.toBe(exports)
+    expect(loadExports).toHaveBeenNthCalledWith(1, 'foo.tsx')
+    expect(loadExports).toHaveBeenNthCalledWith(2, 'foo.tsx')
+    expect(loadExports).toHaveBeenNthCalledWith(3, 'foo.tsx')
+  })
+
+  it('rejects when loadExports returns null', async () => {
+    setRuntime({ loadExports: () => null })
+    await expect(hmrImport('foo.tsx')).rejects.toThrow('no exports for foo.tsx')
+  })
+
+  it('rejects when loadExports throws', async () => {
+    const boom = new Error('boom')
+    setRuntime({
+      loadExports: () => {
+        throw boom
+      },
+    })
+    await expect(hmrImport('foo.tsx')).rejects.toBe(boom)
+  })
+})

--- a/packages/one/src/router/hmrImport.native.ts
+++ b/packages/one/src/router/hmrImport.native.ts
@@ -1,8 +1,26 @@
 /**
- * Native stub: HMR cache-busting is not supported on native.
- * This avoids the dynamic import() syntax that Hermes cannot parse.
+ * Native HMR re-import.
+ *
+ * vxrn's native dev runtime re-registers the edited module into
+ * `globalThis.__rolldown_runtime__` before One evicts its route cache, so the
+ * fresh exports can be pulled straight from the runtime — no dynamic `import()`
+ * (which Hermes cannot parse). Falls back to a rejected promise when the runtime
+ * isn't present (e.g. production), so `resolve()` keeps the memoized module.
  */
-export function hmrImport(_path: string): Promise<any> {
-  // Return a rejected promise to fall back to normal import
-  return Promise.reject(new Error('HMR import not supported on native'))
+export function hmrImport(path: string): Promise<any> {
+  const runtime = (globalThis as any).__rolldown_runtime__
+  if (!runtime || typeof runtime.loadExports !== 'function') {
+    return Promise.reject(new Error('HMR import not supported on native'))
+  }
+  // route paths arrive as `./foo.tsx` / `/foo.tsx`; rolldown ids are bare (`foo.tsx`)
+  const id = String(path).replace(/^\.\//, '').replace(/^\//, '')
+  try {
+    const mod = runtime.loadExports(id)
+    if (mod == null) {
+      return Promise.reject(new Error(`no exports for ${id}`))
+    }
+    return Promise.resolve(mod)
+  } catch (error) {
+    return Promise.reject(error)
+  }
 }

--- a/packages/one/src/router/routeHmr.native.test.ts
+++ b/packages/one/src/router/routeHmr.native.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type RouteHmrModule = typeof import('./routeHmr.native')
+
+describe('routeHmr.native', () => {
+  let routeHmr: RouteHmrModule
+  const realWindow = (globalThis as any).window
+
+  beforeEach(async () => {
+    // the __VXRN_ON_MODULE_UPDATED__ registration is dev-gated and runs at module
+    // load, so stub NODE_ENV then re-import to exercise it
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.resetModules()
+    routeHmr = await import('./routeHmr.native')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    globalThis.__VXRN_ON_MODULE_UPDATED__ = undefined
+    ;(globalThis as any).window = realWindow
+  })
+
+  it('registers globalThis.__VXRN_ON_MODULE_UPDATED__ in development', () => {
+    expect(typeof globalThis.__VXRN_ON_MODULE_UPDATED__).toBe('function')
+  })
+
+  it('bumps the epoch and notifies subscribers, and stops after unsubscribe', () => {
+    const before = routeHmr.getRouteHmrEpoch()
+    const listener = vi.fn()
+    const unsubscribe = routeHmr.subscribeRouteHmr(listener)
+
+    globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')
+    expect(routeHmr.getRouteHmrEpoch()).toBe(before + 1)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('evicts the route cache for the updated file when window.__oneRouteCache is present', () => {
+    const clearFile = vi.fn()
+    ;(globalThis as any).window = { __oneRouteCache: { clearFile } }
+    globalThis.__VXRN_ON_MODULE_UPDATED__!('app/_layout.tsx')
+    expect(clearFile).toHaveBeenCalledWith('app/_layout.tsx')
+  })
+
+  it('does not throw when window / route cache is absent', () => {
+    ;(globalThis as any).window = undefined
+    expect(() => globalThis.__VXRN_ON_MODULE_UPDATED__!('x.tsx')).not.toThrow()
+  })
+})

--- a/packages/one/src/router/routeHmr.native.ts
+++ b/packages/one/src/router/routeHmr.native.ts
@@ -1,0 +1,45 @@
+// Native Fast Refresh for One routes.
+//
+// On native, RN's React Refresh can't repaint One's route components: useScreens'
+// `ScreenComponent` obtains them via `value.loadRoute()` and re-wraps them
+// (`fromImport` -> `forwardRef` -> `getPageExport`), so the mounted fiber isn't in
+// the edited module's Refresh family. vxrn's native HMR runtime surfaces each
+// committed module id to `globalThis.__VXRN_ON_MODULE_UPDATED__`; we evict One's
+// route cache (bumping `useViteRoutes`' `hmrVersion` so `resolve()` re-imports the
+// edited module) and bump a subscribable epoch so subscribed `ScreenComponent`s
+// re-render and re-run `loadRoute()`. Web uses `routeHmr.ts` (a no-op store; the
+// web path repaints via the `one-hmr-update` event, see useScreens' web block).
+//
+// (The web path shows RN's re-wrapping isn't the whole story — web leaf routes
+// Fast-Refresh fine through the same wrapper — so the native-specific failure most
+// likely lives in vxrn's own React Refresh wiring; this bypasses it for routes.)
+
+declare global {
+  // vxrn's native HMR runtime invokes this (when defined) with each committed
+  // module id, so a framework can react to a hot update.
+  var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined
+}
+
+let routeHmrEpoch = 0
+const routeHmrListeners = new Set<() => void>()
+
+export const subscribeRouteHmr = (onStoreChange: () => void) => {
+  routeHmrListeners.add(onStoreChange)
+  return () => {
+    routeHmrListeners.delete(onStoreChange)
+  }
+}
+
+export const getRouteHmrEpoch = () => routeHmrEpoch
+
+if (process.env.NODE_ENV === 'development' && typeof globalThis !== 'undefined') {
+  globalThis.__VXRN_ON_MODULE_UPDATED__ = (id: string) => {
+    try {
+      if (typeof window !== 'undefined' && (window as any).__oneRouteCache) {
+        ;(window as any).__oneRouteCache.clearFile(id)
+      }
+    } catch {}
+    routeHmrEpoch++
+    routeHmrListeners.forEach((listener) => listener())
+  }
+}

--- a/packages/one/src/router/routeHmr.ts
+++ b/packages/one/src/router/routeHmr.ts
@@ -1,0 +1,8 @@
+// Web counterpart of routeHmr.native.ts. Web route Fast Refresh happens through
+// the `one-hmr-update` event (see useScreens' web block), so this is a no-op store
+// — its exports exist only so useScreens can import `./routeHmr` platform-agnostically.
+export const subscribeRouteHmr = (_onStoreChange: () => void): (() => void) => {
+  return () => {}
+}
+
+export const getRouteHmrEpoch = () => 0

--- a/packages/one/src/router/useScreens.tsx
+++ b/packages/one/src/router/useScreens.tsx
@@ -373,6 +373,40 @@ function getRouteMatchesForProps() {
   return clientMatches.length ? clientMatches : serverMatches
 }
 
+// Native Fast Refresh for One routes. On native, RN's React Refresh can't repaint
+// route components: `ScreenComponent` obtains them via `value.loadRoute()` and
+// re-wraps them (`fromImport` → `forwardRef` → `getPageExport`), so the mounted
+// fiber isn't in the edited module's Refresh family. vxrn's native HMR runtime
+// surfaces each updated module id to `globalThis.__oneRouteHotUpdate`; we evict the
+// route cache (bumping `useViteRoutes`' `hmrVersion` so `resolve()` re-imports the
+// edited module) and bump a subscribable epoch so subscribed `ScreenComponent`s
+// re-render and re-run `loadRoute()`. Web uses the `one-hmr-update` event instead.
+let routeHmrEpoch = 0
+const routeHmrListeners = new Set<() => void>()
+const subscribeRouteHmr = (onStoreChange: () => void) => {
+  routeHmrListeners.add(onStoreChange)
+  return () => {
+    routeHmrListeners.delete(onStoreChange)
+  }
+}
+const getRouteHmrEpoch = () => routeHmrEpoch
+
+if (
+  process.env.NODE_ENV === 'development' &&
+  process.env.TAMAGUI_TARGET === 'native' &&
+  typeof globalThis !== 'undefined'
+) {
+  ;(globalThis as any).__oneRouteHotUpdate = (id: string) => {
+    try {
+      if (typeof window !== 'undefined' && (window as any).__oneRouteCache) {
+        ;(window as any).__oneRouteCache.clearFile(id)
+      }
+    } catch {}
+    routeHmrEpoch++
+    routeHmrListeners.forEach((listener) => listener())
+  }
+}
+
 /** Wrap the component with various enhancements and add access to child routes. */
 export function getQualifiedRouteComponent(value: RouteNode) {
   if (value && qualifiedStore.has(value)) {
@@ -393,6 +427,17 @@ export function getQualifiedRouteComponent(value: RouteNode) {
         window.addEventListener('one-hmr-update', handler)
         return () => window.removeEventListener('one-hmr-update', handler)
       }, [])
+    }
+
+    // native Fast Refresh: subscribe to the route-hot epoch (bumped by
+    // __oneRouteHotUpdate above) so this component re-renders and re-runs
+    // loadRoute() to pick up the edited module's fresh exports
+    if (
+      process.env.NODE_ENV === 'development' &&
+      process.env.TAMAGUI_TARGET === 'native'
+    ) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      React.useSyncExternalStore(subscribeRouteHmr, getRouteHmrEpoch, getRouteHmrEpoch)
     }
 
     // in spa-shell mode, only SSG/SSR layouts render on the server.

--- a/packages/one/src/router/useScreens.tsx
+++ b/packages/one/src/router/useScreens.tsx
@@ -28,6 +28,7 @@ import {
 import { SpaShellContext } from './SpaShellContext'
 import { NamedSlot } from '../views/Navigator'
 import { sortRoutesWithInitial } from './sortRoutes'
+import { getRouteHmrEpoch, subscribeRouteHmr } from './routeHmr'
 import { getClientMatchesSnapshot } from '../useMatches'
 
 // `@react-navigation/core` does not expose the Screen or Group components directly, so we have to
@@ -373,40 +374,6 @@ function getRouteMatchesForProps() {
   return clientMatches.length ? clientMatches : serverMatches
 }
 
-// Native Fast Refresh for One routes. On native, RN's React Refresh can't repaint
-// route components: `ScreenComponent` obtains them via `value.loadRoute()` and
-// re-wraps them (`fromImport` → `forwardRef` → `getPageExport`), so the mounted
-// fiber isn't in the edited module's Refresh family. vxrn's native HMR runtime
-// surfaces each updated module id to `globalThis.__oneRouteHotUpdate`; we evict the
-// route cache (bumping `useViteRoutes`' `hmrVersion` so `resolve()` re-imports the
-// edited module) and bump a subscribable epoch so subscribed `ScreenComponent`s
-// re-render and re-run `loadRoute()`. Web uses the `one-hmr-update` event instead.
-let routeHmrEpoch = 0
-const routeHmrListeners = new Set<() => void>()
-const subscribeRouteHmr = (onStoreChange: () => void) => {
-  routeHmrListeners.add(onStoreChange)
-  return () => {
-    routeHmrListeners.delete(onStoreChange)
-  }
-}
-const getRouteHmrEpoch = () => routeHmrEpoch
-
-if (
-  process.env.NODE_ENV === 'development' &&
-  process.env.TAMAGUI_TARGET === 'native' &&
-  typeof globalThis !== 'undefined'
-) {
-  ;(globalThis as any).__oneRouteHotUpdate = (id: string) => {
-    try {
-      if (typeof window !== 'undefined' && (window as any).__oneRouteCache) {
-        ;(window as any).__oneRouteCache.clearFile(id)
-      }
-    } catch {}
-    routeHmrEpoch++
-    routeHmrListeners.forEach((listener) => listener())
-  }
-}
-
 /** Wrap the component with various enhancements and add access to child routes. */
 export function getQualifiedRouteComponent(value: RouteNode) {
   if (value && qualifiedStore.has(value)) {
@@ -429,9 +396,9 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       }, [])
     }
 
-    // native Fast Refresh: subscribe to the route-hot epoch (bumped by
-    // __oneRouteHotUpdate above) so this component re-renders and re-runs
-    // loadRoute() to pick up the edited module's fresh exports
+    // native Fast Refresh: subscribe to the route-hot epoch (the routeHmr.native
+    // store bumps it when vxrn reports a route module update) so this component
+    // re-renders and re-runs loadRoute() to pick up the edited module's exports
     if (
       process.env.NODE_ENV === 'development' &&
       process.env.TAMAGUI_TARGET === 'native'

--- a/packages/vxrn/src/runtime/hmr-runtime.ts
+++ b/packages/vxrn/src/runtime/hmr-runtime.ts
@@ -26,6 +26,10 @@ declare global {
   var __VXRN_CUSTOM_HMR_HANDLER__:
     | ((socket: WebSocket, message: HMRCustomMessage) => void)
     | undefined
+  // called (when a framework defines it) with each committed module id from
+  // applyUpdates, so a framework can react to a native hot update — e.g. One's
+  // routeHmr.native.ts evicts its route cache and re-renders the route
+  var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined
 }
 
 // DO NOT EDIT THIS CLASS NAME - rolldown references it

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -1131,6 +1131,14 @@ class ReactNativeDevRuntime extends BaseDevRuntime {
           ctx.acceptCallbacks[j].fn(this.modules[moduleId].exports);
         }
       }
+      // surface the updated module id to One's route-hot hook so it can evict its
+      // route cache and re-render. RN's React Refresh can't repaint One's route
+      // components (they're re-wrapped away from the edited module's Refresh
+      // family), and the web 'one:route-update' event has no equivalent on the
+      // native /hot transport, so this generic global hook is the bridge.
+      try {
+        if (globalThis.__oneRouteHotUpdate && moduleId) globalThis.__oneRouteHotUpdate(moduleId);
+      } catch (e) {}
     }
   }
 

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -1131,13 +1131,13 @@ class ReactNativeDevRuntime extends BaseDevRuntime {
           ctx.acceptCallbacks[j].fn(this.modules[moduleId].exports);
         }
       }
-      // surface the updated module id to One's route-hot hook so it can evict its
-      // route cache and re-render. RN's React Refresh can't repaint One's route
-      // components (they're re-wrapped away from the edited module's Refresh
-      // family), and the web 'one:route-update' event has no equivalent on the
-      // native /hot transport, so this generic global hook is the bridge.
+      // surface each committed module id to the framework hot-update hook (if one
+      // is registered). RN's React Refresh can't repaint frameworks that re-wrap
+      // route components away from the edited module's Refresh family (e.g. One),
+      // and the web route-update event has no equivalent on the native /hot
+      // socket, so this generic vxrn global is the bridge.
       try {
-        if (globalThis.__oneRouteHotUpdate && moduleId) globalThis.__oneRouteHotUpdate(moduleId);
+        if (globalThis.__VXRN_ON_MODULE_UPDATED__ && moduleId) globalThis.__VXRN_ON_MODULE_UPDATED__(moduleId);
       } catch (e) {}
     }
   }


### PR DESCRIPTION
## Summary

On the Vite-native dev path, **editing a source file never updates the running app**. A dev build compiles, installs, launches, and renders — but a save to e.g. `app/index.tsx` doesn't change what's on screen, and a force-stop + relaunch comes back showing the *old* code. So there's no way to see a change without restarting the whole dev server — the biggest gap in the native dev loop.

## Root cause

The **server side is correct**: on save, the file watcher fires, rolldown recompiles the changed module, and the dev server broadcasts a well-formed `{ type: 'hmr:update', code }` to every `/hot` client. The failure is entirely **client-side, on device** — React Refresh runs but doesn't repaint One's route components.

**Why React Refresh doesn't repaint them isn't fully pinned, and I don't want to overclaim it.** `useScreens`' `ScreenComponent` obtains the component via `value.loadRoute()` and re-wraps it (`fromImport` → `forwardRef` → `getPageExport`), which takes the mounted fiber out of the edited module's Refresh family — but the **same wrapping runs on web**, where leaf routes Fast-Refresh fine. So the native-specific failure more likely also involves vxrn's own React Refresh wiring: the injected outro sets `__hmrWS.onmessage` *and* `__rolldown_runtime__.setup` adds a second `message` listener, so each patch is eval'd twice — a plausible way to defeat the in-place family swap. That's worth a separate look (see Notes).

**Regardless of that root cause**, One already ships a route-cache-refresh fallback for exactly the cases React Refresh can't handle (`window.__oneRouteCache` / `hmrVersion` / `hmrImport`) — the **web** path drives it via the `one-hmr-update` event. On **native** three links to drive that same fallback were missing, each independently fatal:

1. **No trigger.** vxrn's rolldown dev runtime commits each HMR patch in `applyUpdates(boundaries)` (inlined in `createNativeDevEngine.ts`'s runtime source) but never surfaced the updated module ids to any framework hook. (The web `one-hmr-update` event has no equivalent on the native `/hot` transport — and the native prelude stubs `dispatchEvent` to a no-op, so it can't.)
2. **No re-render.** `ScreenComponent` never subscribed to a route-hot signal, so nothing re-invoked `loadRoute()`.
3. **Re-import was a stub.** `hmrImport.native.ts` returned `Promise.reject(...)`, so even after cache eviction + re-render, `resolve()`'s `hmrImport(...).catch(() => routesSync[id]())` fell back to the **memoized original** module → the edit never took effect.

## Fix

A three-link chain that drives One's existing route-cache fallback on native, with **no web changes**:

1. **`vxrn` — a typed hot-update extension point.** `applyUpdates` now surfaces each committed module id to `globalThis.__VXRN_ON_MODULE_UPDATED__(moduleId)` — a generic vxrn hook declared next to the existing `__VXRN_CUSTOM_HMR_HANDLER__` (guarded; a no-op if no framework registered one). Not One-specific.
2. **`one` — a dedicated `routeHmr.native.ts` store.** It registers `__VXRN_ON_MODULE_UPDATED__` to evict the route cache (`window.__oneRouteCache.clearFile`, which bumps `useViteRoutes`' `hmrVersion` so `resolve()` re-imports) and bump a subscribable epoch; `ScreenComponent` subscribes via `useSyncExternalStore` (dev + native only) so it re-renders and re-runs `loadRoute()`. A web no-op `routeHmr.ts` keeps the import platform-agnostic. (This replaces an inline store + import-time side effect that had been sitting in `useScreens.tsx`, matching the existing `hmrImport.ts`/`.native.ts` split.)
3. **`one` — `hmrImport.native.ts`.** Implement the native re-import against vxrn's live rolldown runtime (`__rolldown_runtime__.loadExports`, which the patch just re-registered), replacing the rejecting stub. Still no dynamic `import()` (Hermes can't parse it); falls back to a rejected promise when the runtime is absent (e.g. production).

The `one`-side re-render/re-import is `TAMAGUI_TARGET === 'native'`-gated, so the **web path is untouched** (it keeps using the `one-hmr-update` event).

## Verified chain (on device)

```
edit app/index.tsx
  → applyUpdates([['app/index.tsx', …]])
  → globalThis.__VXRN_ON_MODULE_UPDATED__('app/index.tsx')
  → window.__oneRouteCache.clearFile(...) evicts './index.tsx' + hmrVersion → 1
  → epoch bump → ScreenComponent re-renders
  → value.loadRoute() → resolve() (hmrVersion > 0) → hmrImport('app/index.tsx')
  → __rolldown_runtime__.loadExports('app/index.tsx') → { default: <fresh HomePage> }
  → repaint
```

## Test plan

- **Unit tests** (`packages/one`): `hmrImport.native` — resolves with the runtime exports, strips `./` and `/` prefixes, and rejects when the runtime / `loadExports` / exports are absent or throw; `routeHmr.native` — registers the hook in dev, bumps the epoch + notifies subscribers (and stops after unsubscribe), and evicts `window.__oneRouteCache.clearFile` for the updated file (no-op-safe when absent).
- **On device (Android emulator, Hermes, new arch):** editing a route file updates the screen **live, without a reload** (before: no update at all); `scripts/e2e-check.sh` `native-hot-reload` **FAIL → PASS**. This revision (extracting the store + renaming the hook) is behavior-identical to that validated fix, but it touches the HMR runtime, so an on-device re-smoke is worthwhile.

## Notes

- **Cross-platform** — no Windows-specific logic; the module ids on the wire are always forward-slash.
- **Suspected deeper defect (separate issue):** the two competing `/hot` message handlers eval'ing each patch twice (above) are the more likely reason native React Refresh can't repaint routes in place. Worth investigating on its own — if killing the double-eval restores native RR for routes, both platforms could drop the manual dance. This fix drives One's existing fallback and is independent of that outcome.
- **Out of scope (follow-up):** the full `getBundle()` is memoized per dev-start, so a plain relaunch still serves the dev-start bundle; the incremental path fixed here is what live hot-reload needs.
