### PR TITLE
fix(one): stop remounting every route on the first navigation

### DIFF
--- a/packages/one/src/router/useScreens.tsx
+++ b/packages/one/src/router/useScreens.tsx
@@ -583,8 +583,12 @@ export function getQualifiedRouteComponent(value: RouteNode) {
 
   QualifiedRoute.displayName = `Route(${value.route})`
 
-  qualifiedStore.set(value, QualifiedRoute)
-  return memo(QualifiedRoute)
+  // cache the memoized component, not the raw one: returning a different
+  // component type on the first call than on every call after it remounts the
+  // whole route subtree once, throwing away layout and screen state
+  const Memoized = memo(QualifiedRoute)
+  qualifiedStore.set(value, Memoized)
+  return Memoized
 }
 
 /** @returns a function which provides a screen id that matches the dynamic route name in params. */


### PR DESCRIPTION
`getQualifiedRouteComponent` cached the raw component but returned `memo(component)`, so the first call and every later call handed React two different types for the same route.

In a prod build that tore down and rebuilt the entire route subtree once, on the first client navigation after hydration. It threw away layout state, screen state, scroll position, uncontrolled form values, and anything a layout opened in an effect. Dev was unaffected.

Present since 63c396e0b (2026-02-05), which added the `memo()` wrapper alongside the existing cache line.

Verified by reverting the fix and confirming the regression test fails, then restoring it. A regression test covering it lands with #743; this PR is the fix alone so it can go out now.