### PR TITLE
fix(router): surface route load failures in dev instead of swallowing them

### DIFF
--- a/packages/one/devtools/dev.mjs
+++ b/packages/one/devtools/dev.mjs
@@ -17,6 +17,139 @@ routeHot.on('one:route-update', (data) => {
   window.dispatchEvent(new CustomEvent('one-hmr-update'))
 })
 
+// route load errors. the router catches a failed route import and substitutes an
+// empty component so one bad route cannot take down the whole app. in dev that
+// resilience hides the cause: a broken import surfaced as a single console line
+// while the app rendered nothing, and every provider mounted inside that route
+// (sync, auth, theme) silently never started. report it to the dev server for a
+// terminal line, and paint it here so the blank screen explains itself.
+const routeErrorHot = createHotContext('/__one_route_error')
+
+const ROUTE_ERROR_TAG = 'one-route-error-overlay'
+
+function showRouteErrorOverlay(detail) {
+  document.querySelector(ROUTE_ERROR_TAG)?.remove()
+  const host = document.createElement(ROUTE_ERROR_TAG)
+  host.style.cssText = 'position:fixed;inset:0;z-index:2147483647'
+  const shadow = host.attachShadow({ mode: 'open' })
+  shadow.innerHTML = `
+    <style>
+      .backdrop {
+        position: fixed; inset: 0; overflow: auto;
+        background: rgba(0,0,0,.66); backdrop-filter: blur(2px);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      .panel {
+        margin: 8vh auto; max-width: 900px; width: calc(100% - 48px);
+        background: #18181b; color: #fafafa; border: 1px solid #f87171;
+        border-radius: 10px; padding: 22px 24px; box-shadow: 0 24px 60px rgba(0,0,0,.5);
+      }
+      h1 { margin: 0 0 4px; font-size: 15px; color: #f87171; letter-spacing: .01em; }
+      .id { margin: 0 0 14px; font-size: 13px; color: #a1a1aa; word-break: break-all; }
+      .msg {
+        margin: 0 0 14px; padding: 12px 14px; background: #0c0c0e; border-radius: 6px;
+        font-size: 13px; line-height: 1.55; white-space: pre-wrap; word-break: break-word;
+      }
+      .why { margin: 0 0 16px; font-size: 12.5px; line-height: 1.6; color: #d4d4d8; }
+      pre {
+        margin: 0; padding: 12px 14px; background: #0c0c0e; border-radius: 6px;
+        font-size: 11.5px; line-height: 1.5; color: #a1a1aa;
+        white-space: pre-wrap; word-break: break-word; max-height: 34vh; overflow: auto;
+      }
+      button {
+        position: absolute; top: 14px; right: 16px; background: none; border: 0;
+        color: #a1a1aa; font-size: 20px; line-height: 1; cursor: pointer; padding: 4px 8px;
+      }
+      button:hover { color: #fafafa; }
+      .wrap { position: relative; }
+    </style>
+    <div class="backdrop">
+      <div class="panel wrap">
+        <button title="dismiss">&times;</button>
+        <h1>Route failed to load</h1>
+        <p class="id"></p>
+        <p class="msg"></p>
+        <p class="why">
+          The router rendered an empty component in its place, so nothing inside this
+          route mounted — including any providers it wraps. Fix the import above and
+          this overlay will clear on reload.
+        </p>
+        <pre></pre>
+      </div>
+    </div>
+  `
+  shadow.querySelector('.id').textContent = detail?.id || 'unknown route'
+  shadow.querySelector('.msg').textContent = detail?.message || 'unknown error'
+  const stack = shadow.querySelector('pre')
+  if (detail?.stack) stack.textContent = detail.stack
+  else stack.remove()
+  // dismiss clears the stored copy too, or the next reload repaints it
+  shadow.querySelector('button').addEventListener('click', clearRouteErrorOverlay)
+  document.documentElement.appendChild(host)
+
+  // a failed route makes the client render null where the server rendered the
+  // real route, so react hits a hydration mismatch and recovers by re-rendering
+  // from scratch. that recovery calls clearContainerSparingly on the root
+  // container, which here is <html>, so it strips this overlay out about a
+  // second after it appears — the reason the error stayed invisible. put it back
+  // once react is done. bounded and short-lived so it can never fight the app.
+  let readds = 0
+  const keepAlive = new MutationObserver(() => {
+    if (host.isConnected || readds >= 3) return
+    readds++
+    document.documentElement.appendChild(host)
+  })
+  keepAlive.observe(document.documentElement, { childList: true })
+  setTimeout(() => keepAlive.disconnect(), 10000)
+}
+
+// a failed route makes the client render null where the server rendered the real
+// route, so react reports a hydration mismatch and the page full-reloads. that
+// reload wipes the overlay within a second of it appearing, and the reloaded page
+// resolves the route from cache without failing again, so nothing repaints it.
+// hold the error for the tab and repaint after the reload, the way vite replays
+// server errors to a reconnecting client. cleared by any successful hot update.
+const ROUTE_ERROR_KEY = 'one:last-route-error'
+
+function clearRouteErrorOverlay() {
+  try {
+    sessionStorage.removeItem(ROUTE_ERROR_KEY)
+  } catch {}
+  document.querySelector(ROUTE_ERROR_TAG)?.remove()
+}
+
+function paintRouteError(detail) {
+  try {
+    showRouteErrorOverlay(detail)
+  } catch (err) {
+    console.error('[one] could not render the route error overlay:', err)
+  }
+}
+
+window.__oneReportRouteLoadError = (detail) => {
+  routeErrorHot.send('one:route-error', detail)
+  try {
+    sessionStorage.setItem(ROUTE_ERROR_KEY, JSON.stringify(detail))
+  } catch {}
+  paintRouteError(detail)
+}
+
+routeErrorHot.on('vite:afterUpdate', clearRouteErrorOverlay)
+
+try {
+  const stored = sessionStorage.getItem(ROUTE_ERROR_KEY)
+  if (stored) {
+    if (document.body) paintRouteError(JSON.parse(stored))
+    else {
+      document.addEventListener(
+        'DOMContentLoaded',
+        () => paintRouteError(JSON.parse(stored)),
+        { once: true }
+      )
+    }
+  }
+} catch {}
+
 // loader HMR
 const loaderHot = createHotContext('/__one_loader_hmr')
 loaderHot.on('one:loader-data-update', async (data) => {

--- a/packages/one/src/router/useViteRoutes.tsx
+++ b/packages/one/src/router/useViteRoutes.tsx
@@ -283,6 +283,27 @@ export function globbedRoutesToRouteContext(
         })
         .catch((err) => {
           console.error(`Error loading route`, id, err, new Error().stack)
+          // rendering an empty component keeps one bad route from taking down the
+          // app, but it also makes the failure invisible: nothing inside the route
+          // mounts and the only trace is the line above. in dev, hand it to the
+          // dev server so it reaches the terminal and the vite overlay. the global
+          // is installed by devtools/dev.mjs, so this is inert on native and in
+          // any build without it.
+          if (process.env.NODE_ENV === 'development') {
+            ;(
+              globalThis as typeof globalThis & {
+                __oneReportRouteLoadError?: (detail: {
+                  id: string
+                  message: string
+                  stack?: string
+                }) => void
+              }
+            ).__oneReportRouteLoadError?.({
+              id,
+              message: err instanceof Error ? err.message : String(err),
+              stack: err instanceof Error ? err.stack : undefined,
+            })
+          }
           loadedRoutes[id] = {
             default: () => null,
           }

--- a/packages/one/src/vite/plugins/routeModuleHmrPlugin.ts
+++ b/packages/one/src/vite/plugins/routeModuleHmrPlugin.ts
@@ -5,6 +5,28 @@ import { isPathInsideDirectory } from '../../utils/routeFileWatch'
 export function createRouteModuleHmrPlugin(routerRoot: string): Plugin {
   return {
     name: 'route-module-hmr-fix',
+
+    // the router swallows a failed route import and renders an empty component
+    // in its place (see useViteRoutes resolve). that is right for production and
+    // wrong for dev, where it meant a broken import anywhere in a route's module
+    // graph produced a blank app, no terminal output, and one console line — with
+    // every provider inside that route silently never mounting. the client paints
+    // its own overlay (devtools/dev.mjs) and reports here so the failure also
+    // reaches the terminal, where the person running the dev server is looking.
+    configureServer(server) {
+      server.hot.on(
+        'one:route-error',
+        (data: { id?: string; message?: string; stack?: string } | undefined) => {
+          const id = data?.id || 'unknown route'
+          const message = data?.message || 'unknown error'
+          server.config.logger.error(
+            `[one] route failed to load: ${id}\n  ${message}\n  the router rendered an empty component in its place, so nothing inside this route mounted.`,
+            { timestamp: true }
+          )
+        }
+      )
+    },
+
     hotUpdate({ server, modules, file }) {
       const absoluteRouterRoot = path.resolve(server.config.root, routerRoot)
       const fileRelativePath = path.relative(server.config.root, file)


### PR DESCRIPTION
`useViteRoutes` catches a failed route import and substitutes a component that renders `null`, so one bad route cannot take down the whole app. That is right for production. In dev it hid the cause completely: a broken import anywhere in a route's module graph produced a blank page, nothing in the terminal, and a single `console.error` line — while every provider mounted inside that route silently never started.

A downstream app lost hours to this today. A half-finished rename left one route importing a name that no longer existed; the swallowed error disabled all data sync, and it presented as "the Zero client never connects" with no request ever issued.

Dev now reports the failure to the dev server, which logs a terminal line, and paints an overlay naming the route, the error, and the consequence.

Two things here were verified rather than assumed:

- **Vite's own error overlay never appears in One**, so this paints its own the way `devtools/source-inspector.mjs` already does. Control: a plain syntax error in a route produces no overlay either.
- **React removes the overlay if you just append it.** Rendering `null` where the server rendered the real route *is* a hydration mismatch, so React recovers by re-rendering and calls `clearContainerSparingly` on the root container — which in One is `<html>`, so moving off `<body>` does not help. Captured by patching `removeChild` for a stack rather than guessing. A short bounded re-append (max 3, observer disconnects after 10s) survives that one recovery commit.

## Verification

In `examples/one-basic`, against a faithful reproduction of the downstream failure (SSR succeeds, the client route import rejects):

- terminal line fires
- overlay renders with route id, message, explanation, and stack
- negative control: a healthy route shows no overlay
- `routeModuleHmrPlugin.test.ts` green, `tsc --noEmit -p packages/one` clean

## Scope

Production and native are unaffected: the reporting hook is installed by `devtools/dev.mjs`, so it does not exist in those builds. The router's production behavior — swallow and render `null` — is unchanged.