### PR TITLE
fix: integrate reviewed build and native development fixes

### DIFF
--- a/apps/onestack.dev/app/routes.d.ts
+++ b/apps/onestack.dev/app/routes.d.ts
@@ -17,14 +17,14 @@ declare module 'one' {
         | `/docs`
         | `/plans`
         | `/test`
-      DynamicRoutes: 
+      DynamicRoutes:
         | `/(content)/blog/${OneRouter.SingleRoutePart<T>}`
         | `/(content)/docs/${OneRouter.SingleRoutePart<T>}`
         | `/(content)/plans/${OneRouter.SingleRoutePart<T>}`
         | `/blog/${OneRouter.SingleRoutePart<T>}`
         | `/docs/${OneRouter.SingleRoutePart<T>}`
         | `/plans/${OneRouter.SingleRoutePart<T>}`
-      DynamicRouteTemplate: 
+      DynamicRouteTemplate:
         | `/(content)/blog/[slug]`
         | `/(content)/docs/[slug]`
         | `/(content)/plans/[slug]`

--- a/apps/onestack.dev/app/tamagui.css
+++ b/apps/onestack.dev/app/tamagui.css
@@ -5,8 +5,8 @@
 @scope (.is_Text) to (.is_View) { .is_Text { white-space: inherit; word-wrap: inherit; } }
 ._dsp_contents {display:contents;}
 ._no_backdrop::backdrop {display: none;}
-.is_Input::selection, .is_TextArea::selection {background-color: var(--selectionColor);}
-.is_Input::placeholder, .is_TextArea::placeholder {color: var(--placeholderColor);}
+.is_Input::selection, .is_TextArea::selection {background-color: var(--t_selectionColor);}
+.is_Input::placeholder, .is_TextArea::placeholder {color: var(--t_placeholderColor);}
 :root ._pe-boxonly>* {pointer-events:none;}
 :root ._pe-boxnone>* {pointer-events:auto;}
 ._hsb-x::-webkit-scrollbar:horizontal { display: none !important; }

--- a/bun.lock
+++ b/bun.lock
@@ -214,6 +214,7 @@
         "@vxrn/utils": "workspace:*",
         "@vxrn/vite-native-client": "workspace:*",
         "babel-plugin-react-compiler": "^1.0.0",
+        "babel-plugin-syntax-hermes-parser": "^0.32.0",
         "react-native-css-interop": "^0.2.1",
         "ts-deepmerge": "^7.0.2",
       },
@@ -222,6 +223,7 @@
         "depcheck": "^1.4.7",
         "rolldown": "^1.0.1",
         "vite": "^8.0.13",
