### PR TITLE
fix(expo): box the weak emitter so ExpoModulesCore builds under Swift 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1399,6 +1399,7 @@
     "gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch",
     "@expo/plist@0.8.1": "patches/@expo%2Fplist@0.8.1.patch",
     "plist@3.1.0": "patches/plist@3.1.0.patch",
+    "expo-modules-core@57.0.8": "patches/expo-modules-core@57.0.8.patch",
     "minimatch@3.1.5": "patches/minimatch@3.1.5.patch",
     "expo-modules-jsi@57.0.4": "patches/expo-modules-jsi@57.0.4.patch",
   },

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   "patchedDependencies": {
     "@expo/plist@0.8.1": "patches/@expo%2Fplist@0.8.1.patch",
     "expo-modules-jsi@57.0.4": "patches/expo-modules-jsi@57.0.4.patch",
+    "expo-modules-core@57.0.8": "patches/expo-modules-core@57.0.8.patch",
     "plist@3.1.0": "patches/plist@3.1.0.patch",
     "@tamagui/web@2.0.0-rc.32": "patches/@tamagui%2Fweb@2.0.0-rc.32.patch",
     "gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch",

--- a/patches/expo-modules-core@57.0.8.patch
+++ b/patches/expo-modules-core@57.0.8.patch
@@ -1,0 +1,64 @@
+diff --git a/ios/Core/Events/EventEmitter.swift b/ios/Core/Events/EventEmitter.swift
+--- a/ios/Core/Events/EventEmitter.swift
++++ b/ios/Core/Events/EventEmitter.swift
+@@ -23,6 +23,21 @@
+   func withEventTarget<R>(_ body: (borrowing JavaScriptObject) throws -> R) rethrows -> R?
+ }
+ 
++/**
++ Carries a weak reference to a non-`Sendable` emitter across the `@JavaScriptActor`
++ boundary. `nonisolated(unsafe)` is not enough on its own: region-based isolation still
++ sees the emitter being sent into the actor-isolated closure. The box is safe for the same
++ reason the original capture was - the scheduled closure only reaches `@JavaScriptActor`-
++ isolated or `Sendable` state through it, never the module's own mutable state.
++ */
++private final class WeakEmitterBox<T: AnyObject>: @unchecked Sendable {
++  weak var value: T?
++
++  init(_ value: T?) {
++    self.value = value
++  }
++}
++
+ public extension EventEmitter {
+   /**
+    Schedules an event with the given name to be emitted to the associated JavaScript object.
+@@ -42,14 +57,14 @@
+       return
+     }
+     // The emitter is not necessarily `Sendable` - some modules hold non-sendable state — so we can't let
+-    // the compiler send `self` into the `@JavaScriptActor` region. Capturing it as `nonisolated(unsafe)` is
+-    // safe here because the scheduled closure only calls `withEventTarget`, which touches `@JavaScriptActor`-
+-    // isolated or `Sendable` state (the JS object, the registry, `appContext`) and the emitter's identity -
++    // the compiler send `self` into the `@JavaScriptActor` region. Boxing it is safe here because the
++    // scheduled closure only calls `withEventTarget`, which touches `@JavaScriptActor`-isolated or
++    // `Sendable` state (the JS object, the registry, `appContext`) and the emitter's identity -
+     // never the module's own mutable state.
+-    nonisolated(unsafe) weak let emitter = self
++    let emitterBox = WeakEmitterBox(self)
+ 
+     runtime.schedule {
+-      guard let emitter else {
++      guard let emitter = emitterBox.value else {
+         return
+       }
+       let dispatched = emitter.withEventTarget { target in
+@@ -70,13 +85,13 @@
+       log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
+       return
+     }
+-    // See the note in `emit(event:payload:)` above - the emitter is captured as `nonisolated(unsafe)`
+-    // because it isn't necessarily `Sendable`, and the scheduled closure only reaches `@JavaScriptActor`-
+-    // isolated or `Sendable` state through it.
+-    nonisolated(unsafe) weak let emitter = self
++    // See the note in `emit(event:payload:)` above - the emitter is boxed because it isn't necessarily
++    // `Sendable`, and the scheduled closure only reaches `@JavaScriptActor`-isolated or `Sendable`
++    // state through it.
++    let emitterBox = WeakEmitterBox(self)
+ 
+     runtime.schedule { [weak appContext] in
+-      guard let emitter, let appContext else {
++      guard let emitter = emitterBox.value, let appContext else {
+         return
+       }
+       let jsPayload: JavaScriptValue


### PR DESCRIPTION
iOS Native Tests has been red on main since the expo 57 / RN 0.86 upgrade. Last green was `3d0026162` (07-31, expo 55 / RN 0.83).

The only error is in `expo-modules-core`:

```
EventEmitter.swift:52:17: sending 'emitter' risks causing data races
EventEmitter.swift:79:17: sending 'emitter' risks causing data races
```

It captures the emitter as `nonisolated(unsafe) weak let` and then sends it into a `@JavaScriptActor` closure. `nonisolated(unsafe)` doesn't defeat region-based isolation, so Swift 6 still counts that as a send. The podspec pins `swift_version = '6.0'`, so the strict-concurrency setting can't be relaxed, and 57.0.9 is byte-identical there, so there's no upstream fix to take. Xcode 26.2 and 26.3 both fail (I tried the bump first; it didn't help).

Boxing the weak reference in an `@unchecked Sendable` holder satisfies the checker and keeps exactly the safety argument expo's own comment already makes. The closure's other captures (`runtime`, `appContext`) are already `Sendable`, so `emitter` was the only offender.

Verified: iOS Native Tests green on `cacc0924c` (branch `ci/xcode-26-3`), run 31028199545.

Follow-up: the patch is version-pinned to 57.0.8 and will need regenerating on the next expo bump. Worth filing upstream with expo.