### PR TITLE
fix(compiler): include compiler version in persistent cache fingerprint

### DIFF
--- a/packages/compiler/src/cache.ts
+++ b/packages/compiler/src/cache.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { configuration } from './configure'
 
 /**
@@ -36,11 +37,45 @@ function getCacheDir(): string {
   return cacheDir
 }
 
-// hash config state so cache invalidates when compiler/reanimated/nativewind toggles change
+// the cache persists in node_modules/.vxrn/compiler-cache and entries are
+// validated only against input file mtime/content + the config fingerprint.
+// transform output also depends on the compiler implementation itself, so the
+// fingerprint must include the compiler version - otherwise entries written by
+// an older @vxrn/compiler survive an upgrade and serve stale transforms.
+function getOwnVersion(): string {
+  try {
+    const dir =
+      typeof __dirname !== 'undefined'
+        ? // CommonJS
+          __dirname
+        : // ESM
+          dirname(fileURLToPath(import.meta.url))
+    // compiled output runs from dist/{esm,cjs}, two levels below the package
+    // root; straight from src (tests) it's one level below
+    for (const relativeRoot of ['..', join('..', '..')]) {
+      const candidate = join(dir, relativeRoot, 'package.json')
+      if (existsSync(candidate)) {
+        const packageJson = JSON.parse(readFileSync(candidate, 'utf-8'))
+        if (packageJson.name === '@vxrn/compiler' && packageJson.version) {
+          return packageJson.version
+        }
+      }
+    }
+  } catch {
+    // fall through to the static fallback marker
+  }
+  return 'unknown'
+}
+
+const compilerVersion = getOwnVersion()
+
+// hash compiler version + config state so cache invalidates when the compiler
+// is upgraded or the compiler/reanimated/nativewind toggles change
 function getConfigFingerprint(): string {
   return createHash('sha1')
     .update(
       JSON.stringify({
+        version: compilerVersion,
         compiler: configuration.enableCompiler,
         reanimated: configuration.enableReanimated,
         nativewind: configuration.enableNativewind,


### PR DESCRIPTION
## Symptom

After changing `@vxrn/compiler`'s transform behavior (upgrading it, or in our case editing a carried pnpm patch on it), dev builds kept serving the **old** transform output. The persistent transform cache in `node_modules/.vxrn/compiler-cache` lives in the app's `node_modules` and survives package upgrades, so stale entries keep winning until someone manually deletes the cache dir — a very confusing failure mode, because the symptom looks like "my compiler change did nothing."

## Root cause

`getCachedTransform()` validates entries against input file mtime + content hash, plus `getConfigFingerprint()` — which hashes only the four config toggles (`enableCompiler`, `enableReanimated`, `enableNativewind`, `enableNativeCSS`):

- inputs unchanged ✓
- config unchanged ✓
- compiler implementation changed ✗ (not part of the key)

Nothing in the cache key captures the compiler implementation itself, so any release that changes transform output (or any patch applied to the package) silently reuses transforms produced by the previous implementation.

## Fix

Fold the compiler's own package version into `getConfigFingerprint()`. Version discovery mirrors the existing `getPackageVersion()` pattern in `packages/one/src/cli.ts` (CJS/ESM dual `__dirname`/`import.meta.url` handling); it walks `..` and `../..` so it resolves the right `package.json` both from compiled `dist/{esm,cjs}` output and straight from `src` (tests), verifies `name === '@vxrn/compiler'`, and falls back to a static marker if the read fails.

## Verification

Smoke-tested against the public cache API (`setCachedTransform`/`getCachedTransform`) with a fixed input file and default config, comparing `main` vs this branch:

- `main` writes cache key `c9fc91f1…` (no version in the fingerprint)
- this branch writes `91a459dd…`, which exactly matches an independently recomputed sha1 of the fingerprint JSON with `version: "1.24.1"` — proving the version resolves for real (not the fallback) and lands in the key
- re-running on this branch produces no new key and hits the cache (key is stable across processes)

`tsc --noEmit`, `oxlint`, and `oxfmt --check` are clean on the package. (`vitest run --dir src` currently fails on unmodified `main` in my environment with a `vite` resolution error from `transformBabel.test.ts`, unrelated to this change.)

## Downstream

We hit this in production in the multiplatform.one framework, where we carry pnpm patches on `@vxrn/compiler` (Hermes dev-lowering fixes we're upstreaming separately): after every patch edit the compiler cache kept serving pre-patch transforms. We currently carry a manual `PATCH_VERSION` marker in the fingerprint as a pnpm patch; a version-based marker upstream retires it and fixes the general upgrade case for everyone.

Made with [Cursor](https://cursor.com)