### PR TITLE
feat(vxrn): add native plugin providers

### DIFF
--- a/apps/onestack.dev/data/docs/configuration.mdx
+++ b/apps/onestack.dev/data/docs/configuration.mdx
@@ -969,6 +969,38 @@ One assumes the following environments:
 - `ios`: iOS
 - `android`: Android
 
+The default native bundler uses Rolldown directly. A normal Vite plugin is not
+automatically forwarded into that pipeline because many Vite hooks require a
+Vite dev server or browser build. Plugins that support native can provide an
+explicit Rolldown implementation with `withNativePlugin`:
+
+```tsx fileName=vite.config.ts
+import { one, withNativePlugin } from 'one/vite'
+
+const sourceCompiler = withNativePlugin(
+  {
+    name: 'source-compiler',
+    transform(code, id) {
+      // web transform
+    },
+  },
+  ({ platform, dev }) => ({
+    name: `source-compiler-${platform}`,
+    transform(code, id) {
+      // native Rolldown transform
+    },
+  })
+)
+
+export default {
+  plugins: [one(), sourceCompiler],
+}
+```
+
+The factory receives `root`, `platform`, and `dev`, and creates a separate plugin
+instance for each native engine. This keeps iOS and Android compiler caches and
+watch state isolated. Metro mode continues to use Metro's transformer pipeline.
+
 We set up platform-specific extensions based on the environment:
 
 - client: `.web.(js|ts|tsx|mjs)`

--- a/packages/one/src/vite.ts
+++ b/packages/one/src/vite.ts
@@ -5,6 +5,11 @@ import './server/setupServerGlobals'
 
 // plugins
 export { resolvePath } from '@vxrn/resolve'
+export {
+  withNativePlugin,
+  type NativePluginContext,
+  type NativePluginFactory,
+} from 'vxrn/vite-plugin'
 export { build } from './cli/build'
 export { makePluginWebOnly } from './vite/makePluginWebOnly'
 export { one } from './vite/one'

--- a/packages/one/src/vite/one.ts
+++ b/packages/one/src/vite/one.ts
@@ -10,7 +10,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { normalizePath, type Plugin, type PluginOption } from 'vite'
 import { autoDepOptimizePlugin, getOptionsFilled, loadEnv } from 'vxrn'
-import vxrnVitePlugin from 'vxrn/vite-plugin'
+import vxrnVitePlugin, { withNativePlugin } from 'vxrn/vite-plugin'
 import { CACHE_KEY } from '../constants'
 import { getViteMetroPluginOptions } from '../metro-config/getViteMetroPluginOptions'
 import '../polyfills-server'
