### PR TITLE
ci: install appium fresh instead of restoring a stale cache

### DIFF
--- a/.github/workflows/test-native-ios.yml
+++ b/.github/workflows/test-native-ios.yml
@@ -4,6 +4,9 @@ env:
   simulator_ios_version: 26.4
   # Name of the simulator device to use.
   simulator_device_name: iPhone 17 Pro
+  # Pinned so a run never picks up an incompatible appium/driver pair.
+  appium_version: 3.6.0
+  appium_xcuitest_version: 12.5.0
 
 on:
   push:
@@ -165,34 +168,25 @@ jobs:
           SIMULATOR_UDID: ${{ steps.get-simulator-udid.outputs.simulator_udid }}
         run: xcrun simctl boot $SIMULATOR_UDID
 
-      - name: Cache Appium
-        id: appium-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.appium
-            /usr/local/lib/node_modules/appium
-            /usr/local/bin/appium
-          key: appium-xcuitest-${{ runner.os }}-v3
-
       - name: Install Appium
-        if: steps.appium-cache.outputs.cache-hit != 'true'
+        env:
+          APPIUM_VERSION: ${{ env.appium_version }}
+          APPIUM_XCUITEST_VERSION: ${{ env.appium_xcuitest_version }}
         run: |
-          npm install -g appium
-          appium driver install xcuitest
-
-      - name: Verify Appium
-        run: |
-          # ensure cached appium is functional (symlink can break)
-          if ! appium --version 2>/dev/null; then
-            echo "appium not functional, reinstalling..."
-            npm install -g appium
-            appium driver install xcuitest 2>/dev/null || appium driver update xcuitest
-          fi
-          # ensure xcuitest driver is up to date
-          appium driver update xcuitest 2>/dev/null || true
+          # deliberately not cached: the xcuitest driver resolves `appium` from
+          # its own node_modules under ~/.appium, so a restored tree drifts from
+          # whatever `npm install -g appium` put on this runner. that drift
+          # still lets the server start, then fails every session with
+          # "Could not find a driver for automationName 'XCUITest'". a clean
+          # pinned install takes ~2min and can't drift.
+          npm install -g appium@$APPIUM_VERSION
+          appium driver install xcuitest@$APPIUM_XCUITEST_VERSION
           appium --version
           appium driver list --installed
+          # loading the driver is the only thing that proves the install is
+          # usable; `appium --version` and `driver list` both pass on a tree
+          # whose driver can't import appium.
+          cd ~/.appium && node --input-type=module -e 'await import("appium-xcuitest-driver")'
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/test-native-ios.yml
+++ b/.github/workflows/test-native-ios.yml
@@ -74,7 +74,10 @@ jobs:
       - build-ios-test-container-dev
       - build-ios-test-container-prod
     runs-on: macos-26
-    timeout-minutes: 45
+    # a slow runner roughly doubles this job: dev/metro ran 24m48s on 2026-08-15
+    # and 45m51s on 2026-08-18, where the metro dev bundle alone went 22s -> 56s.
+    # 45 killed that job 10 seconds after its tests had all passed.
+    timeout-minutes: 60
     # rolldown:prod is experimental — don't fail the workflow on it.
     # (prod used to crash on launch with a SIGSEGV from an upstream RN
     # TurboModule/Hermes concurrency bug — now fixed via a builtInDepPatches
@@ -190,7 +193,8 @@ jobs:
 
       - name: Start Appium Server
         run: |
-          appium > /tmp/appium.log 2>&1 &
+          # timestamps make the log usable for finding where a slow session went
+          appium --log-timestamp > /tmp/appium.log 2>&1 &
           # wait for appium to be ready
           for i in {1..30}; do
             if curl -s http://localhost:4723/status | grep -q '"ready":true'; then

--- a/packages/test/src/internal-utils/ios.ts
+++ b/packages/test/src/internal-utils/ios.ts
@@ -478,7 +478,13 @@ export async function getWebDriverConfig(): Promise<WebdriverIOConfig> {
   const wdOpts = {
     hostname: process.env.APPIUM_HOST || 'localhost',
     port: process.env.APPIUM_PORT ? Number.parseInt(process.env.APPIUM_PORT, 10) : 4723,
-    connectionRetryTimeout: 240 * 1000,
+    // the first session of a run pays the whole cold start: install WDA on the
+    // simulator, launch it, then launch the app. the driver already retries WDA
+    // startup on its own (wdaLaunchTimeout x wdaStartupRetries, 180s by
+    // default), so this has to sit above that budget. at 240s a slow CI runner
+    // aborts a session the server is still legitimately starting, and the next
+    // attempt repeats the entire cold start, which cost one CI job 8 minutes.
+    connectionRetryTimeout: 420 * 1000,
     connectionRetryCount: 3,
     logLevel: 'warn' as const,
     capabilities,


### PR DESCRIPTION
iOS Native Tests has been red since 2026-08-16 (first failure 8a7e76f55, unrelated to any source change). Every matrix job fails the same way: no WebDriver session is ever created.

```
Could not find a driver for automationName 'XCUITest' and platformName 'iOS'
(Lower-level error: Cannot find package 'appium' imported from
 /Users/runner/.appium/node_modules/appium-xcuitest-driver/build/lib/driver.js)
```

**What actually happened** (from the run 32172332783 log): the `appium-xcuitest-macOS-v3` cache restores, then `appium --version` fails, so the verify step reinstalls appium globally and runs `appium driver update xcuitest` (12.3.4 -> 12.5.0) on top of the restored tree. `appium --version` prints 3.6.0 and `driver list --installed` prints xcuitest@12.5.0, so the step passes, and the server starts fine. But the driver imports `appium` from its own `node_modules` under `~/.appium`, and the restored tree no longer has one that resolves, so it only fails at createSession, minutes later.

**Fix**: drop the cache and install pinned versions clean each run. A fresh install puts the driver's `appium` peer inside `~/.appium` where it resolves, and nothing mutates it in place. The cache was saving ~60s of a 45-minute job (restore+extract took 109s in the failing run; a clean install is ~150s).

Also added a real check: loading the driver module. `appium --version` and `appium driver list --installed` both pass on a tree whose driver can't import appium, so they never caught this.

Verified locally on macOS:
- `appium driver install xcuitest@12.5.0` accepts the pinned spec, and a clean install nests the `appium` peer at `~/.appium/node_modules/appium-xcuitest-driver/node_modules/appium`.
- The import check passes on that tree (0.4s).
- Negative control: moving that peer aside makes the check fail with the exact CI error, `Cannot find package 'appium' imported from .../build/lib/driver.js`.