### PR TITLE
fix(ci): keep Expo prebuild on npm 11

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: 'true'
   npm-upgrade:
     required: false
-    description: 'Upgrade npm to latest (needed for expo prebuild)'
+    description: 'Upgrade npm to the latest supported major (needed for expo prebuild)'
     default: 'false'
 runs:
   using: composite
@@ -33,7 +33,7 @@ runs:
       if: ${{ inputs.npm-upgrade == 'true' }}
       shell: bash
       run: |
-        npm install -g npm@latest
+        npm install -g npm@11
         npm --version
 
     - name: Cache Bun


### PR DESCRIPTION
The iOS workflow opts into an npm upgrade for Expo prebuild. `npm@latest` now resolves to npm 12, whose Node engine requires `^24.15.0`; this repository and the workflow use Node 24.3.0, so both dev and prod app-build jobs fail before dependency installation.

Keep the upgrade on the latest npm 11 release. The registry currently resolves that to 11.18.0, which supports Node `>=22.9.0` and retains the newer npm behavior Expo prebuild needs.

Observed failure: main run 29465704185, both build variants, `EBADENGINE` while installing npm 12.0.1.