### PR TITLE
fix(ci): generate release notes from commits, not just PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,12 +9,18 @@ jobs:
   tagged-release:
     name: Changelog
     runs-on: ubuntu-latest
-    # needs: release
 
     permissions:
       contents: write
 
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        run: bash scripts/gen-release-notes.sh "${GITHUB_REF_NAME}" CHANGELOG_BODY.md
+
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          generate_release_notes: true
+          body_path: CHANGELOG_BODY.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,4 +183,5 @@ jobs:
           trap 'git config --local --unset-all http.https://github.com/.extraheader || true' EXIT
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $auth"
           git push origin "v$version"
-          gh release create "v$version" --verify-tag --generate-notes --title "v$version"
+          bash scripts/gen-release-notes.sh "v$version" release-notes.md
+          gh release create "v$version" --verify-tag --notes-file release-notes.md --title "v$version"

--- a/scripts/gen-release-notes.sh
+++ b/scripts/gen-release-notes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# generate commit-based release notes for a v* tag.
+# github's built-in note generation only lists merged PRs, so releases cut from
+# direct-to-main commits come out empty. this lists the actual commits instead.
+# usage: scripts/gen-release-notes.sh <tag> [output-file]
+set -euo pipefail
+
+tag="${1:?usage: gen-release-notes.sh <tag> [output-file]}"
+out="${2:-}"
+repo_url="https://github.com/onejs/one"
+
+# previous v* tag reachable from this tag's parent
+prev="$(git describe --tags --match 'v*' --abbrev=0 "${tag}^" 2>/dev/null || true)"
+
+if [ -n "$prev" ]; then
+  range="${prev}..${tag}"
+else
+  range="$tag"
+fi
+
+# non-merge commits in range, dropping the version-bump commits (subject "vX.Y.Z")
+commits="$(git log --no-merges --reverse --pretty=format:'* %s (%h)' "$range" \
+  | grep -vE '^\* v[0-9]+\.[0-9]+\.[0-9]+' || true)"
+
+body="## What's Changed"$'\n\n'
+if [ -n "$commits" ]; then
+  body+="$commits"
+else
+  body+="_No notable changes._"
+fi
+if [ -n "$prev" ]; then
+  body+=$'\n\n'"**Full Changelog**: ${repo_url}/compare/${prev}...${tag}"
+fi
+
+if [ -n "$out" ]; then
+  printf '%s\n' "$body" >"$out"
+else
+  printf '%s\n' "$body"
+fi

--- a/scripts/gen-release-notes.sh
+++ b/scripts/gen-release-notes.sh
@@ -18,9 +18,9 @@ else
   range="$tag"
 fi
 
-# non-merge commits in range, dropping the version-bump commits (subject "vX.Y.Z")
+# non-merge commits in range, dropping version-bump commits (stable "vX.Y.Z" and canary)
 commits="$(git log --no-merges --reverse --pretty=format:'* %s (%h)' "$range" \
-  | grep -vE '^\* v[0-9]+\.[0-9]+\.[0-9]+' || true)"
+  | grep -vE '^\* (v[0-9]+\.[0-9]+\.[0-9]+|canary[0-9])' || true)"
 
 body="## What's Changed"$'\n\n'
 if [ -n "$commits" ]; then


### PR DESCRIPTION
## Problem

GitHub release changelogs are frequently empty (just the "Full Changelog" compare link, no "What's Changed" list) even when the release contains real changes.

**Root cause:** both release-note paths used GitHub's built-in generator, which only lists *merged pull requests* between two tags and ignores direct commits:
- `changelog.yml` → `generate_release_notes: true`
- `release.yml` → `gh release create --generate-notes`

Releases are cut from work committed directly to `main` (the `bun release` flow pushes fixes + the `vX.Y.Z` bump straight to main), so most releases have zero PRs in range and come out blank. e.g. v1.21.5→v1.21.6 had two real fixes but no PRs → empty changelog. v1.21.2 only had content because it happened to include merged PRs.

## Fix

One shared generator, `scripts/gen-release-notes.sh`, lists the actual commits between the previous `v*` tag and the current one (skips merge commits and the version-bump commit, appends the compare link). Both workflows call it, so the local release flow and the OIDC flow produce identical, complete changelogs.

Example — v1.21.6 (previously empty) now renders:

```
## What's Changed

* fix(one): isolate SPA build exports from server bundles (778a95fab)
* fix(release): reuse passkey approval across packages (9f8412ee0)

**Full Changelog**: https://github.com/onejs/one/compare/v1.21.5...v1.21.6
```

Only affects releases cut after merge; existing release notes are untouched.

## Notes

Commit-based notes are more inclusive than a curated PR list, so `chore:`/`format`/`dep lint` commits show up too. Kept inclusive so nothing goes missing; easy to add `chore:`/`format` filtering later if a cleaner list is preferred.