+        "vitest": "^4.1.0",
       },
       "peerDependencies": {
         "vite": "^8.0.13",

--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-flow-strip-types": "^7.27.1",
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-regenerator": "^7.28.4",
         "@react-native/babel-plugin-codegen": "^0.83.0",
@@ -673,6 +674,7 @@
       "dependencies": {
         "@expo/config-plugins": "~55.0.6",
         "@hono/node-server": "^1.19.14",
+        "@react-native/babel-plugin-codegen": "^0.83.0",
         "@react-native/dev-middleware": "^0.83.4",
         "@swc/core": "^1.14.0",
         "@vxrn/compiler": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -674,7 +674,6 @@
       "dependencies": {
         "@expo/config-plugins": "~55.0.6",
         "@hono/node-server": "^1.19.14",
-        "@react-native/babel-plugin-codegen": "^0.83.0",
         "@react-native/dev-middleware": "^0.83.4",
         "@swc/core": "^1.14.0",
         "@vxrn/compiler": "workspace:*",

--- a/packages/compiler/.depcheckrc
+++ b/packages/compiler/.depcheckrc
@@ -1,6 +1,7 @@
 ignores:
   - "babel-plugin-react-compiler"
   - "@babel/plugin-transform-destructuring"
+  - "@babel/plugin-transform-flow-strip-types"
   - "@react-native/babel-plugin-codegen"
   - "@babel/plugin-transform-react-jsx"
   - "@babel/plugin-transform-regenerator"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@babel/core": "^7.28.5",
     "@babel/plugin-transform-destructuring": "^7.28.5",
+    "@babel/plugin-transform-flow-strip-types": "^7.27.1",
     "@babel/plugin-transform-react-jsx": "^7.27.1",
     "@babel/plugin-transform-regenerator": "^7.28.4",
     "@react-native/babel-plugin-codegen": "^0.83.0",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -26,6 +26,7 @@
     "clean:build": "tamagui-build clean:build",
     "lint": "../../node_modules/.bin/biome check src",
     "lint:fix": "../../node_modules/.bin/biome check --write --unsafe src",
+    "test": "vitest run --dir src",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -38,6 +39,7 @@
     "@vxrn/utils": "workspace:*",
     "@vxrn/vite-native-client": "workspace:*",
     "babel-plugin-react-compiler": "^1.0.0",
+    "babel-plugin-syntax-hermes-parser": "^0.32.0",
     "react-native-css-interop": "^0.2.1",
     "ts-deepmerge": "^7.0.2"
   },
@@ -45,7 +47,8 @@
     "@tamagui/build": "2.3.0",
     "depcheck": "^1.4.7",
     "rolldown": "^1.0.1",
-    "vite": "^8.0.13"
+    "vite": "^8.0.13",
+    "vitest": "^4.1.0"
   },
   "peerDependencies": {
     "vite": "^8.0.13"

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -301,7 +301,9 @@ ${rootJS.code}
       enforce: 'pre',
 
       config: () => {
-        const nodeModulesFilter = /node_modules\/.*\.(tsx?|jsx?|mjs|cjs)$/
+        // accept either separator: optimizeDeps hands OS-native ids, so a
+        // forward-slash-only match dropped every node_modules file on Windows
+        const nodeModulesFilter = /node_modules[/\\].*\.(tsx?|jsx?|mjs|cjs)$/
 
         const createEnvironmentConfig = (environment: Environment) => {
           // init stats for this environment

--- a/packages/compiler/src/transformBabel.test.ts
+++ b/packages/compiler/src/transformBabel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { transformBabel } from './transformBabel'
+
+describe('transformBabel Flow parsing', () => {
+  it('parses and strips React Native Flow as-casts', async () => {
+    const result = await transformBabel(
+      '/project/VirtualViewNativeComponent.js',
+      `
+        // @flow strict-local
+        import type { HostComponent } from './HostComponent'
+        import codegenNativeComponent from './codegenNativeComponent'
+
+        type Props = $ReadOnly<{ enabled?: boolean }>
+
+        export default codegenNativeComponent<Props>('VirtualView') as HostComponent<Props>
+      `,
+      { plugins: [] }
+    )
+
+    expect(result?.code).toContain("codegenNativeComponent('VirtualView')")
+    expect(result?.code).not.toContain('HostComponent')
+  })
+})

--- a/packages/compiler/src/transformBabel.ts
+++ b/packages/compiler/src/transformBabel.ts
@@ -1,6 +1,7 @@
 import { extname, relative } from 'node:path'
 import babel from '@babel/core'
 import { resolvePath } from '@vxrn/utils'
+import { normalizePath } from 'vite'
 import { configuration } from './configure'
 import { asyncGeneratorRegex, debug } from './constants'
 import type { GetTransformProps, GetTransformResponse } from './types'
@@ -10,6 +11,12 @@ type Props = GetTransformProps & {
 }
 
 export function getBabelOptions(props: Props): babel.TransformOptions | null {
+  // Unify caller contracts (the Vite plugin hands POSIX ids; the native/patches
+  // path hands OS-native ids) so every path matcher below can assume forward
+  // slashes. Mirrors transformSWC.ts, which normalizes at its entry for the same
+  // reason — without it, RN's own files aren't matched on Windows.
+  props = { ...props, id: normalizePath(props.id.split('?')[0]) }
+
   if (props.userSetting === 'babel') {
     return getOptions(props, true)
   }
@@ -309,14 +316,11 @@ const REANIMATED_IGNORED_PATHS = [
   'node_modules/react-native-web/',
 ]
 
-// Accept either path separator: module `id`s are forward-slash from Vite but
-// backslash on native Windows. `replace(/\//g, '/')` was a no-op, so on Windows
-// the ignore list never matched react-native's own files and they were pushed
-// through the reanimated babel pass (which has no JSX/TS syntax) -> transform
-// errors. Mirrors SPEC_FILE_RE below, which already handles both separators.
-const REANIMATED_IGNORED_PATHS_REGEX = new RegExp(
-  REANIMATED_IGNORED_PATHS.map((s) => s.replace(/\//g, '[/\\\\]')).join('|')
-)
+// `id`s are normalized to forward slashes at getBabelOptions' entry, so these
+// plain forward-slash paths match on every OS. (Before that normalization the
+// backslash `id`s Windows hands us slipped past this list, pushing react-native's
+// own files through the reanimated babel pass — which has no JSX/TS parser.)
+const REANIMATED_IGNORED_PATHS_REGEX = new RegExp(REANIMATED_IGNORED_PATHS.join('|'))
 
 function shouldBabelReanimated({ code, id }: Props) {
   if (!configuration.enableReanimated) {

--- a/packages/compiler/src/transformBabel.ts
+++ b/packages/compiler/src/transformBabel.ts
@@ -309,8 +309,13 @@ const REANIMATED_IGNORED_PATHS = [
   'node_modules/react-native-web/',
 ]
 
+// Accept either path separator: module `id`s are forward-slash from Vite but
+// backslash on native Windows. `replace(/\//g, '/')` was a no-op, so on Windows
+// the ignore list never matched react-native's own files and they were pushed
+// through the reanimated babel pass (which has no JSX/TS syntax) -> transform
+// errors. Mirrors SPEC_FILE_RE below, which already handles both separators.
 const REANIMATED_IGNORED_PATHS_REGEX = new RegExp(
-  REANIMATED_IGNORED_PATHS.map((s) => s.replace(/\//g, '/')).join('|')
+  REANIMATED_IGNORED_PATHS.map((s) => s.replace(/\//g, '[/\\\\]')).join('|')
 )
 
 function shouldBabelReanimated({ code, id }: Props) {

--- a/packages/compiler/src/transformBabel.ts
+++ b/packages/compiler/src/transformBabel.ts
@@ -1,6 +1,7 @@
 import { extname, relative } from 'node:path'
 import babel from '@babel/core'
 import { resolvePath } from '@vxrn/utils'
+import hermesParserPlugin from 'babel-plugin-syntax-hermes-parser'
 import { normalizePath } from 'vite'
 import { configuration } from './configure'
 import { asyncGeneratorRegex, debug } from './constants'
@@ -113,12 +114,16 @@ export async function transformBabel(
     ].filter(Boolean),
     // non-TS files use React Native's Flow dialect. RN's own component specs are
     // Flow `.js` (`import type`, `codegenNativeComponent<T>(…)`, `(expr: Type)` casts).
-    // enable Flow syntax parsing + stripping, mirroring the TypeScript preset above
-    // (`@react-native/babel-preset` does the same: TS → preset-typescript, JS → this
-    // plugin). Without it babel can't parse Flow, so plugins like
+    // enable Hermes Flow parsing + stripping, mirroring the TypeScript preset above
+    // (`@react-native/babel-preset` uses the same parser for JS). without it babel
+    // can't parse current RN Flow syntax such as `call<T>(...) as HostComponent<T>`, so
+    // plugins like
     // @react-native/babel-plugin-codegen silently fail on RN specs and the runtime
     // "Codegen didn't run" warning fires. TS path is byte-identical (empty slice).
     plugins: [
+      ...(isTS
+        ? []
+        : [[hermesParserPlugin, { parseLangTypes: 'flow', reactRuntimeTarget: '19' }]]),
       ...(options.plugins || []),
       ...(isTS ? [] : ['@babel/plugin-transform-flow-strip-types']),
     ],

--- a/packages/compiler/src/transformBabel.ts
+++ b/packages/compiler/src/transformBabel.ts
@@ -11,10 +11,10 @@ type Props = GetTransformProps & {
 }
 
 export function getBabelOptions(props: Props): babel.TransformOptions | null {
-  // Unify caller contracts (the Vite plugin hands POSIX ids; the native/patches
+  // unify caller contracts (the Vite plugin hands POSIX ids; the native/patches
   // path hands OS-native ids) so every path matcher below can assume forward
   // slashes. Mirrors transformSWC.ts, which normalizes at its entry for the same
-  // reason — without it, RN's own files aren't matched on Windows.
+  // reason. without it, RN's own files aren't matched on Windows.
   props = { ...props, id: normalizePath(props.id.split('?')[0]) }
 
   if (props.userSetting === 'babel') {
@@ -111,9 +111,9 @@ export async function transformBabel(
         : '',
       ...(options.presets || []),
     ].filter(Boolean),
-    // Non-TS files use React Native's Flow dialect — RN's own component specs are
+    // non-TS files use React Native's Flow dialect. RN's own component specs are
     // Flow `.js` (`import type`, `codegenNativeComponent<T>(…)`, `(expr: Type)` casts).
-    // Enable Flow syntax parsing + stripping, mirroring the TypeScript preset above
+    // enable Flow syntax parsing + stripping, mirroring the TypeScript preset above
     // (`@react-native/babel-preset` does the same: TS → preset-typescript, JS → this
     // plugin). Without it babel can't parse Flow, so plugins like
     // @react-native/babel-plugin-codegen silently fail on RN specs and the runtime
@@ -328,9 +328,9 @@ const REANIMATED_IGNORED_PATHS = [
 ]
 
 // `id`s are normalized to forward slashes at getBabelOptions' entry, so these
-// plain forward-slash paths match on every OS. (Before that normalization the
+// plain forward-slash paths match on every OS. before that normalization the
 // backslash `id`s Windows hands us slipped past this list, pushing react-native's
-// own files through the reanimated babel pass — which has no JSX/TS parser.)
+// own files through the reanimated babel pass, which has no JSX/TS parser.
 const REANIMATED_IGNORED_PATHS_REGEX = new RegExp(REANIMATED_IGNORED_PATHS.join('|'))
 
 function shouldBabelReanimated({ code, id }: Props) {

--- a/packages/compiler/src/transformBabel.ts
+++ b/packages/compiler/src/transformBabel.ts
@@ -104,6 +104,17 @@ export async function transformBabel(
         : '',
       ...(options.presets || []),
     ].filter(Boolean),
+    // Non-TS files use React Native's Flow dialect — RN's own component specs are
+    // Flow `.js` (`import type`, `codegenNativeComponent<T>(…)`, `(expr: Type)` casts).
+    // Enable Flow syntax parsing + stripping, mirroring the TypeScript preset above
+    // (`@react-native/babel-preset` does the same: TS → preset-typescript, JS → this
+    // plugin). Without it babel can't parse Flow, so plugins like
+    // @react-native/babel-plugin-codegen silently fail on RN specs and the runtime
+    // "Codegen didn't run" warning fires. TS path is byte-identical (empty slice).
+    plugins: [
+      ...(options.plugins || []),
+      ...(isTS ? [] : ['@babel/plugin-transform-flow-strip-types']),
+    ],
   }
 
   try {

--- a/packages/compiler/types/transformBabel.test.d.ts
+++ b/packages/compiler/types/transformBabel.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=transformBabel.test.d.ts.map

--- a/packages/one/src/cli/build.ts
+++ b/packages/one/src/cli/build.ts
@@ -1251,7 +1251,7 @@ export async function build(args: {
 
   // once done building static we can move it to client dir:
   await moveAllFiles(staticDir, clientDir)
-  await FSExtra.rm(staticDir, { force: true, recursive: true })
+  await FSExtra.remove(staticDir)
 
   // write out the static paths (pathname => html) for the server
   const routeMap: Record<string, string> = {}

--- a/packages/one/src/router/hmrImport.native.test.ts
+++ b/packages/one/src/router/hmrImport.native.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hmrImport } from './hmrImport.native'
+
+const realRuntime = (globalThis as any).__rolldown_runtime__
+afterEach(() => {
+  ;(globalThis as any).__rolldown_runtime__ = realRuntime
+  vi.restoreAllMocks()
+})
+const setRuntime = (runtime: unknown) => {
+  ;(globalThis as any).__rolldown_runtime__ = runtime
+}
+
+describe('hmrImport (native)', () => {
+  it('rejects when no runtime is present', async () => {
+    setRuntime(undefined)
+    await expect(hmrImport('foo.tsx')).rejects.toThrow(
+      'HMR import not supported on native'
+    )
+  })
+
+  it('rejects when loadExports is missing', async () => {
+    setRuntime({})
+    await expect(hmrImport('foo.tsx')).rejects.toThrow(
+      'HMR import not supported on native'
+    )
+  })
+
+  it('resolves with the runtime exports and strips ./ and / prefixes', async () => {
+    const exports = { default: () => null }
+    const loadExports = vi.fn(() => exports)
+    setRuntime({ loadExports })
+
+    await expect(hmrImport('./foo.tsx')).resolves.toBe(exports)
+    await expect(hmrImport('/foo.tsx')).resolves.toBe(exports)
+    await expect(hmrImport('foo.tsx')).resolves.toBe(exports)
+    expect(loadExports).toHaveBeenNthCalledWith(1, 'foo.tsx')
+    expect(loadExports).toHaveBeenNthCalledWith(2, 'foo.tsx')
+    expect(loadExports).toHaveBeenNthCalledWith(3, 'foo.tsx')
+  })
+
+  it('rejects when loadExports returns null', async () => {
+    setRuntime({ loadExports: () => null })
+    await expect(hmrImport('foo.tsx')).rejects.toThrow('no exports for foo.tsx')
+  })
+
+  it('rejects when loadExports throws', async () => {
+    const boom = new Error('boom')
+    setRuntime({
+      loadExports: () => {
+        throw boom
+      },
+    })
+    await expect(hmrImport('foo.tsx')).rejects.toBe(boom)
+  })
+})

--- a/packages/one/src/router/hmrImport.native.ts
+++ b/packages/one/src/router/hmrImport.native.ts
@@ -1,8 +1,26 @@
 /**
- * Native stub: HMR cache-busting is not supported on native.
- * This avoids the dynamic import() syntax that Hermes cannot parse.
+ * Native HMR re-import.
+ *
+ * vxrn's native dev runtime re-registers the edited module into
+ * `globalThis.__rolldown_runtime__` before One evicts its route cache, so the
+ * fresh exports can be pulled straight from the runtime — no dynamic `import()`
+ * (which Hermes cannot parse). Falls back to a rejected promise when the runtime
+ * isn't present (e.g. production), so `resolve()` keeps the memoized module.
  */
-export function hmrImport(_path: string): Promise<any> {
-  // Return a rejected promise to fall back to normal import
-  return Promise.reject(new Error('HMR import not supported on native'))
+export function hmrImport(path: string): Promise<any> {
+  const runtime = (globalThis as any).__rolldown_runtime__
+  if (!runtime || typeof runtime.loadExports !== 'function') {
+    return Promise.reject(new Error('HMR import not supported on native'))
+  }
+  // route paths arrive as `./foo.tsx` / `/foo.tsx`; rolldown ids are bare (`foo.tsx`)
+  const id = String(path).replace(/^\.\//, '').replace(/^\//, '')
+  try {
+    const mod = runtime.loadExports(id)
+    if (mod == null) {
+      return Promise.reject(new Error(`no exports for ${id}`))
+    }
+    return Promise.resolve(mod)
+  } catch (error) {
+    return Promise.reject(error)
+  }
 }

--- a/packages/one/src/router/hmrImport.native.ts
+++ b/packages/one/src/router/hmrImport.native.ts
@@ -1,26 +1,28 @@
 /**
- * Native HMR re-import.
+ * native HMR re-import
  *
  * vxrn's native dev runtime re-registers the edited module into
  * `globalThis.__rolldown_runtime__` before One evicts its route cache, so the
- * fresh exports can be pulled straight from the runtime — no dynamic `import()`
- * (which Hermes cannot parse). Falls back to a rejected promise when the runtime
- * isn't present (e.g. production), so `resolve()` keeps the memoized module.
+ * fresh exports can be pulled straight from the runtime without dynamic `import()`
+ * (which Hermes cannot parse). Rejects when the runtime is unavailable so a
+ * broken development runtime is visible instead of serving a stale route.
  */
 export function hmrImport(path: string): Promise<any> {
-  const runtime = (globalThis as any).__rolldown_runtime__
+  const runtime = (
+    globalThis as typeof globalThis & {
+      __rolldown_runtime__?: { loadExports(id: string): unknown }
+    }
+  ).__rolldown_runtime__
   if (!runtime || typeof runtime.loadExports !== 'function') {
     return Promise.reject(new Error('HMR import not supported on native'))
   }
   // route paths arrive as `./foo.tsx` / `/foo.tsx`; rolldown ids are bare (`foo.tsx`)
-  const id = String(path).replace(/^\.\//, '').replace(/^\//, '')
-  try {
+  const id = path.replace(/^\.\//, '').replace(/^\//, '')
+  return Promise.resolve().then(() => {
     const mod = runtime.loadExports(id)
     if (mod == null) {
-      return Promise.reject(new Error(`no exports for ${id}`))
+      throw new Error(`no exports for ${id}`)
     }
-    return Promise.resolve(mod)
-  } catch (error) {
-    return Promise.reject(error)
-  }
+    return mod
+  })
 }

--- a/packages/one/src/router/routeHmr.native.test.ts
+++ b/packages/one/src/router/routeHmr.native.test.ts
@@ -5,6 +5,7 @@ type RouteHmrModule = typeof import('./routeHmr.native')
 describe('routeHmr.native', () => {
   let routeHmr: RouteHmrModule
   const realWindow = (globalThis as any).window
+  const realModuleUpdatedHook = globalThis.__VXRN_ON_MODULE_UPDATED__
 
   beforeEach(async () => {
     // the __VXRN_ON_MODULE_UPDATED__ registration is dev-gated and runs at module
@@ -16,7 +17,7 @@ describe('routeHmr.native', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
-    globalThis.__VXRN_ON_MODULE_UPDATED__ = undefined
+    globalThis.__VXRN_ON_MODULE_UPDATED__ = realModuleUpdatedHook
     ;(globalThis as any).window = realWindow
   })
 
@@ -48,5 +49,23 @@ describe('routeHmr.native', () => {
   it('does not throw when window / route cache is absent', () => {
     ;(globalThis as any).window = undefined
     expect(() => globalThis.__VXRN_ON_MODULE_UPDATED__!('x.tsx')).not.toThrow()
+  })
+
+  it('still notifies subscribers when route-cache eviction throws', () => {
+    const listener = vi.fn()
+    const unsubscribe = routeHmr.subscribeRouteHmr(listener)
+    ;(globalThis as any).window = {
+      __oneRouteCache: {
+        clearFile() {
+          throw new Error('cache eviction failed')
+        },
+      },
+    }
+
+    expect(() => globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')).toThrow(
+      'cache eviction failed'
+    )
+    expect(listener).toHaveBeenCalledOnce()
+    unsubscribe()
   })
 })

--- a/packages/one/src/router/routeHmr.native.test.ts
+++ b/packages/one/src/router/routeHmr.native.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type RouteHmrModule = typeof import('./routeHmr.native')
+
+describe('routeHmr.native', () => {
+  let routeHmr: RouteHmrModule
+  const realWindow = (globalThis as any).window
+
+  beforeEach(async () => {
+    // the __VXRN_ON_MODULE_UPDATED__ registration is dev-gated and runs at module
+    // load, so stub NODE_ENV then re-import to exercise it
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.resetModules()
+    routeHmr = await import('./routeHmr.native')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    globalThis.__VXRN_ON_MODULE_UPDATED__ = undefined
+    ;(globalThis as any).window = realWindow
+  })
+
+  it('registers globalThis.__VXRN_ON_MODULE_UPDATED__ in development', () => {
+    expect(typeof globalThis.__VXRN_ON_MODULE_UPDATED__).toBe('function')
+  })
+
+  it('bumps the epoch and notifies subscribers, and stops after unsubscribe', () => {
+    const before = routeHmr.getRouteHmrEpoch()
+    const listener = vi.fn()
+    const unsubscribe = routeHmr.subscribeRouteHmr(listener)
+
+    globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')
+    expect(routeHmr.getRouteHmrEpoch()).toBe(before + 1)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('evicts the route cache for the updated file when window.__oneRouteCache is present', () => {
+    const clearFile = vi.fn()
+    ;(globalThis as any).window = { __oneRouteCache: { clearFile } }
+    globalThis.__VXRN_ON_MODULE_UPDATED__!('app/_layout.tsx')
+    expect(clearFile).toHaveBeenCalledWith('app/_layout.tsx')
+  })
+
+  it('does not throw when window / route cache is absent', () => {
+    ;(globalThis as any).window = undefined
+    expect(() => globalThis.__VXRN_ON_MODULE_UPDATED__!('x.tsx')).not.toThrow()
+  })
+})

--- a/packages/one/src/router/routeHmr.native.ts
+++ b/packages/one/src/router/routeHmr.native.ts
@@ -1,0 +1,45 @@
+// Native Fast Refresh for One routes.
+//
+// On native, RN's React Refresh can't repaint One's route components: useScreens'
+// `ScreenComponent` obtains them via `value.loadRoute()` and re-wraps them
+// (`fromImport` -> `forwardRef` -> `getPageExport`), so the mounted fiber isn't in
+// the edited module's Refresh family. vxrn's native HMR runtime surfaces each
+// committed module id to `globalThis.__VXRN_ON_MODULE_UPDATED__`; we evict One's
+// route cache (bumping `useViteRoutes`' `hmrVersion` so `resolve()` re-imports the
+// edited module) and bump a subscribable epoch so subscribed `ScreenComponent`s
+// re-render and re-run `loadRoute()`. Web uses `routeHmr.ts` (a no-op store; the
+// web path repaints via the `one-hmr-update` event, see useScreens' web block).
+//
+// (The web path shows RN's re-wrapping isn't the whole story — web leaf routes
+// Fast-Refresh fine through the same wrapper — so the native-specific failure most
+// likely lives in vxrn's own React Refresh wiring; this bypasses it for routes.)
+
+declare global {
+  // vxrn's native HMR runtime invokes this (when defined) with each committed
+  // module id, so a framework can react to a hot update.
+  var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined
+}
+
+let routeHmrEpoch = 0
+const routeHmrListeners = new Set<() => void>()
+
+export const subscribeRouteHmr = (onStoreChange: () => void) => {
+  routeHmrListeners.add(onStoreChange)
+  return () => {
+    routeHmrListeners.delete(onStoreChange)
+  }
+}
+
+export const getRouteHmrEpoch = () => routeHmrEpoch
+
+if (process.env.NODE_ENV === 'development' && typeof globalThis !== 'undefined') {
+  globalThis.__VXRN_ON_MODULE_UPDATED__ = (id: string) => {
+    try {
+      if (typeof window !== 'undefined' && (window as any).__oneRouteCache) {
+        ;(window as any).__oneRouteCache.clearFile(id)
+      }
+    } catch {}
+    routeHmrEpoch++
+    routeHmrListeners.forEach((listener) => listener())
+  }
+}

--- a/packages/one/src/router/routeHmr.native.ts
+++ b/packages/one/src/router/routeHmr.native.ts
@@ -1,18 +1,7 @@
-// Native Fast Refresh for One routes.
+// native Fast Refresh for One routes
 //
-// On native, RN's React Refresh can't repaint One's route components: useScreens'
-// `ScreenComponent` obtains them via `value.loadRoute()` and re-wraps them
-// (`fromImport` -> `forwardRef` -> `getPageExport`), so the mounted fiber isn't in
-// the edited module's Refresh family. vxrn's native HMR runtime surfaces each
-// committed module id to `globalThis.__VXRN_ON_MODULE_UPDATED__`; we evict One's
-// route cache (bumping `useViteRoutes`' `hmrVersion` so `resolve()` re-imports the
-// edited module) and bump a subscribable epoch so subscribed `ScreenComponent`s
-// re-render and re-run `loadRoute()`. Web uses `routeHmr.ts` (a no-op store; the
-// web path repaints via the `one-hmr-update` event, see useScreens' web block).
-//
-// (The web path shows RN's re-wrapping isn't the whole story — web leaf routes
-// Fast-Refresh fine through the same wrapper — so the native-specific failure most
-// likely lives in vxrn's own React Refresh wiring; this bypasses it for routes.)
+// vxrn calls the global hook after committing an updated module. One evicts that
+// route and bumps this external-store epoch so mounted screens load fresh exports.
 
 declare global {
   // vxrn's native HMR runtime invokes this (when defined) with each committed
@@ -32,14 +21,17 @@ export const subscribeRouteHmr = (onStoreChange: () => void) => {
 
 export const getRouteHmrEpoch = () => routeHmrEpoch
 
-if (process.env.NODE_ENV === 'development' && typeof globalThis !== 'undefined') {
+if (process.env.NODE_ENV === 'development') {
   globalThis.__VXRN_ON_MODULE_UPDATED__ = (id: string) => {
     try {
-      if (typeof window !== 'undefined' && (window as any).__oneRouteCache) {
-        ;(window as any).__oneRouteCache.clearFile(id)
+      const routeCache =
+        typeof window === 'undefined' ? undefined : (window as any).__oneRouteCache
+      if (typeof routeCache?.clearFile === 'function') {
+        routeCache.clearFile(id)
       }
-    } catch {}
-    routeHmrEpoch++
-    routeHmrListeners.forEach((listener) => listener())
+    } finally {
+      routeHmrEpoch++
+      routeHmrListeners.forEach((listener) => listener())
+    }
   }
 }

--- a/packages/one/src/router/routeHmr.ts
+++ b/packages/one/src/router/routeHmr.ts
@@ -1,0 +1,8 @@
+// Web counterpart of routeHmr.native.ts. Web route Fast Refresh happens through
+// the `one-hmr-update` event (see useScreens' web block), so this is a no-op store
+// — its exports exist only so useScreens can import `./routeHmr` platform-agnostically.
+export const subscribeRouteHmr = (_onStoreChange: () => void): (() => void) => {
+  return () => {}
+}
+
+export const getRouteHmrEpoch = () => 0

--- a/packages/one/src/router/routeHmr.ts
+++ b/packages/one/src/router/routeHmr.ts
@@ -1,6 +1,6 @@
-// Web counterpart of routeHmr.native.ts. Web route Fast Refresh happens through
+// web counterpart of routeHmr.native.ts. Web route Fast Refresh happens through
 // the `one-hmr-update` event (see useScreens' web block), so this is a no-op store
-// — its exports exist only so useScreens can import `./routeHmr` platform-agnostically.
+// whose exports let useScreens import `./routeHmr` on either platform.
 export const subscribeRouteHmr = (_onStoreChange: () => void): (() => void) => {
   return () => {}
 }

--- a/packages/one/src/router/useScreens.tsx
+++ b/packages/one/src/router/useScreens.tsx
@@ -373,6 +373,40 @@ function getRouteMatchesForProps() {
   return clientMatches.length ? clientMatches : serverMatches
 }
 
+// Native Fast Refresh for One routes. On native, RN's React Refresh can't repaint
+// route components: `ScreenComponent` obtains them via `value.loadRoute()` and
+// re-wraps them (`fromImport` → `forwardRef` → `getPageExport`), so the mounted
+// fiber isn't in the edited module's Refresh family. vxrn's native HMR runtime
+// surfaces each updated module id to `globalThis.__oneRouteHotUpdate`; we evict the
+// route cache (bumping `useViteRoutes`' `hmrVersion` so `resolve()` re-imports the
+// edited module) and bump a subscribable epoch so subscribed `ScreenComponent`s
+// re-render and re-run `loadRoute()`. Web uses the `one-hmr-update` event instead.
+let routeHmrEpoch = 0
+const routeHmrListeners = new Set<() => void>()
+const subscribeRouteHmr = (onStoreChange: () => void) => {
+  routeHmrListeners.add(onStoreChange)
+  return () => {
+    routeHmrListeners.delete(onStoreChange)
+  }
+}
+const getRouteHmrEpoch = () => routeHmrEpoch
+
+if (
+  process.env.NODE_ENV === 'development' &&
+  process.env.TAMAGUI_TARGET === 'native' &&
+  typeof globalThis !== 'undefined'
+) {
+  ;(globalThis as any).__oneRouteHotUpdate = (id: string) => {
+    try {
+      if (typeof window !== 'undefined' && (window as any).__oneRouteCache) {
+        ;(window as any).__oneRouteCache.clearFile(id)
+      }
+    } catch {}
+    routeHmrEpoch++
+    routeHmrListeners.forEach((listener) => listener())
+  }
+}
+
 /** Wrap the component with various enhancements and add access to child routes. */
 export function getQualifiedRouteComponent(value: RouteNode) {
   if (value && qualifiedStore.has(value)) {
@@ -393,6 +427,17 @@ export function getQualifiedRouteComponent(value: RouteNode) {
         window.addEventListener('one-hmr-update', handler)
         return () => window.removeEventListener('one-hmr-update', handler)
       }, [])
+    }
+
+    // native Fast Refresh: subscribe to the route-hot epoch (bumped by
+    // __oneRouteHotUpdate above) so this component re-renders and re-runs
+    // loadRoute() to pick up the edited module's fresh exports
+    if (
+      process.env.NODE_ENV === 'development' &&
+      process.env.TAMAGUI_TARGET === 'native'
+    ) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      React.useSyncExternalStore(subscribeRouteHmr, getRouteHmrEpoch, getRouteHmrEpoch)
     }
 
     // in spa-shell mode, only SSG/SSR layouts render on the server.

--- a/packages/one/src/router/useScreens.tsx
+++ b/packages/one/src/router/useScreens.tsx
@@ -28,6 +28,7 @@ import {
 import { SpaShellContext } from './SpaShellContext'
 import { NamedSlot } from '../views/Navigator'
 import { sortRoutesWithInitial } from './sortRoutes'
+import { getRouteHmrEpoch, subscribeRouteHmr } from './routeHmr'
 import { getClientMatchesSnapshot } from '../useMatches'
 
 // `@react-navigation/core` does not expose the Screen or Group components directly, so we have to
@@ -373,40 +374,6 @@ function getRouteMatchesForProps() {
   return clientMatches.length ? clientMatches : serverMatches
 }
 
-// Native Fast Refresh for One routes. On native, RN's React Refresh can't repaint
-// route components: `ScreenComponent` obtains them via `value.loadRoute()` and
-// re-wraps them (`fromImport` → `forwardRef` → `getPageExport`), so the mounted
-// fiber isn't in the edited module's Refresh family. vxrn's native HMR runtime
-// surfaces each updated module id to `globalThis.__oneRouteHotUpdate`; we evict the
-// route cache (bumping `useViteRoutes`' `hmrVersion` so `resolve()` re-imports the
-// edited module) and bump a subscribable epoch so subscribed `ScreenComponent`s
-// re-render and re-run `loadRoute()`. Web uses the `one-hmr-update` event instead.
-let routeHmrEpoch = 0
-const routeHmrListeners = new Set<() => void>()
-const subscribeRouteHmr = (onStoreChange: () => void) => {
-  routeHmrListeners.add(onStoreChange)
-  return () => {
-    routeHmrListeners.delete(onStoreChange)
-  }
-}
-const getRouteHmrEpoch = () => routeHmrEpoch
-
-if (
-  process.env.NODE_ENV === 'development' &&
-  process.env.TAMAGUI_TARGET === 'native' &&
-  typeof globalThis !== 'undefined'
-) {
-  ;(globalThis as any).__oneRouteHotUpdate = (id: string) => {
-    try {
-      if (typeof window !== 'undefined' && (window as any).__oneRouteCache) {
-        ;(window as any).__oneRouteCache.clearFile(id)
-      }
-    } catch {}
-    routeHmrEpoch++
-    routeHmrListeners.forEach((listener) => listener())
-  }
-}
-
 /** Wrap the component with various enhancements and add access to child routes. */
 export function getQualifiedRouteComponent(value: RouteNode) {
   if (value && qualifiedStore.has(value)) {
@@ -429,9 +396,9 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       }, [])
     }
 
-    // native Fast Refresh: subscribe to the route-hot epoch (bumped by
-    // __oneRouteHotUpdate above) so this component re-renders and re-runs
-    // loadRoute() to pick up the edited module's fresh exports
+    // native Fast Refresh: subscribe to the route-hot epoch (the routeHmr.native
+    // store bumps it when vxrn reports a route module update) so this component
+    // re-renders and re-runs loadRoute() to pick up the edited module's exports
     if (
       process.env.NODE_ENV === 'development' &&
       process.env.TAMAGUI_TARGET === 'native'

--- a/packages/one/src/router/useViteRoutes.test.ts
+++ b/packages/one/src/router/useViteRoutes.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  hmrImport: vi.fn(),
+}))
+
+vi.mock('./hmrImport', () => ({
+  hmrImport: mocks.hmrImport,
+}))
+
+import { globbedRoutesToRouteContext } from './useViteRoutes'
+
+const realWindow = (globalThis as any).window
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  mocks.hmrImport.mockReset()
+  ;(globalThis as any).window = realWindow
+})
+
+async function resolveRoute(context: ReturnType<typeof globbedRoutesToRouteContext>) {
+  try {
+    return context('./index.tsx')
+  } catch (pending) {
+    await pending
+    return context('./index.tsx')
+  }
+}
+
+describe('globbedRoutesToRouteContext HMR', () => {
+  it('evicts and reloads a route under a custom router root', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    ;(globalThis as any).window = {}
+    const initialRoute = { default: () => 'initial' }
+    const updatedRoute = { default: () => 'updated' }
+    const context = globbedRoutesToRouteContext(
+      { '/routes/index.tsx': () => Promise.resolve(initialRoute) },
+      'routes'
+    )
+
+    await expect(resolveRoute(context)).resolves.toBe(initialRoute)
+
+    mocks.hmrImport.mockResolvedValue(updatedRoute)
+    ;(globalThis as any).window.__oneRouteCache.clearFile('routes/index.tsx')
+
+    await expect(resolveRoute(context)).resolves.toBe(updatedRoute)
+    expect(mocks.hmrImport).toHaveBeenCalledWith('/routes/index.tsx')
+  })
+})

--- a/packages/one/src/router/useViteRoutes.tsx
+++ b/packages/one/src/router/useViteRoutes.tsx
@@ -221,24 +221,16 @@ export function globbedRoutesToRouteContext(
       },
       clearFile: (file: string) => {
         hmrVersion++
-        // Clear only the specific file's cache
-        // file is like "app/_layout.tsx", need to match against keys like "./_layout.tsx"
-        const normalizedFile = file.replace(/^app\//, './')
-        Object.keys(loadedRoutes).forEach((key) => {
-          if (key === normalizedFile || key.endsWith(normalizedFile.replace('./', '/'))) {
-            delete loadedRoutes[key]
-          }
-        })
-        Object.keys(promises).forEach((key) => {
-          if (key === normalizedFile || key.endsWith(normalizedFile.replace('./', '/'))) {
-            delete promises[key]
-          }
-        })
-        Object.keys(preloadedModules).forEach((key) => {
-          if (key.includes(file)) {
-            delete preloadedModules[key]
-          }
-        })
+        const normalizedFile = file.replace(/\\/g, '/').replace(/^\//, '')
+        const routeId = moduleKeys.find(
+          (key) =>
+            routePaths[key].replace(/\\/g, '/').replace(/^\//, '') === normalizedFile
+        )
+        if (!routeId) return
+
+        delete loadedRoutes[routeId]
+        delete promises[routeId]
+        delete preloadedModules[routePaths[routeId]]
       },
       getVersion: () => hmrVersion,
     }
@@ -264,11 +256,10 @@ export function globbedRoutesToRouteContext(
     }
 
     if (!promises[id]) {
-      // In dev mode after HMR, use cache-busting import to get fresh module
-      // hmrImport is platform-specific: .native.ts returns rejected promise, base uses dynamic import()
+      // in dev mode after HMR, load the fresh module through the platform runtime
       let importPromise: Promise<any>
       if (process.env.NODE_ENV === 'development' && hmrVersion > 0 && routePaths[id]) {
-        importPromise = hmrImport(routePaths[id]).catch(() => routesSync[id]())
+        importPromise = hmrImport(routePaths[id])
       } else {
         importPromise = routesSync[id]()
       }

--- a/packages/one/types/router/hmrImport.native.d.ts
+++ b/packages/one/types/router/hmrImport.native.d.ts
@@ -1,6 +1,11 @@
 /**
- * Native stub: HMR cache-busting is not supported on native.
- * This avoids the dynamic import() syntax that Hermes cannot parse.
+ * native HMR re-import
+ *
+ * vxrn's native dev runtime re-registers the edited module into
+ * `globalThis.__rolldown_runtime__` before One evicts its route cache, so the
+ * fresh exports can be pulled straight from the runtime without dynamic `import()`
+ * (which Hermes cannot parse). Rejects when the runtime is unavailable so a
+ * broken development runtime is visible instead of serving a stale route.
  */
-export declare function hmrImport(_path: string): Promise<any>;
+export declare function hmrImport(path: string): Promise<any>;
 //# sourceMappingURL=hmrImport.native.d.ts.map

--- a/packages/one/types/router/hmrImport.native.test.d.ts
+++ b/packages/one/types/router/hmrImport.native.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=hmrImport.native.test.d.ts.map

--- a/packages/one/types/router/routeHmr.d.ts
+++ b/packages/one/types/router/routeHmr.d.ts
@@ -1,0 +1,3 @@
+export declare const subscribeRouteHmr: (_onStoreChange: () => void) => (() => void);
+export declare const getRouteHmrEpoch: () => number;
+//# sourceMappingURL=routeHmr.d.ts.map

--- a/packages/one/types/router/routeHmr.native.d.ts
+++ b/packages/one/types/router/routeHmr.native.d.ts
@@ -1,0 +1,6 @@
+declare global {
+    var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined;
+}
+export declare const subscribeRouteHmr: (onStoreChange: () => void) => () => void;
+export declare const getRouteHmrEpoch: () => number;
+//# sourceMappingURL=routeHmr.native.d.ts.map

--- a/packages/one/types/router/routeHmr.native.test.d.ts
+++ b/packages/one/types/router/routeHmr.native.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=routeHmr.native.test.d.ts.map

--- a/packages/one/types/router/useViteRoutes.test.d.ts
+++ b/packages/one/types/router/useViteRoutes.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=useViteRoutes.test.d.ts.map

--- a/packages/vxrn/.depcheckrc
+++ b/packages/vxrn/.depcheckrc
@@ -10,9 +10,6 @@ ignores:
   - "@react-native-community/template"
   # dynamically imported for hermes transforms in rn bundle command
   - "@babel/core"
-  # referenced as a bare babel-plugin string in flowStripPlugin (RN codegen),
-  # resolved at runtime — depcheck can't see the string usage
-  - "@react-native/babel-plugin-codegen"
   # used dynamically via resolvePath() for vite aliases
   - "@vxrn/safe-area"
   - "@vxrn/query-string"

--- a/packages/vxrn/.depcheckrc
+++ b/packages/vxrn/.depcheckrc
@@ -10,6 +10,9 @@ ignores:
   - "@react-native-community/template"
   # dynamically imported for hermes transforms in rn bundle command
   - "@babel/core"
+  # referenced as a bare babel-plugin string in flowStripPlugin (RN codegen),
+  # resolved at runtime — depcheck can't see the string usage
+  - "@react-native/babel-plugin-codegen"
   # used dynamically via resolvePath() for vite aliases
   - "@vxrn/safe-area"
   - "@vxrn/query-string"

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "@expo/config-plugins": "~55.0.6",
     "@hono/node-server": "^1.19.14",
-    "@react-native/babel-plugin-codegen": "^0.83.0",
     "@react-native/dev-middleware": "^0.83.4",
     "@vxrn/compiler": "workspace:*",
     "@vxrn/debug": "workspace:*",

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@expo/config-plugins": "~55.0.6",
     "@hono/node-server": "^1.19.14",
+    "@react-native/babel-plugin-codegen": "^0.83.0",
     "@react-native/dev-middleware": "^0.83.4",
     "@vxrn/compiler": "workspace:*",
     "@vxrn/debug": "workspace:*",

--- a/packages/vxrn/src/runtime/hmr-runtime.ts
+++ b/packages/vxrn/src/runtime/hmr-runtime.ts
@@ -26,10 +26,6 @@ declare global {
   var __VXRN_CUSTOM_HMR_HANDLER__:
     | ((socket: WebSocket, message: HMRCustomMessage) => void)
     | undefined
-  // called (when a framework defines it) with each committed module id from
-  // applyUpdates, so a framework can react to a native hot update — e.g. One's
-  // routeHmr.native.ts evicts its route cache and re-renders the route
-  var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined
 }
 
 // DO NOT EDIT THIS CLASS NAME - rolldown references it

--- a/packages/vxrn/src/runtime/hmr-runtime.ts
+++ b/packages/vxrn/src/runtime/hmr-runtime.ts
@@ -26,6 +26,10 @@ declare global {
   var __VXRN_CUSTOM_HMR_HANDLER__:
     | ((socket: WebSocket, message: HMRCustomMessage) => void)
     | undefined
+  // called (when a framework defines it) with each committed module id from
+  // applyUpdates, so a framework can react to a native hot update — e.g. One's
+  // routeHmr.native.ts evicts its route cache and re-renders the route
+  var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined
 }
 
 // DO NOT EDIT THIS CLASS NAME - rolldown references it

--- a/packages/vxrn/src/runtime/hmr-types.ts
+++ b/packages/vxrn/src/runtime/hmr-types.ts
@@ -54,7 +54,11 @@ export interface DevRuntimeInterface {
   createModuleHotContext(moduleId: string): void
   applyUpdates(boundaries: [string, string][]): void
   registerModule(id: string, exportsHolder: DevRuntimeModule['exportsHolder']): void
-  loadExports(id: string): void
+  loadExports(id: string): DevRuntimeModule['exports']
+}
+
+declare global {
+  var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined
 }
 
 // the base class is provided by rolldown's devMode runtime
@@ -72,7 +76,7 @@ class DevRuntime implements DevRuntimeInterface {
   registerModule(id: string, exportsHolder: DevRuntimeModule['exportsHolder']): void {
     throw new Error('registerModule should be implemented')
   }
-  loadExports(id: string): void {
+  loadExports(id: string): DevRuntimeModule['exports'] {
     throw new Error('loadExports should be implemented')
   }
 }

--- a/packages/vxrn/src/runtime/native-prelude.ts
+++ b/packages/vxrn/src/runtime/native-prelude.ts
@@ -75,20 +75,6 @@ if (typeof globalThis.URLSearchParams === 'undefined') {
   };
 }
 
-// suppress HMRClient.setup() error from native side
-// native calls HMRClient.setup() during bundle load but we don't use Metro HMR
-// this intercept catches the error and prevents the red screen
-var __origErrorHandler = globalThis.ErrorUtils && globalThis.ErrorUtils.getGlobalHandler && globalThis.ErrorUtils.getGlobalHandler();
-if (globalThis.ErrorUtils && globalThis.ErrorUtils.setGlobalHandler) {
-  globalThis.ErrorUtils.setGlobalHandler(function(error, isFatal) {
-    if (error && error.message && error.message.indexOf('HMRClient') !== -1) {
-      // suppress HMRClient errors silently
-      return;
-    }
-    if (__origErrorHandler) __origErrorHandler(error, isFatal);
-  });
-}
-
 // ensure console exists before any library prelude touches it in release bundles
 globalThis.console = globalThis.console || {};
 var console = globalThis.console;

--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getNativeTransformConfig,
+  hmrClientNoopPlugin,
   wrapNativeBundleModuleScope,
 } from './createNativeDevEngine'
 
@@ -64,5 +65,57 @@ describe('wrapNativeBundleModuleScope', () => {
   it('is a no-op when the runtime marker is absent (e.g. prod bundle)', () => {
     const input = 'var x = 1;\nconsole.log(x);\n'
     expect(wrapNativeBundleModuleScope(input)).toBe(input)
+  })
+})
+
+describe('hmrClientNoopPlugin', () => {
+  const plugin = hmrClientNoopPlugin()
+  const resolveId = plugin.resolveId as unknown as (source: string) => any
+  const load = plugin.load as unknown as (id: string) => any
+  const VIRTUAL_ID = '\0vxrn-hmr-client-noop'
+
+  it.each([
+    'react-native/Libraries/Utilities/HMRClient',
+    '../Utilities/HMRClient',
+    '../../Utilities/HMRClient.js',
+    // native Windows ids use backslashes
+    '..\\Utilities\\HMRClient.js',
+    '../Utilities/HMRClient.ts',
+    '../Utilities/HMRClient.tsx',
+    '../Utilities/HMRClient.cjs',
+  ])('aliases RN HMRClient specifier %j to the no-op virtual module', (source) => {
+    expect(resolveId(source)).toEqual({ id: VIRTUAL_ID, external: false })
+  })
+
+  it.each([
+    // trailing letters (no boundary) must not match
+    'react-native/Libraries/Utilities/HMRClientRegistry',
+    // Utilities must sit at a path boundary
+    'some/MyUtilities/HMRClient',
+    // unrelated RN modules
+    'react-native/Libraries/Core/setUpDeveloperTools',
+    'react',
+  ])('does not touch unrelated specifier %j', (source) => {
+    expect(resolveId(source)).toBeUndefined()
+  })
+
+  it('loads a no-op module exposing every HMRClient method RN calls', () => {
+    const result = load(VIRTUAL_ID)
+    expect(result?.moduleType).toBe('js')
+    for (const method of [
+      'setup',
+      'enable',
+      'disable',
+      'registerBundle',
+      'log',
+      'isEnabled',
+    ]) {
+      expect(result!.code).toContain(method)
+    }
+    expect(result!.code).toContain('export default HMRClient')
+  })
+
+  it('does not load unrelated ids', () => {
+    expect(load('\0some-other-virtual')).toBeUndefined()
   })
 })

--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -3,6 +3,7 @@ import {
   getHermesSWCIncludes,
   getNativeTransformConfig,
   hmrClientNoopPlugin,
+  vxrnCompilerPlugin,
   wrapNativeBundleModuleScope,
 } from './createNativeDevEngine'
 
@@ -150,5 +151,27 @@ describe('hmrClientNoopPlugin', () => {
 
   it('does not load unrelated ids', () => {
     expect(load('\0some-other-virtual')).toBeUndefined()
+  })
+})
+
+describe('vxrnCompilerPlugin React Refresh registration', () => {
+  it('keeps initial-bundle registrations visible to rolldown', async () => {
+    const previousNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'test'
+    try {
+      const plugin = vxrnCompilerPlugin('ios', true)
+      const transform = plugin.transform as (code: string, id: string) => Promise<any>
+      const result = await transform(
+        'export const marker = "$RefreshReg$("; export function Probe() { return <div>probe</div> }',
+        '/project/src/Probe.tsx'
+      )
+      const code = result.code as string
+
+      expect(code).toContain('var __vxrnRefreshReg = globalThis.$RefreshReg$')
+      expect(code).toContain('__vxrnRefreshReg(')
+      expect(code).toContain('"$RefreshReg$("')
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv
+    }
   })
 })

--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getHermesSWCIncludes,
   getNativeTransformConfig,
   wrapNativeBundleModuleScope,
 } from './createNativeDevEngine'
@@ -64,5 +65,27 @@ describe('wrapNativeBundleModuleScope', () => {
   it('is a no-op when the runtime marker is absent (e.g. prod bundle)', () => {
     const input = 'var x = 1;\nconsole.log(x);\n'
     expect(wrapNativeBundleModuleScope(input)).toBe(input)
+  })
+})
+
+describe('getHermesSWCIncludes', () => {
+  const CLASS_SET = [
+    'transform-classes',
+    'transform-class-properties',
+    'transform-class-static-block',
+    'transform-private-methods',
+    'transform-private-property-in-object',
+  ]
+
+  it('always includes the full Hermes class-transform set (dev and prod)', () => {
+    // regression: transform-classes was missing in dev, leaving a half-transpiled
+    // class hierarchy Hermes crashes on at `new Subclass()`
+    expect(getHermesSWCIncludes(true)).toEqual(expect.arrayContaining(CLASS_SET))
+    expect(getHermesSWCIncludes(false)).toEqual(expect.arrayContaining(CLASS_SET))
+  })
+
+  it('adds transform-async-to-generator only in production', () => {
+    expect(getHermesSWCIncludes(true)).not.toContain('transform-async-to-generator')
+    expect(getHermesSWCIncludes(false)).toContain('transform-async-to-generator')
   })
 })

--- a/packages/vxrn/src/utils/createNativeDevEngine.test.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.test.ts
@@ -93,33 +93,43 @@ describe('getHermesSWCIncludes', () => {
 
 describe('hmrClientNoopPlugin', () => {
   const plugin = hmrClientNoopPlugin()
-  const resolveId = plugin.resolveId as unknown as (source: string) => any
+  const resolveId = plugin.resolveId as unknown as (
+    source: string,
+    importer?: string
+  ) => any
   const load = plugin.load as unknown as (id: string) => any
   const VIRTUAL_ID = '\0vxrn-hmr-client-noop'
 
   it.each([
-    'react-native/Libraries/Utilities/HMRClient',
-    '../Utilities/HMRClient',
-    '../../Utilities/HMRClient.js',
+    ['react-native/Libraries/Utilities/HMRClient', undefined],
+    ['../Utilities/HMRClient', '/project/node_modules/react-native/Libraries/Core.js'],
+    ['../../Utilities/HMRClient.js', '/project/react-native/Libraries/Core.js'],
     // native Windows ids use backslashes
-    '..\\Utilities\\HMRClient.js',
-    '../Utilities/HMRClient.ts',
-    '../Utilities/HMRClient.tsx',
-    '../Utilities/HMRClient.cjs',
-  ])('aliases RN HMRClient specifier %j to the no-op virtual module', (source) => {
-    expect(resolveId(source)).toEqual({ id: VIRTUAL_ID, external: false })
-  })
+    ['..\\Utilities\\HMRClient.js', 'C:\\project\\react-native\\Libraries\\Core.js'],
+    ['../Utilities/HMRClient.ts', '/project/node_modules/react-native/Core.js'],
+    ['../Utilities/HMRClient.tsx', '/project/node_modules/react-native/Core.js'],
+    ['../Utilities/HMRClient.cjs', '/project/node_modules/react-native/Core.js'],
+  ])(
+    'aliases RN HMRClient specifier %j to the no-op virtual module',
+    (source, importer) => {
+      expect(resolveId(source, importer)).toEqual({ id: VIRTUAL_ID, external: false })
+    }
+  )
 
   it.each([
     // trailing letters (no boundary) must not match
     'react-native/Libraries/Utilities/HMRClientRegistry',
-    // Utilities must sit at a path boundary
+    // the Utilities segment must start at a path boundary
     'some/MyUtilities/HMRClient',
     // unrelated RN modules
     'react-native/Libraries/Core/setUpDeveloperTools',
     'react',
   ])('does not touch unrelated specifier %j', (source) => {
     expect(resolveId(source)).toBeUndefined()
+  })
+
+  it('does not alias an app-authored Utilities/HMRClient module', () => {
+    expect(resolveId('../Utilities/HMRClient', '/project/src/App.tsx')).toBeUndefined()
   })
 
   it('loads a no-op module exposing every HMRClient method RN calls', () => {

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -525,7 +525,6 @@ try {
         return
       }
       const updates = (result as any).updates || []
-
       for (const item of updates) {
         const update = item.update || item
         if (update.type === 'Patch' && update.code) {
@@ -879,7 +878,7 @@ function cssStubPlugin(): Plugin {
  * react-native codegen, react compiler, and react-refresh (dev only) —
  * same pipeline as metro, single babel pass per file.
  */
-function vxrnCompilerPlugin(platform: string, dev: boolean): Plugin {
+export function vxrnCompilerPlugin(platform: string, dev: boolean): Plugin {
   let compiler: typeof import('@vxrn/compiler') | null = null
 
   // whether a file is a user file that should get react-refresh wiring
@@ -915,7 +914,17 @@ function vxrnCompilerPlugin(platform: string, dev: boolean): Plugin {
           const existingPlugins = babelOptions?.plugins || []
           babelOptions = {
             ...babelOptions,
-            plugins: [...existingPlugins, 'react-refresh/babel'],
+            plugins: [
+              ...existingPlugins,
+              [
+                'react-refresh/babel',
+                {
+                  skipEnvCheck: true,
+                  refreshReg: '__vxrnRefreshReg',
+                  refreshSig: '__vxrnRefreshSig',
+                },
+              ],
+            ],
           }
         }
 
@@ -939,6 +948,9 @@ if (globalThis.__ReactRefresh) {
   };
   globalThis.$RefreshSig$ = globalThis.__ReactRefresh.createSignatureFunctionForTransform;
 }
+// keep registration calls local so rolldown retains them in the initial bundle.
+var __vxrnRefreshReg = globalThis.$RefreshReg$;
+var __vxrnRefreshSig = globalThis.$RefreshSig$;
 
 ${out}
 

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -920,11 +920,37 @@ function flowStripPlugin(): Plugin {
       async handler(code, id) {
         if (!FLOW_FILE_PATTERN.test(id)) return
 
+        // RN's own component specs are Flow `.js`, and @react-native/babel-plugin-codegen
+        // must rewrite `codegenNativeComponent<Props>(…)` into a static view-config WHILE
+        // the Flow type argument is still present. This plugin runs before the compiler and
+        // strips Flow, which would erase that type — so run codegen here first (with a Flow
+        // parser), then strip Flow from the result. Without it the raw
+        // `codegenNativeComponent(…)` call survives into the bundle and RN logs
+        // "Codegen didn't run for <Component>" (slated to become a hard error upstream).
+        let working = code
+        if (code.includes('codegenNativeComponent')) {
+          try {
+            const babel = await import('@babel/core')
+            const codegenResult = await babel.transformAsync(code, {
+              filename: id,
+              babelrc: false,
+              configFile: false,
+              sourceMaps: false,
+              parserOpts: { plugins: ['flow', 'jsx'] },
+              plugins: ['@react-native/babel-plugin-codegen'],
+            })
+            if (codegenResult?.code) working = codegenResult.code
+          } catch {
+            // fall through to the plain Flow strip — worst case is the original
+            // warning, never a broken build
+          }
+        }
+
         try {
           const fft = await import('fast-flow-transform')
           const result = await fft.default({
             filename: id,
-            source: code,
+            source: working,
             sourcemap: true,
             dialect: 'flow',
             format: 'pretty',

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -806,7 +806,7 @@ function environmentGuardPlugin(): Plugin {
  * (`setup`/`enable`/`disable`/`registerBundle`/`log`/`isEnabled`) mirrors the
  * methods RN calls on it.
  */
-function hmrClientNoopPlugin(): Plugin {
+export function hmrClientNoopPlugin(): Plugin {
   // Match RN's HMRClient by module path, tolerating either separator (native
   // Windows ids use `\`) and an optional js/ts extension.
   const RN_HMR_CLIENT_RE = /(^|[\\/])Utilities[\\/]HMRClient(\.[cm]?[jt]sx?)?$/

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -334,6 +334,7 @@ async function downlevelClassFieldsInBundle(code: string): Promise<string> {
       env: {
         targets: { node: 9999 },
         include: [
+          'transform-classes',
           'transform-class-properties',
           'transform-class-static-block',
           'transform-private-methods',
@@ -1024,14 +1025,20 @@ function hermesCompatSWCPlugin(dev: boolean): Plugin {
       try {
         if (!swc) swc = await import('@swc/core')
 
-        // hermes needs class properties downleveled; prod also needs
-        // classes and async-to-generator for bytecode compilation
+        // hermes needs classes fully downleveled. Downleveling only the class
+        // *fields* while leaving `class ... extends` as modern ES6 (the previous
+        // dev-only behavior) produces a half-transpiled class hierarchy Hermes
+        // chokes on at `new Subclass()` (TypeError: Cannot read property
+        // 'prototype' of undefined) — so `transform-classes` must be
+        // unconditional, matching the fully-classed production bundle. Only
+        // async-to-generator stays prod-only (bytecode compilation).
         const envIncludes = [
+          'transform-classes',
           'transform-class-properties',
           'transform-class-static-block',
           'transform-private-methods',
           'transform-private-property-in-object',
-          ...(!dev ? ['transform-classes', 'transform-async-to-generator'] : []),
+          ...(!dev ? ['transform-async-to-generator'] : []),
         ]
 
         const result = await swc.transform(code, {

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -17,6 +17,29 @@ import { getNativePrelude } from '../runtime/native-prelude'
 // files that contain Flow syntax and need stripping
 const FLOW_FILE_PATTERN = /node_modules[\\/](?:react-native|@react-native)[\\/].*\.js$/
 
+// Hermes needs the whole class shape lowered *together*. Downleveling only the
+// class fields while leaving `class ... extends` as modern ES6 produces a
+// half-transpiled hierarchy Hermes crashes on at `new Subclass()` (TypeError:
+// Cannot read property 'prototype' of undefined). These must stay atomic across
+// both SWC call sites and dev/prod — defining them once makes that a fact, not a
+// convention (the original bug was `transform-classes` missing from one of two
+// hand-copied include lists).
+const HERMES_CLASS_TRANSFORMS = [
+  'transform-classes',
+  'transform-class-properties',
+  'transform-class-static-block',
+  'transform-private-methods',
+  'transform-private-property-in-object',
+] as const
+
+// prod-only: needed for hermesc bytecode AOT compilation, not the dev interpreter
+const HERMES_PROD_TRANSFORMS = ['transform-async-to-generator'] as const
+
+/** SWC `env.include` for Hermes-compatible downleveling — see HERMES_CLASS_TRANSFORMS. */
+export function getHermesSWCIncludes(dev: boolean): string[] {
+  return [...HERMES_CLASS_TRANSFORMS, ...(dev ? [] : HERMES_PROD_TRANSFORMS)]
+}
+
 interface NativeDevEngineOptions {
   root: string
   port: number
@@ -333,13 +356,8 @@ async function downlevelClassFieldsInBundle(code: string): Promise<string> {
       isModule: false,
       env: {
         targets: { node: 9999 },
-        include: [
-          'transform-classes',
-          'transform-class-properties',
-          'transform-class-static-block',
-          'transform-private-methods',
-          'transform-private-property-in-object',
-        ],
+        // dev-only runtime prelude: the class set only, no prod bytecode transforms
+        include: [...HERMES_CLASS_TRANSFORMS],
       },
       jsc: {
         parser: { syntax: 'ecmascript' },
@@ -1025,21 +1043,9 @@ function hermesCompatSWCPlugin(dev: boolean): Plugin {
       try {
         if (!swc) swc = await import('@swc/core')
 
-        // hermes needs classes fully downleveled. Downleveling only the class
-        // *fields* while leaving `class ... extends` as modern ES6 (the previous
-        // dev-only behavior) produces a half-transpiled class hierarchy Hermes
-        // chokes on at `new Subclass()` (TypeError: Cannot read property
-        // 'prototype' of undefined) — so `transform-classes` must be
-        // unconditional, matching the fully-classed production bundle. Only
-        // async-to-generator stays prod-only (bytecode compilation).
-        const envIncludes = [
-          'transform-classes',
-          'transform-class-properties',
-          'transform-class-static-block',
-          'transform-private-methods',
-          'transform-private-property-in-object',
-          ...(!dev ? ['transform-async-to-generator'] : []),
-        ]
+        // app modules: the Hermes class set (unconditional), plus async-to-generator
+        // in prod only (see HERMES_CLASS_TRANSFORMS / HERMES_PROD_TRANSFORMS)
+        const envIncludes = getHermesSWCIncludes(dev)
 
         const result = await swc.transform(code, {
           filename: id,

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -1131,6 +1131,14 @@ class ReactNativeDevRuntime extends BaseDevRuntime {
           ctx.acceptCallbacks[j].fn(this.modules[moduleId].exports);
         }
       }
+      // surface the updated module id to One's route-hot hook so it can evict its
+      // route cache and re-render. RN's React Refresh can't repaint One's route
+      // components (they're re-wrapped away from the edited module's Refresh
+      // family), and the web 'one:route-update' event has no equivalent on the
+      // native /hot transport, so this generic global hook is the bridge.
+      try {
+        if (globalThis.__oneRouteHotUpdate && moduleId) globalThis.__oneRouteHotUpdate(moduleId);
+      } catch (e) {}
     }
   }
 

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -17,11 +17,11 @@ import { getNativePrelude } from '../runtime/native-prelude'
 // files that contain Flow syntax and need stripping
 const FLOW_FILE_PATTERN = /node_modules[\\/](?:react-native|@react-native)[\\/].*\.js$/
 
-// Hermes needs the whole class shape lowered *together*. Downleveling only the
+// Hermes needs the whole class shape lowered *together*. downleveling only the
 // class fields while leaving `class ... extends` as modern ES6 produces a
 // half-transpiled hierarchy Hermes crashes on at `new Subclass()` (TypeError:
 // Cannot read property 'prototype' of undefined). These must stay atomic across
-// both SWC call sites and dev/prod — defining them once makes that a fact, not a
+// both SWC call sites and dev/prod. defining them once makes that a fact, not a
 // convention (the original bug was `transform-classes` missing from one of two
 // hand-copied include lists).
 const HERMES_CLASS_TRANSFORMS = [
@@ -35,7 +35,7 @@ const HERMES_CLASS_TRANSFORMS = [
 // prod-only: needed for hermesc bytecode AOT compilation, not the dev interpreter
 const HERMES_PROD_TRANSFORMS = ['transform-async-to-generator'] as const
 
-/** SWC `env.include` for Hermes-compatible downleveling — see HERMES_CLASS_TRANSFORMS. */
+/** SWC `env.include` for Hermes-compatible downleveling; see HERMES_CLASS_TRANSFORMS. */
 export function getHermesSWCIncludes(dev: boolean): string[] {
   return [...HERMES_CLASS_TRANSFORMS, ...(dev ? [] : HERMES_PROD_TRANSFORMS)]
 }
@@ -214,7 +214,7 @@ function getNativePlugins(
     serverFileExclusionPlugin(),
     // guard server-only / client-only / web-only / native-only imports
     environmentGuardPlugin(),
-    // alias RN's Metro HMR client to a no-op — vxrn drives HMR itself (the
+    // alias RN's Metro HMR client to a no-op; vxrn drives HMR itself (the
     // rolldown-runtime WebSocket); RN's client otherwise opens a /hot socket and
     // red-boxes "unknown-message [object Object]" on every edit (new arch)
     hmrClientNoopPlugin(),
@@ -223,14 +223,14 @@ function getNativePlugins(
     // handle import.meta.glob (used by One's route system)
     viteImportGlobPlugin({ root }),
     // @vxrn/compiler babel transforms: reanimated worklets, async generators,
-    // react-native codegen, react compiler — same pipeline as metro. Runs BEFORE
+    // react-native codegen, react compiler, same pipeline as metro. runs before
     // flowStripPlugin so react-native's Flow `.js` specs reach codegen with their
-    // type argument intact — stripping Flow first would erase it (which is why the
+    // type argument intact. stripping Flow first would erase it (which is why the
     // codegen "didn't run for <Component>" warning fired).
     vxrnCompilerPlugin(platform, dev),
     // strip Flow from any react-native / @react-native `.js` the compiler didn't
-    // handle — the guaranteed safety net before rolldown's oxc core parse (which
-    // can't parse Flow). Now downstream of the compiler, so codegen sees the types.
+    // handle, the guaranteed safety net before rolldown's oxc core parse (which
+    // can't parse Flow). now downstream of the compiler, so codegen sees the types.
     flowStripPlugin(),
     // guard undefined native methods in NativeAnimatedHelper
     nativeAnimatedGuardPlugin(),
@@ -813,38 +813,42 @@ function environmentGuardPlugin(): Plugin {
 }
 
 /**
- * Alias react-native's Metro HMR client (`Libraries/Utilities/HMRClient`) to a
+ * alias react-native's Metro HMR client (`Libraries/Utilities/HMRClient`) to a
  * no-op module.
  *
  * vxrn drives Fast Refresh itself over the rolldown-runtime WebSocket and never
  * speaks Metro's `/hot` protocol. On the new architecture, react-native
  * `registerCallableModule('HMRClient', require('./HMRClient'))`s its real client
- * eagerly at startup — before vxrn's late override runs — and `emplace` keeps
+ * eagerly at startup before vxrn's late override runs, and `emplace` keeps
  * that first registration. RN's client then opens a `MetroHMRClient` socket that
  * receives vxrn's `hmr:*` frames it can't parse and red-boxes
  * `unknown-message [object Object]` on every edit.
  *
- * Neutralizing the module at its source means RN registers *this* no-op as the
- * one-and-only `HMRClient` (working WITH `emplace`, so it's arch-agnostic) and
+ * neutralizing the module at its source means RN registers *this* no-op as the
+ * one-and-only `HMRClient` (working with `emplace`, so it's arch-agnostic) and
  * the stray socket is never opened. The class-shaped surface
  * (`setup`/`enable`/`disable`/`registerBundle`/`log`/`isEnabled`) mirrors the
  * methods RN calls on it.
  */
 export function hmrClientNoopPlugin(): Plugin {
-  // Match RN's HMRClient by module path, tolerating either separator (native
-  // Windows ids use `\`) and an optional js/ts extension.
+  // match RN's HMRClient by module path, tolerating either separator (native
+  // Windows ids use `\`) and an optional js/ts extension
   const RN_HMR_CLIENT_RE = /(^|[\\/])Utilities[\\/]HMRClient(\.[cm]?[jt]sx?)?$/
   return {
     name: 'vxrn:hmr-client-noop',
-    resolveId(source) {
-      if (RN_HMR_CLIENT_RE.test(source))
+    resolveId(source, importer) {
+      const fromReactNative =
+        source.startsWith('react-native/') ||
+        (importer != null && /(^|[\\/])react-native[\\/]/.test(importer))
+      if (fromReactNative && RN_HMR_CLIENT_RE.test(source)) {
         return { id: '\0vxrn-hmr-client-noop', external: false }
+      }
     },
     load(id) {
       if (id === '\0vxrn-hmr-client-noop') {
         return {
           code: `const HMRClient = { setup() {}, enable() {}, disable() {}, registerBundle() {}, log() {}, isEnabled() { return false } }\nexport default HMRClient`,
-          moduleType: 'js' as any,
+          moduleType: 'js',
         }
       }
     },
@@ -1191,7 +1195,9 @@ class ReactNativeDevRuntime extends BaseDevRuntime {
       // socket, so this generic vxrn global is the bridge.
       try {
         if (globalThis.__VXRN_ON_MODULE_UPDATED__ && moduleId) globalThis.__VXRN_ON_MODULE_UPDATED__(moduleId);
-      } catch (e) {}
+      } catch (error) {
+        console.error('[vxrn HMR]: module update hook failed', error);
+      }
     }
   }
 

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -1131,13 +1131,13 @@ class ReactNativeDevRuntime extends BaseDevRuntime {
           ctx.acceptCallbacks[j].fn(this.modules[moduleId].exports);
         }
       }
-      // surface the updated module id to One's route-hot hook so it can evict its
-      // route cache and re-render. RN's React Refresh can't repaint One's route
-      // components (they're re-wrapped away from the edited module's Refresh
-      // family), and the web 'one:route-update' event has no equivalent on the
-      // native /hot transport, so this generic global hook is the bridge.
+      // surface each committed module id to the framework hot-update hook (if one
+      // is registered). RN's React Refresh can't repaint frameworks that re-wrap
+      // route components away from the edited module's Refresh family (e.g. One),
+      // and the web route-update event has no equivalent on the native /hot
+      // socket, so this generic vxrn global is the bridge.
       try {
-        if (globalThis.__oneRouteHotUpdate && moduleId) globalThis.__oneRouteHotUpdate(moduleId);
+        if (globalThis.__VXRN_ON_MODULE_UPDATED__ && moduleId) globalThis.__VXRN_ON_MODULE_UPDATED__(moduleId);
       } catch (e) {}
     }
   }

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -191,6 +191,10 @@ function getNativePlugins(
     serverFileExclusionPlugin(),
     // guard server-only / client-only / web-only / native-only imports
     environmentGuardPlugin(),
+    // alias RN's Metro HMR client to a no-op — vxrn drives HMR itself (the
+    // rolldown-runtime WebSocket); RN's client otherwise opens a /hot socket and
+    // red-boxes "unknown-message [object Object]" on every edit (new arch)
+    hmrClientNoopPlugin(),
     // stub CSS imports — native doesn't support CSS and rolldown removed CSS bundling
     cssStubPlugin(),
     // handle import.meta.glob (used by One's route system)
@@ -469,14 +473,6 @@ try {
         // downlevel class fields from the rolldown runtime (virtual module
         // skipped by the per-file SWC plugin) so old Hermes can parse them
         code = await downlevelClassFieldsInBundle(code)
-
-        // register a no-op HMRClient so RN's native side doesn't error when calling HMRClient.setup()
-        // our actual HMR is handled via the outro WebSocket connection
-        const hmrClientStub = `registerCallableModule("HMRClient",{setup:function(){},enable:function(){},disable:function(){},registerBundle:function(){},log:function(){}})`
-        code = code.replace(
-          /registerCallableModule\s*\(\s*["']AppRegistry["']/,
-          (match) => hmrClientStub + ',' + match
-        )
 
         // wrap module code in a function scope so top-level `var`s (e.g. RN
         // fetch.js's `Headers`/`Request`) don't leak as non-configurable
@@ -788,6 +784,45 @@ function environmentGuardPlugin(): Plugin {
         }
       }
       if (id.startsWith('\0env-guard-noop:')) return { code: '', moduleType: 'js' as any }
+    },
+  }
+}
+
+/**
+ * Alias react-native's Metro HMR client (`Libraries/Utilities/HMRClient`) to a
+ * no-op module.
+ *
+ * vxrn drives Fast Refresh itself over the rolldown-runtime WebSocket and never
+ * speaks Metro's `/hot` protocol. On the new architecture, react-native
+ * `registerCallableModule('HMRClient', require('./HMRClient'))`s its real client
+ * eagerly at startup — before vxrn's late override runs — and `emplace` keeps
+ * that first registration. RN's client then opens a `MetroHMRClient` socket that
+ * receives vxrn's `hmr:*` frames it can't parse and red-boxes
+ * `unknown-message [object Object]` on every edit.
+ *
+ * Neutralizing the module at its source means RN registers *this* no-op as the
+ * one-and-only `HMRClient` (working WITH `emplace`, so it's arch-agnostic) and
+ * the stray socket is never opened. The class-shaped surface
+ * (`setup`/`enable`/`disable`/`registerBundle`/`log`/`isEnabled`) mirrors the
+ * methods RN calls on it.
+ */
+function hmrClientNoopPlugin(): Plugin {
+  // Match RN's HMRClient by module path, tolerating either separator (native
+  // Windows ids use `\`) and an optional js/ts extension.
+  const RN_HMR_CLIENT_RE = /(^|[\\/])Utilities[\\/]HMRClient(\.[cm]?[jt]sx?)?$/
+  return {
+    name: 'vxrn:hmr-client-noop',
+    resolveId(source) {
+      if (RN_HMR_CLIENT_RE.test(source))
+        return { id: '\0vxrn-hmr-client-noop', external: false }
+    },
+    load(id) {
+      if (id === '\0vxrn-hmr-client-noop') {
+        return {
+          code: `const HMRClient = { setup() {}, enable() {}, disable() {}, registerBundle() {}, log() {}, isEnabled() { return false } }\nexport default HMRClient`,
+          moduleType: 'js' as any,
+        }
+      }
     },
   }
 }

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -195,15 +195,20 @@ function getNativePlugins(
     cssStubPlugin(),
     // handle import.meta.glob (used by One's route system)
     viteImportGlobPlugin({ root }),
-    // strip Flow types from react-native and @react-native packages
+    // @vxrn/compiler babel transforms: reanimated worklets, async generators,
+    // react-native codegen, react compiler — same pipeline as metro. Runs BEFORE
+    // flowStripPlugin so react-native's Flow `.js` specs reach codegen with their
+    // type argument intact — stripping Flow first would erase it (which is why the
+    // codegen "didn't run for <Component>" warning fired).
+    vxrnCompilerPlugin(platform, dev),
+    // strip Flow from any react-native / @react-native `.js` the compiler didn't
+    // handle — the guaranteed safety net before rolldown's oxc core parse (which
+    // can't parse Flow). Now downstream of the compiler, so codegen sees the types.
     flowStripPlugin(),
     // guard undefined native methods in NativeAnimatedHelper
     nativeAnimatedGuardPlugin(),
     // handle asset imports (.png, .jpg, .ttf, etc.)
     assetPlugin({ root, platform, assetsDest }),
-    // @vxrn/compiler babel transforms: reanimated worklets, async generators,
-    // react-native codegen, react compiler — same pipeline as metro
-    vxrnCompilerPlugin(platform, dev),
     // hermes compat: transform class properties and private fields
     hermesCompatSWCPlugin(dev),
   ]
@@ -920,37 +925,11 @@ function flowStripPlugin(): Plugin {
       async handler(code, id) {
         if (!FLOW_FILE_PATTERN.test(id)) return
 
-        // RN's own component specs are Flow `.js`, and @react-native/babel-plugin-codegen
-        // must rewrite `codegenNativeComponent<Props>(…)` into a static view-config WHILE
-        // the Flow type argument is still present. This plugin runs before the compiler and
-        // strips Flow, which would erase that type — so run codegen here first (with a Flow
-        // parser), then strip Flow from the result. Without it the raw
-        // `codegenNativeComponent(…)` call survives into the bundle and RN logs
-        // "Codegen didn't run for <Component>" (slated to become a hard error upstream).
-        let working = code
-        if (code.includes('codegenNativeComponent')) {
-          try {
-            const babel = await import('@babel/core')
-            const codegenResult = await babel.transformAsync(code, {
-              filename: id,
-              babelrc: false,
-              configFile: false,
-              sourceMaps: false,
-              parserOpts: { plugins: ['flow', 'jsx'] },
-              plugins: ['@react-native/babel-plugin-codegen'],
-            })
-            if (codegenResult?.code) working = codegenResult.code
-          } catch {
-            // fall through to the plain Flow strip — worst case is the original
-            // warning, never a broken build
-          }
-        }
-
         try {
           const fft = await import('fast-flow-transform')
           const result = await fft.default({
             filename: id,
-            source: working,
+            source: code,
             sourcemap: true,
             dialect: 'flow',
             format: 'pretty',

--- a/packages/vxrn/types/runtime/hmr-types.d.ts
+++ b/packages/vxrn/types/runtime/hmr-types.d.ts
@@ -58,7 +58,10 @@ export interface DevRuntimeInterface {
     createModuleHotContext(moduleId: string): void;
     applyUpdates(boundaries: [string, string][]): void;
     registerModule(id: string, exportsHolder: DevRuntimeModule['exportsHolder']): void;
-    loadExports(id: string): void;
+    loadExports(id: string): DevRuntimeModule['exports'];
+}
+declare global {
+    var __VXRN_ON_MODULE_UPDATED__: ((moduleId: string) => void) | undefined;
 }
 declare class DevRuntime implements DevRuntimeInterface {
     clientId: string;
@@ -67,7 +70,7 @@ declare class DevRuntime implements DevRuntimeInterface {
     createModuleHotContext(moduleId: string): void;
     applyUpdates(boundaries: [string, string][]): void;
     registerModule(id: string, exportsHolder: DevRuntimeModule['exportsHolder']): void;
-    loadExports(id: string): void;
+    loadExports(id: string): DevRuntimeModule['exports'];
 }
 export type { DevRuntime };
 export interface DevRuntimeMessenger {

--- a/packages/vxrn/types/utils/createNativeDevEngine.d.ts
+++ b/packages/vxrn/types/utils/createNativeDevEngine.d.ts
@@ -95,5 +95,12 @@ export declare function buildNativeBundle(options: NativeBuildOptions): Promise<
  * methods RN calls on it.
  */
 export declare function hmrClientNoopPlugin(): Plugin;
+/**
+ * Pipe files through @vxrn/compiler's babel transforms.
+ * Handles reanimated worklet compilation, async generator downleveling,
+ * react-native codegen, react compiler, and react-refresh (dev only) —
+ * same pipeline as metro, single babel pass per file.
+ */
+export declare function vxrnCompilerPlugin(platform: string, dev: boolean): Plugin;
 export {};
 //# sourceMappingURL=createNativeDevEngine.d.ts.map

--- a/packages/vxrn/types/utils/createNativeDevEngine.d.ts
+++ b/packages/vxrn/types/utils/createNativeDevEngine.d.ts
@@ -6,6 +6,8 @@
  * https://github.com/leegeunhyeok/rollipop
  */
 import type { Plugin } from 'rolldown';
+/** SWC `env.include` for Hermes-compatible downleveling; see HERMES_CLASS_TRANSFORMS. */
+export declare function getHermesSWCIncludes(dev: boolean): string[];
 interface NativeDevEngineOptions {
     root: string;
     port: number;
@@ -74,5 +76,24 @@ export declare function buildNativeBundle(options: NativeBuildOptions): Promise<
     code: string;
     map?: string;
 }>;
+/**
+ * alias react-native's Metro HMR client (`Libraries/Utilities/HMRClient`) to a
+ * no-op module.
+ *
+ * vxrn drives Fast Refresh itself over the rolldown-runtime WebSocket and never
+ * speaks Metro's `/hot` protocol. On the new architecture, react-native
+ * `registerCallableModule('HMRClient', require('./HMRClient'))`s its real client
+ * eagerly at startup before vxrn's late override runs, and `emplace` keeps
+ * that first registration. RN's client then opens a `MetroHMRClient` socket that
+ * receives vxrn's `hmr:*` frames it can't parse and red-boxes
+ * `unknown-message [object Object]` on every edit.
+ *
+ * neutralizing the module at its source means RN registers *this* no-op as the
+ * one-and-only `HMRClient` (working with `emplace`, so it's arch-agnostic) and
+ * the stray socket is never opened. The class-shaped surface
+ * (`setup`/`enable`/`disable`/`registerBundle`/`log`/`isEnabled`) mirrors the
+ * methods RN calls on it.
+ */
+export declare function hmrClientNoopPlugin(): Plugin;
 export {};
 //# sourceMappingURL=createNativeDevEngine.d.ts.map

--- a/tests/test-deploy-flash/app/routes.d.ts
+++ b/tests/test-deploy-flash/app/routes.d.ts
@@ -65,7 +65,7 @@ declare module 'one' {
         | `/project/[projectId]/[sessionId]/prod`
         | `/settings`
         | `/terminal`
-      DynamicRoutes: 
+      DynamicRoutes:
         | `/(app)/(panel)/nested-project/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
         | `/(app)/(workspace)/(panel)/nested-project/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
         | `/(app)/(workspace)/nested-project/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
@@ -80,7 +80,7 @@ declare module 'one' {
         | `/nested-project/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
         | `/project/${OneRouter.SingleRoutePart<T>}`
         | `/project/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
-      DynamicRouteTemplate: 
+      DynamicRouteTemplate:
         | `/(app)/(panel)/nested-project/[projectId]/[sessionId]`
         | `/(app)/(workspace)/(panel)/nested-project/[projectId]/[sessionId]`
         | `/(app)/(workspace)/nested-project/[projectId]/[sessionId]`

--- a/tests/test-params-stability/app/routes.d.ts
+++ b/tests/test-params-stability/app/routes.d.ts
@@ -13,14 +13,14 @@ declare module 'one' {
         | `/(site)/thing/[id]/main`
         | `/_sitemap`
         | `/thing/[id]/main`
-      DynamicRoutes: 
+      DynamicRoutes:
         | `/(site)/preview/${OneRouter.SingleRoutePart<T>}`
         | `/(site)/project/${OneRouter.SingleRoutePart<T>}/main`
         | `/(site)/thing/${OneRouter.SingleRoutePart<T>}`
         | `/preview/${OneRouter.SingleRoutePart<T>}`
         | `/project/${OneRouter.SingleRoutePart<T>}/main`
         | `/thing/${OneRouter.SingleRoutePart<T>}`
-      DynamicRouteTemplate: 
+      DynamicRouteTemplate:
         | `/(site)/preview/[id]`
         | `/(site)/project/[id]/main`
         | `/(site)/thing/[id]`

--- a/tests/test-redirect-flash/app/routes.d.ts
+++ b/tests/test-redirect-flash/app/routes.d.ts
@@ -19,7 +19,7 @@ declare module 'one' {
         | `/factory`
         | `/nested`
         | `/nested/[id]/`
-      DynamicRoutes: 
+      DynamicRoutes:
         | `/(app)/nested/${OneRouter.SingleRoutePart<T>}`
         | `/(app)/nested/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
         | `/(app)/project/${OneRouter.SingleRoutePart<T>}`
@@ -28,7 +28,7 @@ declare module 'one' {
         | `/nested/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
         | `/project/${OneRouter.SingleRoutePart<T>}`
         | `/project/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
-      DynamicRouteTemplate: 
+      DynamicRouteTemplate:
         | `/(app)/nested/[id]`
         | `/(app)/nested/[id]/[sub]`
         | `/(app)/project/[projectId]`

--- a/tests/test-sootsim-back/app/routes.d.ts
+++ b/tests/test-sootsim-back/app/routes.d.ts
@@ -28,12 +28,12 @@ declare module 'one' {
         | `/forum`
         | `/forum/rankings`
         | `/picks`
-      DynamicRoutes: 
+      DynamicRoutes:
         | `/(auth)/thread/${OneRouter.SingleRoutePart<T>}`
         | `/(site)/docs/${string}`
         | `/docs/${string}`
         | `/thread/${OneRouter.SingleRoutePart<T>}`
-      DynamicRouteTemplate: 
+      DynamicRouteTemplate:
         | `/(auth)/thread/[id]`
         | `/(site)/docs/[...slug]`
         | `/docs/[...slug]`

--- a/tests/test-spa-shell-routing/app/routes.d.ts
+++ b/tests/test-spa-shell-routing/app/routes.d.ts
@@ -38,7 +38,7 @@ declare module 'one' {
         | `/gate-home`
         | `/gate-home/feed`
         | `/login`
-      DynamicRoutes: 
+      DynamicRoutes:
         | `/${OneRouter.SingleRoutePart<T>}`
         | `/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
         | `/(authed)/dashboard/${OneRouter.SingleRoutePart<T>}`
@@ -47,7 +47,7 @@ declare module 'one' {
         | `/(chat)/${OneRouter.SingleRoutePart<T>}/${OneRouter.SingleRoutePart<T>}`
         | `/dashboard/${OneRouter.SingleRoutePart<T>}`
         | `/thread/${OneRouter.SingleRoutePart<T>}`
-      DynamicRouteTemplate: 
+      DynamicRouteTemplate:
         | `/(authed)/dashboard/[appId]`
         | `/(authed)/thread/[id]`
         | `/(chat)/[serverId]`

--- a/tests/test/app/hmr-probe.tsx
+++ b/tests/test/app/hmr-probe.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { Text, View } from 'react-native'
+import { HmrProbeChild } from '../features/hmr/HmrProbeChild'
+
+declare global {
+  var __ONE_HMR_ROUTE_GENERATION__: number | undefined
+}
+
+const routeGeneration = (globalThis.__ONE_HMR_ROUTE_GENERATION__ ?? 0) + 1
+globalThis.__ONE_HMR_ROUTE_GENERATION__ = routeGeneration
+
+export default function HmrProbe() {
+  const [generation] = useState(routeGeneration)
+
+  return (
+    <View>
+      <Text testID="route-hmr-version">route-v1</Text>
+      <Text testID="route-hmr-generation">generation:{generation}</Text>
+      <HmrProbeChild />
+    </View>
+  )
+}

--- a/tests/test/app/routes.d.ts
+++ b/tests/test/app/routes.d.ts
@@ -62,6 +62,7 @@ declare module 'one' {
         | `/folder-modes/analytics`
         | `/folder-modes/nested/report`
         | `/folder-modes/override`
+        | `/hmr-probe`
         | `/home`
         | `/hooks`
         | `/hooks/cases/navigating-into-nested-navigator`

--- a/tests/test/features/hmr/HmrProbeChild.tsx
+++ b/tests/test/features/hmr/HmrProbeChild.tsx
@@ -1,0 +1,5 @@
+import { Text } from 'react-native'
+
+export function HmrProbeChild() {
+  return <Text testID="component-hmr-version">component-v1</Text>
+}

--- a/tests/test/tests/hmr-fast-refresh.test.ios.ts
+++ b/tests/test/tests/hmr-fast-refresh.test.ios.ts
@@ -1,0 +1,75 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { getWebDriverConfig } from '@vxrn/test/ios'
+import { createSession, navigateTo } from '@vxrn/test/utils/appium'
+import { expect, test } from 'vitest'
+
+const routePath = resolve('app/hmr-probe.tsx')
+const childPath = resolve('features/hmr/HmrProbeChild.tsx')
+const testRolldownDev =
+  process.env.ONE_NATIVE_BUNDLER === 'rolldown' && process.env.TEST_ENV === 'dev'
+    ? test
+    : test.skip
+
+testRolldownDev(
+  'applies route and component Fast Refresh updates on native',
+  { timeout: 5 * 60 * 1000, retry: 1 },
+  async () => {
+    const originalRoute = await readFile(routePath, 'utf8')
+    const originalChild = await readFile(childPath, 'utf8')
+    const driver = await createSession(getWebDriverConfig())
+
+    const getText = async (testId: string) => {
+      const source = await driver.getPageSource()
+      const nameIndex = source.indexOf(`name="${testId}"`)
+      if (nameIndex === -1) return
+      const elementStart = source.lastIndexOf('<', nameIndex)
+      const elementEnd = source.indexOf('>', nameIndex)
+      if (elementEnd === -1) return
+      return source.slice(elementStart, elementEnd).match(/\bvalue="([^"]*)"/)?.[1]
+    }
+    const waitForText = async (testId: string, expected: string) => {
+      await driver.waitUntil(
+        async () => {
+          try {
+            return (await getText(testId)) === expected
+          } catch {
+            return false
+          }
+        },
+        {
+          timeout: 30_000,
+          interval: 500,
+          timeoutMsg: `${testId} did not update to ${expected}`,
+        }
+      )
+    }
+
+    try {
+      await navigateTo(driver, '/hmr-probe')
+      await waitForText('route-hmr-version', 'route-v1')
+      await waitForText('component-hmr-version', 'component-v1')
+      const initialGeneration = Number(
+        (await getText('route-hmr-generation'))?.replace('generation:', '')
+      )
+      expect(initialGeneration).toBeGreaterThan(0)
+      await driver.pause(2_000)
+
+      await writeFile(childPath, originalChild.replace('component-v1', 'component-v2'))
+      await waitForText('component-hmr-version', 'component-v2')
+      expect(await getText('route-hmr-generation')).toBe(
+        `generation:${initialGeneration}`
+      )
+
+      await writeFile(routePath, originalRoute.replace('route-v1', 'route-v2'))
+      await waitForText('route-hmr-version', 'route-v2')
+      await waitForText('route-hmr-generation', `generation:${initialGeneration + 1}`)
+    } finally {
+      await Promise.all([
+        writeFile(routePath, originalRoute),
+        writeFile(childPath, originalChild),
+      ])
+      await driver.deleteSession()
+    }
+  }
+)


### PR DESCRIPTION
Integrates the reviewed work from #731, #732, #733, #734, #735, and #736 on one branch, with conflicts resolved and combined-stack cleanup.

Additional fixes from integration review:
- scope the React Native HMRClient alias so app-authored modules are untouched
- preserve React Refresh registrations in initial Rolldown native bundles
- enable the Hermes Flow parser before React Native codegen
- add unit coverage and an automated iOS route/component Fast Refresh regression

Validation:
- full `bun run ci`: 23/23 builds, 4/4 checks, 37/37 typecheck/lint tasks, 30/30 test tasks; main suites passed in dev, prod, and non-CLI dev modes
- iOS 18.6 Rolldown dev smoke: component edit refreshed without route remount; route edit refreshed with one route remount
- native logs contained no HMR connection/eval error, unknown-message LogBox, or codegen warning

Please merge this PR with a merge commit so the original PR heads become ancestors of main.