### PR TITLE
fix: serve loader responses as CJS for ?platform=native requests

### DIFF
--- a/packages/one/src/createHandleRequest.test.ts
+++ b/packages/one/src/createHandleRequest.test.ts
@@ -242,6 +242,76 @@ describe('createHandleRequest', () => {
     })
   })
 
+  describe('loader responses for ?platform=native requests', () => {
+    // in dev, useLoader on native fetches loaders with ?platform=native and
+    // runs the response body as CJS on hermes - a web ESM body
+    // ("export function loader()...") is a parse error there, which the
+    // client swallows (the route silently loses its loader data)
+
+    it('should serve loader bodies as CJS for platform=native', async () => {
+      const mockHandlersWithLoader = {
+        handlePage: vi.fn().mockResolvedValue('<html></html>'),
+        handleLoader: vi
+          .fn()
+          .mockResolvedValue('export function loader() { return {"a":1} }'),
+      }
+      const { handler } = createHandleRequest(mockHandlersWithLoader, {
+        routerRoot: '/app',
+      })
+
+      const response = (await handler(
+        createRequest('/assets/profile_123_vxrn_loader.js?platform=native')
+      )) as Response | null
+
+      expect(response).not.toBeNull()
+      const body = await response!.text()
+      expect(body).toContain('exports.loader=')
+      expect(body).not.toContain('export function loader')
+    })
+
+    it('should serve redirect loader bodies as CJS for platform=native', async () => {
+      const mockHandlersWithLoader = {
+        handlePage: vi.fn().mockResolvedValue('<html></html>'),
+        handleLoader: vi.fn().mockRejectedValue(
+          new Response(null, {
+            status: 302,
+            headers: { location: '/login' },
+          })
+        ),
+      }
+      const { handler } = createHandleRequest(mockHandlersWithLoader, {
+        routerRoot: '/app',
+      })
+
+      const response = (await handler(
+        createRequest('/assets/profile_123_vxrn_loader.js?platform=native')
+      )) as Response | null
+
+      expect(response).not.toBeNull()
+      const body = await response!.text()
+      expect(body).toContain('exports.loader=')
+      expect(body).toContain('__oneRedirect')
+    })
+
+    it('should keep serving ESM loader bodies to web requests', async () => {
+      const esmBody = 'export function loader() { return {"a":1} }'
+      const mockHandlersWithLoader = {
+        handlePage: vi.fn().mockResolvedValue('<html></html>'),
+        handleLoader: vi.fn().mockResolvedValue(esmBody),
+      }
+      const { handler } = createHandleRequest(mockHandlersWithLoader, {
+        routerRoot: '/app',
+      })
+
+      const response = (await handler(
+        createRequest('/assets/profile_123_vxrn_loader.js')
+      )) as Response | null
+
+      expect(response).not.toBeNull()
+      expect(await response!.text()).toBe(esmBody)
+    })
+  })
+
   describe('dynamic route matching', () => {
     it('should match dynamic routes for regular paths without extensions', async () => {
       const { handler } = createHandleRequest(mockHandlers, { routerRoot: '/app' })

--- a/packages/one/src/createHandleRequest.ts
+++ b/packages/one/src/createHandleRequest.ts
@@ -190,7 +190,8 @@ export async function resolveLoaderRoute(
 
   const isNativeRequest =
     url.searchParams.get('platform') === 'ios' ||
-    url.searchParams.get('platform') === 'android'
+    url.searchParams.get('platform') === 'android' ||
+    url.searchParams.get('platform') === 'native'
 
   const response = await runMiddlewares(handlers, request, route, async () => {
     return await resolveResponse(async () => {

--- a/packages/one/src/vite/plugins/fileSystemRouterPlugin.tsx
+++ b/packages/one/src/vite/plugins/fileSystemRouterPlugin.tsx
@@ -485,11 +485,22 @@ export function createFileSystemRouterPlugin(
             throw new Error(`No transformed js returned`)
           }
 
+          const platform = url.searchParams.get('platform')
+          const isNativeRequest =
+            platform === 'ios' || platform === 'android' || platform === 'native'
+
           // the client tree-shake plugin replaces loader exports with stubs
           // like "export function loader()". if no stub exists, this route has
           // no loader - skip the SSR module import to avoid evaluating modules
-          // with potentially SSR-incompatible deps (e.g. tamagui in SSR)
-          if (!/export function loader\(\)/.test(transformedJS)) {
+          // with potentially SSR-incompatible deps (e.g. tamagui in SSR).
+          // never take this shortcut for native requests: native runs loader
+          // responses as CJS on hermes, so returning the vite-transformed web
+          // ESM (import statements + HMR preamble) is unparseable there and
+          // silently drops the route's loader data. the stub can also be
+          // legitimately absent for loader shapes the tree-shaker doesn't
+          // rewrite (e.g. `export { x as loader } from './loaders'`), which the
+          // module runner import below resolves fine.
+          if (!isNativeRequest && !/export function loader\(\)/.test(transformedJS)) {
             return transformedJS
           }
 
@@ -562,9 +573,7 @@ export function createFileSystemRouterPlugin(
             })
           }
 
-          const platform = url.searchParams.get('platform')
-
-          if (platform === 'ios' || platform === 'android' || platform === 'native') {
+          if (isNativeRequest) {
             // Need to transpile to CommonJS for React Native
 
             const environment =


### PR DESCRIPTION
## Symptom

In dev, `useLoader` on native fetches route loaders with `?platform=native` (the comment in `useLoader.ts` even says "`?platform=native` tells vite plugin to return CJS") and evaluates the response body as CJS on Hermes. But two gates in the request pipeline only recognize `platform=ios|android`, so `platform=native` requests can receive the Vite-transformed **web ESM** module instead. Hermes then throws while compiling the loader body:

```
[one] native loader error for /pokemon: 1:21:import declaration must be at top level of module
```

The error is caught and swallowed (`data: {}`), so the route silently loses its server-side loader data — including `__oneRedirect` / `__oneError` signals, meaning server redirects thrown from loaders never reach the native client.

## Root cause (two spots)

1. **`createHandleRequest.ts` → `resolveLoaderRoute`**: `isNativeRequest` misses `platform=native`, so the CJS conversion (`toCjsLoader`) and the redirect (302) / auth (401/403) fallback loader bodies are emitted as web ESM for those requests. (The dispatch-level check in `handleRequest` already recognizes `native`; this inner one didn't.)

2. **`fileSystemRouterPlugin.tsx` → `handleLoader`**: the `export function loader()` stub-regex gate early-returns the raw Vite-transformed web ESM (HMR preamble included) *above* the platform check that would have produced the native CJS body. Any route whose loader the client tree-shake plugin doesn't rewrite to the literal stub — e.g. a re-export like `export { pokemonListLoader as loader } from './loaders'` — fails the regex and sends web ESM to native. The regex is irrelevant for native responses: the native branch never uses `transformedJS` at all — it imports the route through the module runner (which resolves re-exports fine) and returns the JSON-embedding CJS body.

## Fix

- include `native` in `resolveLoaderRoute`'s `isNativeRequest`
- hoist the platform check in `handleLoader` above the stub-regex gate so native requests always take the module-runner path; web requests keep the existing shortcut (including the skip-SSR-import optimization for routes without loader stubs)

## Verification

- 3 new unit tests in `createHandleRequest.test.ts`. The two `platform=native` ones fail before the fix (body arrives as `export function loader(){...}` web ESM) and pass after; the web test guards against regressions on the ESM path. Full file: 23/23 pass.
- Downstream: we've been carrying the dist-level equivalent of this diff as a pnpm patch in [multiplatform.one](https://gitlab.com/bitspur/frappe/multiplatform.one) against `one@1.16.5`. With routes written as plain re-exports:

```sh
curl 'http://localhost:3000/assets/pokemon_<cachekey>_vxrn_loader.js?platform=native'
# before: import { createHotContext as __vite__createHotContext } from "/@vite/client";...  (Hermes parse error)
# after:  exports.loader = () => ({"pokemon":[{"name":"bulbasaur",...}]});
```

On device (Expo Go SDK 55 / Hermes): the `[one] native loader error` toast is gone and the route receives the server-prefetched loader data.

Made with [Cursor](https://cursor.com)