### PR TITLE
fix(one): prune stale warm dependencies

### DIFF
--- a/packages/one/src/vite/plugins/warmRoutesPlugin.ts
+++ b/packages/one/src/vite/plugins/warmRoutesPlugin.ts
@@ -53,21 +53,47 @@ export function autoWarmPlugin(persistPath?: string): Plugin {
       }
     },
 
-    configResolved(config: ResolvedConfig) {
-      // build the exclude set from the resolved config
+    async configResolved(config: ResolvedConfig) {
       excludeSet = new Set(config.optimizeDeps.exclude || [])
 
-      if (cachedDeps.length > 0 && excludeSet.size > 0) {
-        // remove any cached deps that are in the exclude list
-        const conflicts = cachedDeps.filter((d) => excludeSet.has(d))
-        if (conflicts.length > 0) {
-          console.info(`[one] filtered ${conflicts.length} excluded deps from warm cache`)
+      if (cachedDeps.length > 0) {
+        const resolve = config.createResolver()
+        const staleDeps = new Set<string>()
 
-          // mutate the resolved include to remove conflicts
+        await Promise.all(
+          cachedDeps.map(async (dep) => {
+            if (excludeSet.has(dep)) {
+              staleDeps.add(dep)
+              return
+            }
+
+            try {
+              if (!(await resolve(dep))) staleDeps.add(dep)
+            } catch {
+              staleDeps.add(dep)
+            }
+          })
+        )
+
+        if (staleDeps.size > 0) {
+          cachedDeps = cachedDeps.filter((dep) => !staleDeps.has(dep))
+          console.info(`[one] pruned ${staleDeps.size} stale deps from warm cache`)
+
           if (config.optimizeDeps.include) {
-            ;(config.optimizeDeps as any).include = config.optimizeDeps.include.filter(
-              (d: string) => !excludeSet.has(d)
+            config.optimizeDeps.include = config.optimizeDeps.include.filter(
+              (dep) => !staleDeps.has(dep)
             )
+          }
+
+          try {
+            const nextRaw = JSON.stringify({ deps: [...cachedDeps].sort() }, null, 2)
+            if (!existsSync(cacheFile) || readFileSync(cacheFile, 'utf-8') !== nextRaw) {
+              const dir = dirname(cacheFile)
+              if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+              writeFileSync(cacheFile, nextRaw)
+            }
+          } catch {
+            // a future snapshot can retry the cache write
           }
         }
       }

--- a/tests/test-warm-routes/tests/warm-routes.test.ts
+++ b/tests/test-warm-routes/tests/warm-routes.test.ts
@@ -1,10 +1,12 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 
 const testDir = join(import.meta.dirname, '..')
 const cacheFile = join(testDir, 'node_modules', '.vite', 'one-warm-deps.json')
+const privateExportDep = '@one-tests/private-export'
+const privateExportDir = join(testDir, 'node_modules', '@one-tests', 'private-export')
 // Resolve one's JS entry (run.mjs) instead of node_modules/.bin/one: on Windows
 // the .bin shim is a .cmd/.ps1/.exe wrapper that `node <path>` can't load
 // (MODULE_NOT_FOUND), so the dev server never starts. Resolving via package.json
@@ -19,6 +21,9 @@ function cleanup() {
   const viteCache = join(testDir, 'node_modules', '.vite')
   if (existsSync(viteCache)) {
     rmSync(viteCache, { recursive: true })
+  }
+  if (existsSync(privateExportDir)) {
+    rmSync(privateExportDir, { recursive: true })
   }
 }
 
@@ -53,7 +58,13 @@ function startDevServer(port: number): {
 
   function waitFor(pattern: string | RegExp, timeoutMs = 60_000): Promise<string> {
     return new Promise((resolve, reject) => {
+      const cleanupListeners = () => {
+        proc.stdout?.off('data', onData)
+        proc.stderr?.off('data', onData)
+        proc.off('exit', onExit)
+      }
       const timer = setTimeout(() => {
+        cleanupListeners()
         reject(
           new Error(
             `Timed out waiting for "${pattern}" after ${timeoutMs}ms.\nOutput so far:\n${output.join('')}`
@@ -76,13 +87,22 @@ function startDevServer(port: number): {
         const all = output.join('')
         if (typeof pattern === 'string' ? all.includes(pattern) : pattern.test(all)) {
           clearTimeout(timer)
-          proc.stdout?.off('data', onData)
-          proc.stderr?.off('data', onData)
+          cleanupListeners()
           resolve(all)
         }
       }
+      const onExit = (code: number | null) => {
+        clearTimeout(timer)
+        cleanupListeners()
+        reject(
+          new Error(
+            `Dev server exited with code ${code} before "${pattern}".\nOutput so far:\n${output.join('')}`
+          )
+        )
+      }
       proc.stdout?.on('data', onData)
       proc.stderr?.on('data', onData)
+      proc.on('exit', onExit)
     })
   }
 
@@ -160,7 +180,26 @@ async function main() {
     process.exit(1)
   }
 
-  console.info('--- Run 2: expecting cached deps to be loaded on startup ---\n')
+  const cache = JSON.parse(readFileSync(cacheFile, 'utf-8'))
+  mkdirSync(privateExportDir, { recursive: true })
+  writeFileSync(
+    join(privateExportDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: privateExportDep,
+        type: 'module',
+        exports: { './allowed': './allowed.js' },
+      },
+      null,
+      2
+    )
+  )
+  writeFileSync(
+    cacheFile,
+    JSON.stringify({ deps: [...cache.deps, privateExportDep].sort() }, null, 2)
+  )
+
+  console.info('--- Run 2: expecting stale cached deps to be pruned on startup ---\n')
 
   const run2 = startDevServer(port)
 
@@ -178,6 +217,11 @@ async function main() {
       console.info('\n❌ Run 2 FAILED: cached deps were NOT loaded on startup')
       console.info('Full output:')
       console.info(fullOutput)
+    }
+
+    const prunedCache = JSON.parse(readFileSync(cacheFile, 'utf-8'))
+    if (prunedCache.deps.includes(privateExportDep)) {
+      throw new Error(`Stale warm dependency was not pruned: ${privateExportDep}`)
     }
   } finally {
     run2.kill()


### PR DESCRIPTION
## Summary

- validate persisted warm dependencies with Vite before optimization
- prune excluded, missing, and package-export-incompatible entries from the cache
- cover the Legend List failure mode with a package whose root export is unavailable

## Validation

- `bun turbo run build --filter=one`
- `bun run typecheck` in `packages/one`
- `bun run lint` in `packages/one`
- `bun run test` in `packages/one` (566 passed, 56 skipped)
- `bun run test` in `tests/test-warm-routes` (reproduced failure before fix, passed after)