@@ -61,10 +61,24 @@ export function one(options: One.PluginOptions = {}): PluginOption {
   // and all native-only globals — One runs as a pure web framework.
   const nativeDisabled = options.native === false
   const nativeOptions = options.native === false ? undefined : options.native
+  const flags: One.Flags = {}
+  const nativeClientTreeShakePlugin = withNativePlugin(clientTreeShakePlugin(), () =>
+    clientTreeShakePlugin({ runtime: 'rolldown' })
+  )
 
   if (nativeDisabled) {
     // tamagui compiler reads this to decide whether to process the native env
     globalThis.__vxrnEnableNativeEnv = false
+    delete globalThis.__vxrnNativeEntryConfig
+  } else {
+    globalThis.__vxrnEnableNativeEnv = true
+    globalThis.__vxrnNativeEntryConfig = {
+      routerRoot,
+      ignoredRouteFiles: options.router?.ignoredRouteFiles,
+      linking: options.router?.linking,
+      setupFile: options.setupFile,
+      flags,
+    }
   }
 
   /**
@@ -141,7 +155,7 @@ export function one(options: One.PluginOptions = {}): PluginOption {
       setOneOptions(options)
       globalThis['__vxrnPluginConfig__'] = options
       globalThis['__vxrnMetroOptions__'] = metroOptions
-      return []
+      return nativeDisabled ? [] : [nativeClientTreeShakePlugin]
     }
   }
 
@@ -828,26 +842,8 @@ export function one(options: One.PluginOptions = {}): PluginOption {
   ] satisfies Plugin[]
 
   // TODO move to single config and through environments
-  const nativeWebDevAndProdPlugsin: Plugin[] = [clientTreeShakePlugin()]
-
-  // TODO make this passed into vxrn through real API
-  if (!nativeDisabled) {
-    globalThis.__vxrnAddNativePlugins = [clientTreeShakePlugin({ runtime: 'rolldown' })]
-  }
+  const nativeWebDevAndProdPlugsin: Plugin[] = [nativeClientTreeShakePlugin]
   globalThis.__vxrnAddWebPluginsProd = devAndProdPlugins
-
-  const flags: One.Flags = {}
-
-  // pass config to the rolldown native entry (createNativeDevEngine reads this)
-  if (!nativeDisabled) {
-    globalThis.__vxrnNativeEntryConfig = {
-      routerRoot: routerRoot,
-      ignoredRouteFiles: options.router?.ignoredRouteFiles,
-      linking: options.router?.linking,
-      setupFile: options.setupFile,
-      flags,
-    }
-  }
 
   // source inspector must come before clientTreeShakePlugin so line numbers
   // are computed from original source (tree-shaking removes loader code, shifting lines)

--- a/packages/one/types/vite.d.ts
+++ b/packages/one/types/vite.d.ts
@@ -1,5 +1,6 @@
 import './server/setupServerGlobals';
 export { resolvePath } from '@vxrn/resolve';
+export { withNativePlugin, type NativePluginContext, type NativePluginFactory, } from 'vxrn/vite-plugin';
 export { build } from './cli/build';
 export { makePluginWebOnly } from './vite/makePluginWebOnly';
 export { one } from './vite/one';

--- a/packages/vxrn/src/exports/build.ts
+++ b/packages/vxrn/src/exports/build.ts
@@ -18,6 +18,7 @@ import type { BuildArgs, VXRNOptions } from '../types'
 import { getServerCJSSetting, getServerEntry } from '../utils/getServerEntry'
 import { applyBuiltInPatches } from '../utils/patches'
 import { loadEnv } from './loadEnv'
+import { getNativePluginsFromOptions } from '../nativePlugin'
 
 const { existsSync } = FSExtra
 
@@ -96,7 +97,14 @@ export const build = async (optionsIn: VXRNOptions, buildArgs: BuildArgs = {}) =
 
     return buildBundle(
       [],
-      { root: options.root },
+      {
+        root: options.root,
+        nativePlugins: await getNativePluginsFromOptions(userViteConfig?.plugins ?? [], {
+          root: options.root,
+          platform: buildArgs.platform,
+          dev: false,
+        }),
+      },
       {
         platform: buildArgs.platform,
         bundleOutput: `${outDir}${sep}${buildArgs.platform}.js`,

--- a/packages/vxrn/src/nativePlugin.test.ts
+++ b/packages/vxrn/src/nativePlugin.test.ts
@@ -1,0 +1,126 @@
+import { rolldown } from 'rolldown'
+import type { Plugin as VitePlugin } from 'vite'
+import { describe, expect, it } from 'vitest'
+import {
+  getNativePlugins,
+  getNativePluginsFromOptions,
+  withNativePlugin,
+} from './nativePlugin'
+
+describe('native Vite plugin providers', () => {
+  it('only creates explicitly provided native plugins', () => {
+    const webOnly = { name: 'web-only' }
+    const shared = withNativePlugin({ name: 'shared' }, ({ platform, dev }) => ({
+      name: `shared-${platform}-${dev ? 'dev' : 'prod'}`,
+    }))
+
+    expect(
+      getNativePlugins([webOnly, shared], {
+        root: '/project',
+        platform: 'android',
+        dev: false,
+      }).map((plugin) => plugin.name)
+    ).toEqual(['shared-android-prod'])
+  })
+
+  it('preserves an existing plugin api', () => {
+    const plugin = withNativePlugin({ name: 'shared', api: { marker: true } }, () => ({
+      name: 'shared-native',
+    }))
+
+    expect(plugin.api).toMatchObject({ marker: true })
+    expect(typeof (plugin.api as any).vxrnNative).toBe('function')
+  })
+
+  it('flattens async Vite plugin options', async () => {
+    const provider = withNativePlugin({ name: 'shared' }, () => ({
+      name: 'shared-native',
+    }))
+
+    const plugins = await getNativePluginsFromOptions(
+      [false, Promise.resolve([undefined, provider])],
+      { root: '/project', platform: 'ios', dev: true }
+    )
+
+    expect(plugins.map((plugin) => plugin.name)).toEqual(['shared-native'])
+  })
+
+  it('preserves provider order while resolving async plugin options', async () => {
+    let resolveFirst!: (plugin: VitePlugin) => void
+    const first = new Promise<VitePlugin>((resolve) => {
+      resolveFirst = resolve
+    })
+    const second = Promise.resolve(
+      withNativePlugin({ name: 'second' }, () => ({ name: 'second-native' }))
+    )
+    const pluginsPromise = getNativePluginsFromOptions([first, second], {
+      root: '/project',
+      platform: 'ios',
+      dev: true,
+    })
+
+    resolveFirst(withNativePlugin({ name: 'first' }, () => ({ name: 'first-native' })))
+
+    await expect(
+      pluginsPromise.then((plugins) => plugins.map((plugin) => plugin.name))
+    ).resolves.toEqual(['first-native', 'second-native'])
+  })
+
+  it('runs providers in the fixed native transform slot', async () => {
+    const calls = new Map<string, string[]>()
+    const record = (id: string, name: string) => {
+      const moduleCalls = calls.get(id) ?? []
+      moduleCalls.push(name)
+      calls.set(id, moduleCalls)
+    }
+    const provider = withNativePlugin({ name: 'shared' }, () => ({
+      name: 'shared-native',
+      enforce: 'pre',
+      transform: {
+        order: 'pre',
+        filter: { id: /entry$/ },
+        handler(code, id) {
+          record(id, 'provider')
+          return code
+        },
+      },
+    }))
+    const [native] = getNativePlugins([provider], {
+      root: '/project',
+      platform: 'android',
+      dev: false,
+    })
+    const transform = (name: string) => ({
+      name,
+      transform(code: string, id: string) {
+        record(id, name)
+        return code
+      },
+    })
+    const bundle = await rolldown({
+      input: 'entry',
+      plugins: [
+        {
+          name: 'fixture',
+          resolveId(id, importer) {
+            if (id === 'entry') return id
+            if (id === './dependency' && importer === 'entry') return 'dependency'
+          },
+          load(id) {
+            if (id === 'entry') return `import './dependency'; export const value = 1`
+            if (id === 'dependency') return 'export const dependency = 1'
+          },
+        },
+        transform('compiler'),
+        native!,
+        transform('flow'),
+      ],
+    })
+
+    await bundle.generate({ format: 'esm' })
+    await bundle.close()
+
+    expect(calls.get('entry')).toEqual(['compiler', 'provider', 'flow'])
+    expect(calls.get('dependency')).toEqual(['compiler', 'flow'])
+  })
+})

--- a/packages/vxrn/src/nativePlugin.ts
+++ b/packages/vxrn/src/nativePlugin.ts
@@ -1,0 +1,96 @@
+import type { Plugin as RolldownPlugin } from 'rolldown'
+import type { Plugin as VitePlugin, PluginOption } from 'vite'
+
+export type NativePluginContext = {
+  root: string
+  platform: 'ios' | 'android'
+  dev: boolean
+}
+
+export type NativePluginFactory = (
+  context: NativePluginContext
+) => RolldownPlugin | readonly RolldownPlugin[]
+
+type NativePluginApi = {
+  vxrnNative?: NativePluginFactory
+}
+
+/**
+ * Adds a native Rolldown implementation to a Vite plugin.
+ *
+ * VxRN only forwards plugins with this explicit provider into native builds.
+ */
+export function withNativePlugin(
+  plugin: VitePlugin,
+  factory: NativePluginFactory
+): VitePlugin {
+  const api =
+    plugin.api && typeof plugin.api === 'object'
+      ? (plugin.api as Record<string, unknown>)
+      : {}
+
+  return {
+    ...plugin,
+    api: {
+      ...api,
+      vxrnNative: factory,
+    },
+  }
+}
+
+export function getNativePlugins(
+  plugins: readonly VitePlugin[],
+  context: NativePluginContext
+): RolldownPlugin[] {
+  return plugins.flatMap((plugin) => {
+    const api = plugin.api as NativePluginApi | undefined
+    const nativePlugin = api?.vxrnNative?.(context)
+    const nativePlugins = nativePlugin
+      ? Array.isArray(nativePlugin)
+        ? [...nativePlugin]
+        : [nativePlugin]
+      : []
+
+    return nativePlugins.map(normalizeNativePlugin)
+  })
+}
+
+export async function getNativePluginsFromOptions(
+  pluginOptions: readonly PluginOption[],
+  context: NativePluginContext
+): Promise<RolldownPlugin[]> {
+  const plugins: VitePlugin[] = []
+
+  const visit = async (option: PluginOption): Promise<void> => {
+    const resolved = await option
+    if (!resolved) return
+    if (Array.isArray(resolved)) {
+      for (const nested of resolved) {
+        await visit(nested)
+      }
+      return
+    }
+    plugins.push(resolved as VitePlugin)
+  }
+
+  for (const option of pluginOptions) {
+    await visit(option)
+  }
+  return getNativePlugins(plugins, context)
+}
+
+function normalizeNativePlugin(plugin: RolldownPlugin): RolldownPlugin {
+  const transform = plugin.transform
+  const { enforce: _enforce, ...normalized } = plugin as RolldownPlugin & {
+    enforce?: unknown
+  }
+  const normalizedTransform =
+    transform && typeof transform === 'object' && 'handler' in transform
+      ? (({ order: _order, ...hook }) => hook)(transform)
+      : transform
+
+  return {
+    ...normalized,
+    transform: normalizedTransform,
+  }
+}

--- a/packages/vxrn/src/plugins/reactNativeDevServer.ts
+++ b/packages/vxrn/src/plugins/reactNativeDevServer.ts
@@ -10,6 +10,7 @@ import { URL } from 'node:url'
 import { createDevMiddleware } from '@react-native/dev-middleware'
 import { createNativeDevEngine } from '../utils/createNativeDevEngine'
 import { getBoundPort } from '../utils/getBoundPort'
+import { getNativePlugins } from '../nativePlugin'
 
 type ClientMessage = {
   type: 'client-log'
@@ -22,8 +23,14 @@ export function createReactNativeDevServerPlugin(
     Pick<VXRNOptionsFilled, 'cacheDir' | 'debugBundle' | 'debugBundlePaths' | 'entries'>
   >
 ): Plugin {
+  let vitePlugins: readonly Plugin[] = []
+
   return {
     name: 'vite-plugin-react-native-server',
+
+    configResolved(config) {
+      vitePlugins = config.plugins
+    },
 
     configureServer(server: ViteDevServer) {
       const { host } = server.config.server
@@ -178,6 +185,11 @@ export function createReactNativeDevServerPlugin(
                       port: getBoundPort(server),
                       host: typeof host === 'string' ? host : 'localhost',
                       platform,
+                      plugins: getNativePlugins(vitePlugins, {
+                        root,
+                        platform,
+                        dev: true,
+                      }),
                       serverUrl: `http://${typeof host === 'string' && host !== '0.0.0.0' ? host : 'localhost'}:${getBoundPort(server)}`,
                       onHmrUpdate: (update) => {
                         const msg = JSON.stringify(update)

--- a/packages/vxrn/src/rn-commands/bundle/buildBundle.test.ts
+++ b/packages/vxrn/src/rn-commands/bundle/buildBundle.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, readFile, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildNativeBundle: vi.fn(),
+  getBuildBundleFn: vi.fn(),
+  loadConfigFromFile: vi.fn(),
+  loadEnv: vi.fn(),
+}))
+
+vi.mock('@vxrn/vite-plugin-metro/rn-commands', () => ({
+  bundle: { getBuildBundleFn: mocks.getBuildBundleFn },
+}))
+vi.mock('../../utils/createNativeDevEngine', () => ({
+  buildNativeBundle: mocks.buildNativeBundle,
+}))
+vi.mock('../../exports/loadEnv', () => ({ loadEnv: mocks.loadEnv }))
+vi.mock('vite', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vite')>()),
+  loadConfigFromFile: mocks.loadConfigFromFile,
+}))
+
+import { withNativePlugin } from '../../nativePlugin'
+import { buildBundle } from './buildBundle'
+
+const root = path.join(import.meta.dirname, '.bundle-command-fixture')
+const bundleOutput = path.join(root, 'android.js')
+
+afterEach(async () => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('React Native bundle command', () => {
+  it('loads native providers from the project Vite config', async () => {
+    vi.useFakeTimers()
+    await mkdir(root, { recursive: true })
+    const provider = withNativePlugin({ name: 'shared' }, ({ platform }) => ({
+      name: `shared-${platform}`,
+    }))
+    mocks.getBuildBundleFn.mockResolvedValue(null)
+    mocks.loadConfigFromFile.mockResolvedValue({
+      path: path.join(root, 'vite.config.ts'),
+      config: { plugins: [provider] },
+      dependencies: [],
+    })
+    mocks.buildNativeBundle.mockResolvedValue({ code: 'native bundle', map: null })
+
+    await buildBundle(
+      [],
+      { root },
+      {
+        entryFile: '',
+        resetCache: true,
+        resetGlobalCache: true,
+        platform: 'android',
+        dev: false,
+        bundleOutput,
+        sourcemapUseAbsolutePath: true,
+        verbose: false,
+        unstableTransformProfile: '',
+      }
+    )
+
+    expect(mocks.loadConfigFromFile).toHaveBeenCalledWith(
+      { command: 'build', mode: 'prod' },
+      undefined,
+      root
+    )
+    expect(mocks.buildNativeBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root,
+        platform: 'android',
+        plugins: [expect.objectContaining({ name: 'shared-android' })],
+      })
+    )
+    expect(await readFile(bundleOutput, 'utf8')).toBe('native bundle')
+  })
+})

--- a/packages/vxrn/src/rn-commands/bundle/buildBundle.ts
+++ b/packages/vxrn/src/rn-commands/bundle/buildBundle.ts
@@ -1,7 +1,9 @@
 import path from 'node:path'
 import FSExtra from 'fs-extra'
 import { bundle as metroBundle } from '@vxrn/vite-plugin-metro/rn-commands'
+import { loadConfigFromFile } from 'vite'
 import { loadEnv } from '../../exports/loadEnv'
+import { getNativePluginsFromOptions } from '../../nativePlugin'
 import { buildNativeBundle } from '../../utils/createNativeDevEngine'
 
 export type BundleCommandArgs = {
@@ -71,6 +73,20 @@ export async function buildBundle(
     process.env.NODE_ENV = 'production'
   }
 
+  const nativePlugins =
+    ctx.nativePlugins ??
+    (await loadConfigFromFile(
+      { command: 'build', mode: dev ? 'dev' : 'prod' },
+      undefined,
+      root
+    ).then((loaded) =>
+      getNativePluginsFromOptions(loaded?.config.plugins ?? [], {
+        root,
+        platform,
+        dev,
+      })
+    ))
+
   console.info(`[vxrn] building native bundle for ${platform}...`)
   const nativeEntryFile = (globalThis as { __vxrnNativeEntryFile?: unknown })
     .__vxrnNativeEntryFile
@@ -84,6 +100,7 @@ export async function buildBundle(
     // 'http://one-server.example.com' and runtime loader fetches fail in prod.
     serverUrl: process.env.ONE_SERVER_URL,
     assetsDest,
+    plugins: nativePlugins,
   })
   const builtBundle = result.code
 

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -205,11 +205,10 @@ function getNativePlugins(
   platform: string,
   viteImportGlobPlugin: any,
   dev: boolean,
-  assetsDest?: string
+  assetsDest?: string,
+  userPlugins: Plugin[] = []
 ): Plugin[] {
   return [
-    // plugins provided by One (clientTreeShakePlugin for loader removal, etc.)
-    ...(globalThis.__vxrnAddNativePlugins || []),
     // block .server.* and _middleware.* files from entering the native bundle
     serverFileExclusionPlugin(),
     // guard server-only / client-only / web-only / native-only imports
@@ -228,6 +227,9 @@ function getNativePlugins(
     // type argument intact. stripping Flow first would erase it (which is why the
     // codegen "didn't run for <Component>" warning fired).
     vxrnCompilerPlugin(platform, dev),
+    // Native implementations explicitly provided by Vite plugins. These run
+    // after RN syntax transforms and before the Flow/Hermes lowering passes.
+    ...userPlugins,
     // strip Flow from any react-native / @react-native `.js` the compiler didn't
     // handle, the guaranteed safety net before rolldown's oxc core parse (which
     // can't parse Flow). now downstream of the compiler, so codegen sees the types.
@@ -443,8 +445,7 @@ export async function createNativeDevEngine(
 
     plugins: [
       nativeVirtualEntryPlugin(root, { dev: true }),
-      ...getNativePlugins(root, platform, viteImportGlobPlugin, true),
-      ...userPlugins,
+      ...getNativePlugins(root, platform, viteImportGlobPlugin, true, undefined, userPlugins),
     ],
   }
 
@@ -625,8 +626,14 @@ export async function buildNativeBundle(
     moduleTypes: { '.js': 'jsx' },
     plugins: [
       ...(entryFile ? [] : [nativeVirtualEntryPlugin(root, { dev })]),
-      ...getNativePlugins(root, platform, viteImportGlobPlugin, dev, assetsDest),
-      ...userPlugins,
+      ...getNativePlugins(
+        root,
+        platform,
+        viteImportGlobPlugin,
+        dev,
+        assetsDest,
+        userPlugins
+      ),
     ],
     output: getNativeOutputOptions(prelude),
   })

--- a/packages/vxrn/src/vxrn-vite-plugin.ts
+++ b/packages/vxrn/src/vxrn-vite-plugin.ts
@@ -9,6 +9,12 @@ import type {
   ExpoManifestRequestHandlerPluginPluginOptions,
 } from '@vxrn/vite-plugin-metro'
 
+export {
+  withNativePlugin,
+  type NativePluginContext,
+  type NativePluginFactory,
+} from './nativePlugin'
+
 /**
  * This is considered private API for now, and may change anytime.
  */

--- a/packages/vxrn/types/nativePlugin.d.ts
+++ b/packages/vxrn/types/nativePlugin.d.ts
@@ -1,0 +1,17 @@
+import type { Plugin as RolldownPlugin } from 'rolldown';
+import type { Plugin as VitePlugin, PluginOption } from 'vite';
+export type NativePluginContext = {
+    root: string;
+    platform: 'ios' | 'android';
+    dev: boolean;
+};
+export type NativePluginFactory = (context: NativePluginContext) => RolldownPlugin | readonly RolldownPlugin[];
+/**
+ * Adds a native Rolldown implementation to a Vite plugin.
+ *
+ * VxRN only forwards plugins with this explicit provider into native builds.
+ */
+export declare function withNativePlugin(plugin: VitePlugin, factory: NativePluginFactory): VitePlugin;
+export declare function getNativePlugins(plugins: readonly VitePlugin[], context: NativePluginContext): RolldownPlugin[];
+export declare function getNativePluginsFromOptions(pluginOptions: readonly PluginOption[], context: NativePluginContext): Promise<RolldownPlugin[]>;
+//# sourceMappingURL=nativePlugin.d.ts.map

--- a/packages/vxrn/types/nativePlugin.test.d.ts
+++ b/packages/vxrn/types/nativePlugin.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=nativePlugin.test.d.ts.map

--- a/packages/vxrn/types/rn-commands/bundle/buildBundle.test.d.ts
+++ b/packages/vxrn/types/rn-commands/bundle/buildBundle.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=buildBundle.test.d.ts.map

--- a/packages/vxrn/types/vxrn-vite-plugin.d.ts
+++ b/packages/vxrn/types/vxrn-vite-plugin.d.ts
@@ -1,5 +1,6 @@
 import { type PluginOption } from 'vite';
 import type { MetroPluginOptions, ExpoManifestRequestHandlerPluginPluginOptions } from '@vxrn/vite-plugin-metro';
+export { withNativePlugin, type NativePluginContext, type NativePluginFactory, } from './nativePlugin';
 /**
  * This is considered private API for now, and may change anytime.
  */


### PR DESCRIPTION
Adds an explicit bundler-neutral native provider contract for Vite plugins, integrates providers into One's Rolldown dev and production native pipelines, and documents the API. Tamagui uses this to share its generic compiler session with One native without adding Babel or pretending the web Vite transform can run natively.\n\nValidated with focused VxRN tests, VxRN and One typechecks/builds, full monorepo build, and real iOS/Android Tamagui-lowered bundles.