### PR TITLE
v1.25.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ on:
           - patch
           - minor
           - major
+          # publish the version already committed on main, bumping nothing.
+          # `patch`/`minor`/`major` bump in-workflow and then have to push that
+          # version commit to main, which main's protection rejects outright:
+          # "GH006 ... Changes must be made through the merge queue". every
+          # stable release attempt has died there. so land the version bump as
+          # an ordinary pull request through the queue, then dispatch this to
+          # publish it. see docs/releasing.md.
+          - republish
 
 permissions: {}
 
@@ -156,7 +164,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # republish takes the version exactly as main already has it, so there is
+      # nothing to prepare and nothing to push.
       - name: Prepare release commit
+        if: inputs.release != 'republish'
         env:
           RELEASE_KIND: ${{ inputs.release }}
         shell: bash
@@ -172,8 +183,13 @@ jobs:
       # pull request and a merge queue, so the push is rejected with GH006 and
       # the publish step below never runs. the version bump only has to exist in
       # the tree for npm, never on main.
+      #
+      # the same rejection kills patch/minor/major, which DO need their version
+      # commit on main. those have never once published: every Release run in
+      # this repo's history failed here. use `republish` instead, which expects
+      # the version commit to already be on main via a normal pull request.
       - name: Push release commit
-        if: inputs.release != 'canary'
+        if: inputs.release != 'canary' && inputs.release != 'republish'
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ github.sha }}
@@ -206,6 +222,12 @@ jobs:
         run: |
           set -euo pipefail
           version=$(node -p "require('./packages/one/package.json').version")
+          # the bump path tags as part of preparing the version. republish has
+          # no prepare step, so tag the main commit that already carries this
+          # version. the assertion below guards both paths identically.
+          if ! git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            git tag "v$version"
+          fi
           [[ "$(git rev-list -n 1 "v$version")" == "$(git rev-parse HEAD)" ]]
           auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
           trap 'git config --local --unset-all http.https://github.com/.extraheader || true' EXIT

--- a/apps/one-tray/package.json
+++ b/apps/one-tray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-tray",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "scripts": {
     "build": "[ \"$(uname)\" = \"Darwin\" ] && make debug || true",

--- a/apps/onestack.dev/package.json
+++ b/apps/onestack.dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
     },
     "apps/one-tray": {
       "name": "one-tray",
-      "version": "1.24.9",
+      "version": "1.25.0",
     },
     "apps/onestack.dev": {
       "name": "site",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@docsearch/react": "^3.9.0",
         "@react-navigation/native": "~7.3.16",
@@ -75,7 +75,7 @@
     },
     "examples/bare": {
       "name": "example-bare",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "expo-constants": "~57.0.9",
         "react": "19.2.3",
@@ -101,7 +101,7 @@
     },
     "examples/expo-blank": {
       "name": "expo-blank-app",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "expo": "~57.0.11",
         "expo-status-bar": "~57.0.1",
@@ -113,7 +113,7 @@
     },
     "examples/expo-blank-with-vite-metro": {
       "name": "expo-blank-with-vite-metro",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "expo": "~57.0.11",
         "one": "workspace:*",
@@ -130,7 +130,7 @@
     },
     "examples/one-basic": {
       "name": "example-basic",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -152,7 +152,7 @@
     },
     "examples/testflight": {
       "name": "example-testflight",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@bottom-tabs/react-navigation": "^0.9.1",
         "@dotenvx/dotenvx": "^1.12.1",
@@ -191,7 +191,7 @@
     },
     "packages/color-scheme": {
       "name": "@vxrn/color-scheme",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@vxrn/use-isomorphic-layout-effect": "workspace:*",
       },
@@ -208,7 +208,7 @@
     },
     "packages/compiler": {
       "name": "@vxrn/compiler",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/plugin-transform-destructuring": "^7.28.5",
@@ -240,7 +240,7 @@
     },
     "packages/create-vxrn": {
       "name": "create-vxrn",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "bin": {
         "create-vxrn": "run.js",
       },
@@ -265,7 +265,7 @@
     },
     "packages/debug": {
       "name": "@vxrn/debug",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "debug": "^4.3.7",
       },
@@ -276,7 +276,7 @@
     },
     "packages/emitter": {
       "name": "@vxrn/emitter",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "devDependencies": {
         "@tamagui/build": "2.6.2",
         "react": "19.2.3",
@@ -287,7 +287,7 @@
     },
     "packages/lllink": {
       "name": "lllink",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "bin": {
         "lllink": "dist/index.mjs",
       },
@@ -298,7 +298,7 @@
     },
     "packages/mdx": {
       "name": "@vxrn/mdx",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "compare-versions": "^4.1.3",
         "esbuild-wasm": "^0.25.11",
@@ -330,7 +330,7 @@
     },
     "packages/mdx-rust": {
       "name": "@vxrn/mdx-rust",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "compare-versions": "^4.1.3",
         "fast-glob": "^3.3.3",
@@ -353,7 +353,7 @@
     },
     "packages/native": {
       "name": "@vxrn/native",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@vxrn/use-isomorphic-layout-effect": "workspace:*",
       },
@@ -368,7 +368,7 @@
       "peerDependencies": {
         "@react-navigation/native": "~7.3.16",
         "@react-navigation/native-stack": "~7.18.8",
-        "one": "1.24.9",
+        "one": "1.25.0",
         "react": "*",
         "react-native": "*",
         "react-native-safe-area-context": ">=5.4.0",
@@ -380,7 +380,7 @@
     },
     "packages/one": {
       "name": "one",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "bin": {
         "one": "run.mjs",
       },
@@ -488,7 +488,7 @@
     },
     "packages/one-vscode": {
       "name": "one-vscode",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "ws": "^8.21.0",
       },
@@ -501,7 +501,7 @@
     },
     "packages/query-string": {
       "name": "@vxrn/query-string",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "query-string": "^9.1.0",
       },
@@ -511,7 +511,7 @@
     },
     "packages/react-native-prebuilt": {
       "name": "@vxrn/react-native-prebuilt",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@vxrn/utils": "workspace:*",
         "@vxrn/vite-flow": "workspace:*",
@@ -535,7 +535,7 @@
     },
     "packages/resolve": {
       "name": "@vxrn/resolve",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "devDependencies": {
         "@tamagui/build": "2.6.2",
         "vitest": "^4.1.0",
@@ -543,11 +543,11 @@
     },
     "packages/rn-proxy": {
       "name": "@vxrn/rn-proxy",
-      "version": "1.24.9",
+      "version": "1.25.0",
     },
     "packages/safe-area": {
       "name": "@vxrn/safe-area",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "devDependencies": {
         "@biomejs/biome": "2.3.3",
         "@tamagui/build": "2.6.2",
@@ -555,7 +555,7 @@
     },
     "packages/test": {
       "name": "@vxrn/test",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "react": "19.2.3",
         "zx": "^8.5.5",
@@ -569,15 +569,15 @@
     },
     "packages/test-package": {
       "name": "@vxrn/test-package",
-      "version": "1.24.9",
+      "version": "1.25.0",
     },
     "packages/tslib-lite": {
       "name": "@vxrn/tslib-lite",
-      "version": "1.24.9",
+      "version": "1.25.0",
     },
     "packages/url-parse": {
       "name": "@vxrn/url-parse",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "url-parse": "^1.5.10",
       },
@@ -587,7 +587,7 @@
     },
     "packages/use-isomorphic-layout-effect": {
       "name": "@vxrn/use-isomorphic-layout-effect",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "devDependencies": {
         "@tamagui/build": "2.6.2",
         "react": "19.2.3",
@@ -598,7 +598,7 @@
     },
     "packages/utils": {
       "name": "@vxrn/utils",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@vxrn/debug": "workspace:*",
         "@vxrn/resolve": "workspace:*",
@@ -611,11 +611,11 @@
     },
     "packages/vendor": {
       "name": "@vxrn/vendor",
-      "version": "1.24.9",
+      "version": "1.25.0",
     },
     "packages/vite-flow": {
       "name": "@vxrn/vite-flow",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -630,7 +630,7 @@
     },
     "packages/vite-native-client": {
       "name": "@vxrn/vite-native-client",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "devDependencies": {
         "@biomejs/biome": "2.3.3",
         "@tamagui/build": "2.6.2",
@@ -642,7 +642,7 @@
     },
     "packages/vite-native-hmr": {
       "name": "@vxrn/vite-native-hmr",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@types/webpack-env": "^1.18.8",
         "pretty-format": "^28.1.0",
@@ -657,7 +657,7 @@
     },
     "packages/vite-plugin-metro": {
       "name": "@vxrn/vite-plugin-metro",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -694,7 +694,7 @@
     },
     "packages/vxrn": {
       "name": "vxrn",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "bin": {
         "vxrn": "run.mjs",
       },
@@ -748,7 +748,7 @@
     },
     "tests/hmr": {
       "name": "test-hmr",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -768,7 +768,7 @@
     },
     "tests/native-features": {
       "name": "test-native-features",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@vxrn/native": "workspace:*",
@@ -817,7 +817,7 @@
     },
     "tests/sandbox": {
       "name": "test-sandbox",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -843,7 +843,7 @@
     },
     "tests/test": {
       "name": "test-test",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -884,7 +884,7 @@
     },
     "tests/test-app-cases": {
       "name": "test-app-cases",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -907,7 +907,7 @@
     },
     "tests/test-build-unified": {
       "name": "test-build-unified",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "axios": "^1.18.0",
         "date-fns": "^3.6.0",
@@ -925,7 +925,7 @@
     },
     "tests/test-bundled-dev": {
       "name": "test-bundled-dev",
-      "version": "1.24.6",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -940,7 +940,7 @@
     },
     "tests/test-cache-headers": {
       "name": "test-cache-headers",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -955,7 +955,7 @@
     },
     "tests/test-cloudflare": {
       "name": "test-cloudflare",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
       },
@@ -970,7 +970,7 @@
     },
     "tests/test-css-merged": {
       "name": "test-css-merged",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -985,7 +985,7 @@
     },
     "tests/test-css-preload": {
       "name": "test-css-preload",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1000,7 +1000,7 @@
     },
     "tests/test-deploy-flash": {
       "name": "test-deploy-flash",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1020,7 +1020,7 @@
     },
     "tests/test-env": {
       "name": "test-env",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1036,7 +1036,7 @@
     },
     "tests/test-headless-web": {
       "name": "test-headless-web",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1051,7 +1051,7 @@
     },
     "tests/test-hydration-id": {
       "name": "test-hydration-id",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1070,7 +1070,7 @@
     },
     "tests/test-id-remount": {
       "name": "test-id-remount",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1087,7 +1087,7 @@
     },
     "tests/test-layout-flicker": {
       "name": "test-layout-flicker",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1107,7 +1107,7 @@
     },
     "tests/test-layout-render-modes": {
       "name": "test-layout-render-modes",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1123,7 +1123,7 @@
     },
     "tests/test-loaders": {
       "name": "test-loaders",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -1150,7 +1150,7 @@
     },
     "tests/test-native-tree-shaking": {
       "name": "test-native-tree-shaking",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@vxrn/mdx": "workspace:*",
@@ -1172,7 +1172,7 @@
     },
     "tests/test-not-found": {
       "name": "test-not-found",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1192,7 +1192,7 @@
     },
     "tests/test-params-stability": {
       "name": "test-params-stability",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1212,7 +1212,7 @@
     },
     "tests/test-redirect-flash": {
       "name": "test-redirect-flash",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1232,7 +1232,7 @@
     },
     "tests/test-route-file-watching": {
       "name": "test-route-file-watching",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1252,7 +1252,7 @@
     },
     "tests/test-routing-flicker": {
       "name": "test-routing-flicker",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -1278,7 +1278,7 @@
     },
     "tests/test-script-loading": {
       "name": "test-script-loading",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1293,7 +1293,7 @@
     },
     "tests/test-skew-protection": {
       "name": "test-skew-protection",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1313,7 +1313,7 @@
     },
     "tests/test-sootsim-back": {
       "name": "test-sootsim-back",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1333,7 +1333,7 @@
     },
     "tests/test-spa-shell-routing": {
       "name": "test-spa-shell-routing",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1349,7 +1349,7 @@
     },
     "tests/test-use-dom": {
       "name": "test-use-dom",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1368,7 +1368,7 @@
     },
     "tests/test-vercel": {
       "name": "test-vercel",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1384,7 +1384,7 @@
     },
     "tests/test-warm-routes": {
       "name": "test-warm-routes",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1400,7 +1400,7 @@
     },
     "tests/test-weird-deps": {
       "name": "test-weird-deps",
-      "version": "1.24.9",
+      "version": "1.25.0",
       "devDependencies": {
         "vite": "^8.2.2",
       },

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,65 @@
+# Releasing One
+
+## Stable releases (patch / minor / major)
+
+Two steps, because `main` is protected by a merge queue.
+
+1. **Land the version bump as a normal pull request.**
+
+   ```sh
+   bun scripts/release.ts --minor --ci --dirty \
+     --skip-publish --skip-push --skip-tests --skip-native-tests
+   ```
+
+   That rewrites the workspace `package.json` versions and leaves them
+   uncommitted. Review the diff, run `bun install` so the lockfile matches,
+   commit as exactly `vX.Y.Z`, push a branch, open a PR and merge it through
+   the queue like any other change.
+
+2. **Dispatch the release workflow with `republish`.**
+
+   ```sh
+   gh workflow run release.yml --repo onejs/one --ref main -f release=republish
+   ```
+
+   It checks that `main` is current and that CI is green on that exact SHA,
+   publishes the version `main` already carries via npm trusted publishing
+   (OIDC, no token), pushes the `vX.Y.Z` tag, and creates the GitHub release.
+
+## Why not `release=minor` directly
+
+The `patch` / `minor` / `major` inputs bump the version inside the workflow and
+then push that commit straight to `main`. `main` does not accept that:
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - Changes must be made through the merge queue
+remote: - Changes must be made through a pull request.
+```
+
+Every Release run in this repo's history failed on that step, so those three
+inputs have never successfully published anything. They are kept only so the
+failure stays visible rather than looking like a missing feature. Use
+`republish`.
+
+## Canaries
+
+Canaries are unaffected: they publish the prepared tree to the `canary`
+dist-tag and mutate no git at all, so they work from any branch.
+
+```sh
+gh workflow run release.yml --repo onejs/one --ref main -f release=canary
+```
+
+Canary publishing is on-demand only. Keep well under ~20/day across all repos
+sharing this infrastructure.
+
+To test an upstream fix downstream without publishing anything at all, prefer:
+
+```sh
+bun release --into ~/<downstream>
+```
+
+Verify a canary by its content, never its version string: a local `--into`
+build and a published npm canary have carried the same version with different
+code. `npm pack <pkg>@<version>` and grep the built output.

--- a/examples/bare/package.json
+++ b/examples/bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-bare",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/examples/expo-blank-with-vite-metro/package.json
+++ b/examples/expo-blank-with-vite-metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-blank-with-vite-metro",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/examples/expo-blank/package.json
+++ b/examples/expo-blank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-blank-app",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "main": "expo/AppEntry.js",
   "scripts": {

--- a/examples/one-basic/package.json
+++ b/examples/one-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-basic",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/testflight/package.json
+++ b/examples/testflight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-testflight",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/color-scheme/package.json
+++ b/packages/color-scheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/color-scheme",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "exports": {
     "./package.json": "./package.json",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/compiler",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/create-vxrn/package.json
+++ b/packages/create-vxrn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-vxrn",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "bin": {
     "create-vxrn": "run.js"
   },

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/debug",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "source": "src/index.ts",
   "type": "module",

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/emitter",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "source": "src/index.ts",
   "types": "./src/index.ts",

--- a/packages/lllink/package.json
+++ b/packages/lllink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lllink",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "module": "dist",
   "exports": {

--- a/packages/mdx-rust/package.json
+++ b/packages/mdx-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/mdx-rust",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "sideEffects": false,
   "module": "dist",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/mdx",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "commonjs",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/native",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "description": "Native navigation features for One - zoom transitions, toolbar, color API, split view",
   "license": "MIT",
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "@react-navigation/native": "~7.3.16",
     "@react-navigation/native-stack": "~7.18.8",
-    "one": "1.24.9",
+    "one": "1.25.0",
     "react": "*",
     "react-native": "*",
     "react-native-screens": ">=4.0.0",

--- a/packages/one-vscode/package.json
+++ b/packages/one-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "one-vscode",
   "displayName": "One Framework",
   "description": "VSCode integration for One framework - live element highlighting",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "publisher": "one",
   "engines": {

--- a/packages/one/package.json
+++ b/packages/one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "license": "BSD-3-Clause",
   "sideEffects": [
     "setup.mjs",

--- a/packages/one/types/layouts/Drawer.d.ts
+++ b/packages/one/types/layouts/Drawer.d.ts
@@ -5,42 +5,42 @@ export declare const Drawer: React.ForwardRefExoticComponent<Omit<Omit<Omit<impo
     children: React.ReactNode;
     layout?: ((props: {
         state: DrawerNavigationState<ParamListBase>;
-        navigation: import("@react-navigation/core").NavigationHelpers<ParamListBase, {}>;
-        descriptors: Record<string, import("@react-navigation/core").Descriptor<DrawerNavigationOptions, import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, DrawerNavigationState<ParamListBase>, DrawerNavigationOptions, DrawerNavigationEventMap>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>;
+        navigation: import("@react-navigation/native").NavigationHelpers<ParamListBase, {}>;
+        descriptors: Record<string, import("@react-navigation/native").Descriptor<DrawerNavigationOptions, import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, DrawerNavigationState<ParamListBase>, DrawerNavigationOptions, DrawerNavigationEventMap>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>;
         children: React.ReactNode;
     }) => React.ReactElement) | undefined;
     screenListeners?: Partial<{
-        drawerItemPress: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
-        gestureEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
+        drawerItemPress: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
+        gestureEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
     }> | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>;
     }) => Partial<{
-        drawerItemPress: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
-        gestureEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
+        drawerItemPress: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
+        gestureEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
     }>) | undefined;
     screenOptions?: DrawerNavigationOptions | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>;
         theme: ReactNavigation.Theme;
     }) => DrawerNavigationOptions) | undefined;
-    screenLayout?: ((props: import("@react-navigation/core").ScreenLayoutArgs<ParamListBase, string, DrawerNavigationOptions, import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
+    screenLayout?: ((props: import("@react-navigation/native").ScreenLayoutArgs<ParamListBase, string, DrawerNavigationOptions, import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
     UNSTABLE_router?: (<Action extends Readonly<{
         type: string;
         payload?: object;
@@ -56,42 +56,42 @@ export declare const Drawer: React.ForwardRefExoticComponent<Omit<Omit<Omit<impo
     children: React.ReactNode;
     layout?: ((props: {
         state: DrawerNavigationState<ParamListBase>;
-        navigation: import("@react-navigation/core").NavigationHelpers<ParamListBase, {}>;
-        descriptors: Record<string, import("@react-navigation/core").Descriptor<DrawerNavigationOptions, import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, DrawerNavigationState<ParamListBase>, DrawerNavigationOptions, DrawerNavigationEventMap>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>;
+        navigation: import("@react-navigation/native").NavigationHelpers<ParamListBase, {}>;
+        descriptors: Record<string, import("@react-navigation/native").Descriptor<DrawerNavigationOptions, import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, DrawerNavigationState<ParamListBase>, DrawerNavigationOptions, DrawerNavigationEventMap>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>;
         children: React.ReactNode;
     }) => React.ReactElement) | undefined;
     screenListeners?: Partial<{
-        drawerItemPress: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
-        gestureEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
+        drawerItemPress: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
+        gestureEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
     }> | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>;
     }) => Partial<{
-        drawerItemPress: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureStart: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
-        gestureEnd: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/core").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
+        drawerItemPress: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "drawerItemPress", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureStart: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureStart", unknown>;
+        gestureEnd: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<DrawerNavigationEventMap & import("@react-navigation/native").EventMapCore<DrawerNavigationState<ParamListBase>>, "beforeRemove", true>;
     }>) | undefined;
     screenOptions?: DrawerNavigationOptions | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>;
         theme: ReactNavigation.Theme;
     }) => DrawerNavigationOptions) | undefined;
-    screenLayout?: ((props: import("@react-navigation/core").ScreenLayoutArgs<ParamListBase, string, DrawerNavigationOptions, import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
+    screenLayout?: ((props: import("@react-navigation/native").ScreenLayoutArgs<ParamListBase, string, DrawerNavigationOptions, import("@react-navigation/drawer").DrawerNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
     UNSTABLE_router?: (<Action extends Readonly<{
         type: string;
         payload?: object;

--- a/packages/one/types/layouts/Stack.d.ts
+++ b/packages/one/types/layouts/Stack.d.ts
@@ -6,38 +6,38 @@ export declare const Stack: React.ForwardRefExoticComponent<Omit<Omit<Omit<impor
     children: React.ReactNode;
     layout?: ((props: {
         state: StackNavigationState<ParamListBase>;
-        navigation: import("@react-navigation/core").NavigationHelpers<ParamListBase, {}>;
-        descriptors: Record<string, import("@react-navigation/core").Descriptor<NativeStackNavigationOptions, import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, StackNavigationState<ParamListBase>, NativeStackNavigationOptions, NativeStackNavigationEventMap>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>;
+        navigation: import("@react-navigation/native").NavigationHelpers<ParamListBase, {}>;
+        descriptors: Record<string, import("@react-navigation/native").Descriptor<NativeStackNavigationOptions, import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, StackNavigationState<ParamListBase>, NativeStackNavigationOptions, NativeStackNavigationEventMap>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>;
         children: React.ReactNode;
     }) => React.ReactElement) | undefined;
     screenListeners?: Partial<{
-        transitionStart: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        sheetDetentChange: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        sheetDetentChange: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
     }> | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>;
     }) => Partial<{
-        transitionStart: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        sheetDetentChange: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        sheetDetentChange: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
     }>) | undefined;
     screenOptions?: NativeStackNavigationOptions | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>;
         theme: ReactNavigation.Theme;
     }) => NativeStackNavigationOptions) | undefined;
-    screenLayout?: ((props: import("@react-navigation/core").ScreenLayoutArgs<ParamListBase, string, NativeStackNavigationOptions, import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
+    screenLayout?: ((props: import("@react-navigation/native").ScreenLayoutArgs<ParamListBase, string, NativeStackNavigationOptions, import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
     UNSTABLE_router?: (<Action extends Readonly<{
         type: string;
         payload?: object;
@@ -53,38 +53,38 @@ export declare const Stack: React.ForwardRefExoticComponent<Omit<Omit<Omit<impor
     children: React.ReactNode;
     layout?: ((props: {
         state: StackNavigationState<ParamListBase>;
-        navigation: import("@react-navigation/core").NavigationHelpers<ParamListBase, {}>;
-        descriptors: Record<string, import("@react-navigation/core").Descriptor<NativeStackNavigationOptions, import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, StackNavigationState<ParamListBase>, NativeStackNavigationOptions, NativeStackNavigationEventMap>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>;
+        navigation: import("@react-navigation/native").NavigationHelpers<ParamListBase, {}>;
+        descriptors: Record<string, import("@react-navigation/native").Descriptor<NativeStackNavigationOptions, import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, StackNavigationState<ParamListBase>, NativeStackNavigationOptions, NativeStackNavigationEventMap>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>;
         children: React.ReactNode;
     }) => React.ReactElement) | undefined;
     screenListeners?: Partial<{
-        transitionStart: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        sheetDetentChange: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        sheetDetentChange: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
     }> | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>;
     }) => Partial<{
-        transitionStart: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        gestureCancel: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
-        sheetDetentChange: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/core").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        gestureCancel: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "gestureCancel", unknown>;
+        sheetDetentChange: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "sheetDetentChange", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<NativeStackNavigationEventMap & import("@react-navigation/native").EventMapCore<StackNavigationState<ParamListBase>>, "beforeRemove", true>;
     }>) | undefined;
     screenOptions?: NativeStackNavigationOptions | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>;
         theme: ReactNavigation.Theme;
     }) => NativeStackNavigationOptions) | undefined;
-    screenLayout?: ((props: import("@react-navigation/core").ScreenLayoutArgs<ParamListBase, string, NativeStackNavigationOptions, import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
+    screenLayout?: ((props: import("@react-navigation/native").ScreenLayoutArgs<ParamListBase, string, NativeStackNavigationOptions, import("@react-navigation/native-stack").NativeStackNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
     UNSTABLE_router?: (<Action extends Readonly<{
         type: string;
         payload?: object;

--- a/packages/one/types/layouts/Tabs.d.ts
+++ b/packages/one/types/layouts/Tabs.d.ts
@@ -5,38 +5,38 @@ export declare const Tabs: React.ForwardRefExoticComponent<Omit<Omit<Omit<import
     children: React.ReactNode;
     layout?: ((props: {
         state: TabNavigationState<ParamListBase>;
-        navigation: import("@react-navigation/core").NavigationHelpers<ParamListBase, {}>;
-        descriptors: Record<string, import("@react-navigation/core").Descriptor<BottomTabNavigationOptions, import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, TabNavigationState<ParamListBase>, BottomTabNavigationOptions, BottomTabNavigationEventMap>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>;
+        navigation: import("@react-navigation/native").NavigationHelpers<ParamListBase, {}>;
+        descriptors: Record<string, import("@react-navigation/native").Descriptor<BottomTabNavigationOptions, import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, TabNavigationState<ParamListBase>, BottomTabNavigationOptions, BottomTabNavigationEventMap>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>;
         children: React.ReactNode;
     }) => React.ReactElement) | undefined;
     screenListeners?: Partial<{
-        tabPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
-        tabLongPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
+        tabPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
+        tabLongPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
     }> | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>;
     }) => Partial<{
-        tabPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
-        tabLongPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
+        tabPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
+        tabLongPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
     }>) | undefined;
     screenOptions?: BottomTabNavigationOptions | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>;
         theme: ReactNavigation.Theme;
     }) => BottomTabNavigationOptions) | undefined;
-    screenLayout?: ((props: import("@react-navigation/core").ScreenLayoutArgs<ParamListBase, string, BottomTabNavigationOptions, import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
+    screenLayout?: ((props: import("@react-navigation/native").ScreenLayoutArgs<ParamListBase, string, BottomTabNavigationOptions, import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
     UNSTABLE_router?: (<Action extends Readonly<{
         type: string;
         payload?: object;
@@ -52,38 +52,38 @@ export declare const Tabs: React.ForwardRefExoticComponent<Omit<Omit<Omit<import
     children: React.ReactNode;
     layout?: ((props: {
         state: TabNavigationState<ParamListBase>;
-        navigation: import("@react-navigation/core").NavigationHelpers<ParamListBase, {}>;
-        descriptors: Record<string, import("@react-navigation/core").Descriptor<BottomTabNavigationOptions, import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, TabNavigationState<ParamListBase>, BottomTabNavigationOptions, BottomTabNavigationEventMap>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>;
+        navigation: import("@react-navigation/native").NavigationHelpers<ParamListBase, {}>;
+        descriptors: Record<string, import("@react-navigation/native").Descriptor<BottomTabNavigationOptions, import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, TabNavigationState<ParamListBase>, BottomTabNavigationOptions, BottomTabNavigationEventMap>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>;
         children: React.ReactNode;
     }) => React.ReactElement) | undefined;
     screenListeners?: Partial<{
-        tabPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
-        tabLongPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
+        tabPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
+        tabLongPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
     }> | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>;
     }) => Partial<{
-        tabPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
-        tabLongPress: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
-        transitionStart: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
-        transitionEnd: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
-        focus: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
-        blur: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
-        state: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
-        beforeRemove: import("@react-navigation/core").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
+        tabPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabPress", true>;
+        tabLongPress: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "tabLongPress", unknown>;
+        transitionStart: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionStart", unknown>;
+        transitionEnd: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "transitionEnd", unknown>;
+        focus: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "focus", unknown>;
+        blur: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "blur", unknown>;
+        state: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "state", unknown>;
+        beforeRemove: import("@react-navigation/native").EventListenerCallback<BottomTabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<ParamListBase>>, "beforeRemove", true>;
     }>) | undefined;
     screenOptions?: BottomTabNavigationOptions | ((props: {
-        route: import("@react-navigation/core").RouteProp<ParamListBase, string>;
+        route: import("@react-navigation/native").RouteProp<ParamListBase, string>;
         navigation: import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>;
         theme: ReactNavigation.Theme;
     }) => BottomTabNavigationOptions) | undefined;
-    screenLayout?: ((props: import("@react-navigation/core").ScreenLayoutArgs<ParamListBase, string, BottomTabNavigationOptions, import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
+    screenLayout?: ((props: import("@react-navigation/native").ScreenLayoutArgs<ParamListBase, string, BottomTabNavigationOptions, import("@react-navigation/bottom-tabs").BottomTabNavigationProp<ParamListBase, string, string | undefined>>) => React.ReactElement) | undefined;
     UNSTABLE_router?: (<Action extends Readonly<{
         type: string;
         payload?: object;

--- a/packages/one/types/ui/TabContext.d.ts
+++ b/packages/one/types/ui/TabContext.d.ts
@@ -45,7 +45,7 @@ export declare const TabTriggerMapContext: import("react").Context<TriggerMap>;
 /**
  * @hidden
  */
-export declare const TabsDescriptorsContext: import("react").Context<Record<string, import("@react-navigation/core").Descriptor<ExpoTabsNavigatorScreenOptions, Omit<{
+export declare const TabsDescriptorsContext: import("react").Context<Record<string, import("@react-navigation/native").Descriptor<ExpoTabsNavigatorScreenOptions, Omit<{
     dispatch(action: Readonly<{
         type: string;
         payload?: object;
@@ -80,9 +80,9 @@ export declare const TabsDescriptorsContext: import("react").Context<Record<stri
     isFocused(): boolean;
     canGoBack(): boolean;
     getId(): string | undefined;
-    getParent<T = import("@react-navigation/core").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
+    getParent<T = import("@react-navigation/native").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
     getState(): TabNavigationState<any>;
-} & import("@react-navigation/core").PrivateValueStore<[ParamListBase, unknown, unknown]>, "getParent"> & {
+} & import("@react-navigation/native").PrivateValueStore<[ParamListBase, unknown, unknown]>, "getParent"> & {
     getParent<T = NavigationProp<ParamListBase, string, string | undefined, Readonly<{
         key: string;
         index: number;
@@ -96,7 +96,7 @@ export declare const TabsDescriptorsContext: import("react").Context<Record<stri
 } & {
     setParams(params: Partial<object | undefined>): void;
     replaceParams(params: object | undefined): void;
-} & import("@react-navigation/core").EventConsumer<TabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<any>>> & import("@react-navigation/core").PrivateValueStore<[ParamListBase, string, TabNavigationEventMap]> & TabActionHelpers<ParamListBase>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>>;
+} & import("@react-navigation/native").EventConsumer<TabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<any>>> & import("@react-navigation/native").PrivateValueStore<[ParamListBase, string, TabNavigationEventMap]> & TabActionHelpers<ParamListBase>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>>;
 /**
  * @hidden
  */
@@ -159,7 +159,7 @@ export declare const TabsNavigatorContext: import("react").Context<({
     isFocused(): boolean;
     canGoBack(): boolean;
     getId(): string | undefined;
-    getParent<T = import("@react-navigation/core").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
+    getParent<T = import("@react-navigation/native").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
     getState(): Readonly<{
         key: string;
         index: number;
@@ -169,7 +169,7 @@ export declare const TabsNavigatorContext: import("react").Context<({
         type: string;
         stale: false;
     }>;
-} & import("@react-navigation/core").PrivateValueStore<[ParamListBase, unknown, unknown]> & import("@react-navigation/core").EventEmitter<TabNavigationEventMap> & {
+} & import("@react-navigation/native").PrivateValueStore<[ParamListBase, unknown, unknown]> & import("@react-navigation/native").EventEmitter<TabNavigationEventMap> & {
     setParams(params: Partial<object | undefined>): void;
     replaceParams(params: object | undefined): void;
 } & TabActionHelpers<ParamListBase>) | null>;

--- a/packages/one/types/ui/Tabs.shared.d.ts
+++ b/packages/one/types/ui/Tabs.shared.d.ts
@@ -75,7 +75,7 @@ export declare function useTabsWithChildren(options: UseTabsWithChildrenOptions)
         isFocused(): boolean;
         canGoBack(): boolean;
         getId(): string | undefined;
-        getParent<T = import("@react-navigation/core").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
+        getParent<T = import("@react-navigation/native").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
         getState(): Readonly<{
             key: string;
             index: number;
@@ -85,11 +85,11 @@ export declare function useTabsWithChildren(options: UseTabsWithChildrenOptions)
             type: string;
             stale: false;
         }>;
-    } & import("@react-navigation/core").PrivateValueStore<[ParamListBase, unknown, unknown]> & import("@react-navigation/core").EventEmitter<TabNavigationEventMap> & {
+    } & import("@react-navigation/native").PrivateValueStore<[ParamListBase, unknown, unknown]> & import("@react-navigation/native").EventEmitter<TabNavigationEventMap> & {
         setParams(params: Partial<object | undefined>): void;
         replaceParams(params: object | undefined): void;
     } & TabActionHelpers<ParamListBase>;
-    describe: (route: import("@react-navigation/core").RouteProp<ParamListBase>, placeholder: boolean) => import("@react-navigation/core").Descriptor<import("./TabContext").ExpoTabsNavigatorScreenOptions, Omit<{
+    describe: (route: import("@react-navigation/native").RouteProp<ParamListBase>, placeholder: boolean) => import("@react-navigation/native").Descriptor<import("./TabContext").ExpoTabsNavigatorScreenOptions, Omit<{
         dispatch(action: Readonly<{
             type: string;
             payload?: object;
@@ -124,10 +124,10 @@ export declare function useTabsWithChildren(options: UseTabsWithChildrenOptions)
         isFocused(): boolean;
         canGoBack(): boolean;
         getId(): string | undefined;
-        getParent<T = import("@react-navigation/core").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
+        getParent<T = import("@react-navigation/native").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
         getState(): TabNavigationState<any>;
-    } & import("@react-navigation/core").PrivateValueStore<[ParamListBase, unknown, unknown]>, "getParent"> & {
-        getParent<T = import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, Readonly<{
+    } & import("@react-navigation/native").PrivateValueStore<[ParamListBase, unknown, unknown]>, "getParent"> & {
+        getParent<T = import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, Readonly<{
             key: string;
             index: number;
             routeNames: string[];
@@ -140,8 +140,8 @@ export declare function useTabsWithChildren(options: UseTabsWithChildrenOptions)
     } & {
         setParams(params: Partial<object | undefined>): void;
         replaceParams(params: object | undefined): void;
-    } & import("@react-navigation/core").EventConsumer<TabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<any>>> & import("@react-navigation/core").PrivateValueStore<[ParamListBase, string, TabNavigationEventMap]> & TabActionHelpers<ParamListBase>, import("@react-navigation/core").RouteProp<ParamListBase, string>>;
-    descriptors: Record<string, import("@react-navigation/core").Descriptor<import("./TabContext").ExpoTabsNavigatorScreenOptions, Omit<{
+    } & import("@react-navigation/native").EventConsumer<TabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<any>>> & import("@react-navigation/native").PrivateValueStore<[ParamListBase, string, TabNavigationEventMap]> & TabActionHelpers<ParamListBase>, import("@react-navigation/native").RouteProp<ParamListBase, string>>;
+    descriptors: Record<string, import("@react-navigation/native").Descriptor<import("./TabContext").ExpoTabsNavigatorScreenOptions, Omit<{
         dispatch(action: Readonly<{
             type: string;
             payload?: object;
@@ -176,10 +176,10 @@ export declare function useTabsWithChildren(options: UseTabsWithChildrenOptions)
         isFocused(): boolean;
         canGoBack(): boolean;
         getId(): string | undefined;
-        getParent<T = import("@react-navigation/core").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
+        getParent<T = import("@react-navigation/native").NavigationHelpers<ParamListBase, {}> | undefined>(id?: string): T;
         getState(): TabNavigationState<any>;
-    } & import("@react-navigation/core").PrivateValueStore<[ParamListBase, unknown, unknown]>, "getParent"> & {
-        getParent<T = import("@react-navigation/core").NavigationProp<ParamListBase, string, string | undefined, Readonly<{
+    } & import("@react-navigation/native").PrivateValueStore<[ParamListBase, unknown, unknown]>, "getParent"> & {
+        getParent<T = import("@react-navigation/native").NavigationProp<ParamListBase, string, string | undefined, Readonly<{
             key: string;
             index: number;
             routeNames: string[];
@@ -192,7 +192,7 @@ export declare function useTabsWithChildren(options: UseTabsWithChildrenOptions)
     } & {
         setParams(params: Partial<object | undefined>): void;
         replaceParams(params: object | undefined): void;
-    } & import("@react-navigation/core").EventConsumer<TabNavigationEventMap & import("@react-navigation/core").EventMapCore<TabNavigationState<any>>> & import("@react-navigation/core").PrivateValueStore<[ParamListBase, string, TabNavigationEventMap]> & TabActionHelpers<ParamListBase>, import("@react-navigation/core").RouteProp<ParamListBase, string>>>;
+    } & import("@react-navigation/native").EventConsumer<TabNavigationEventMap & import("@react-navigation/native").EventMapCore<TabNavigationState<any>>> & import("@react-navigation/native").PrivateValueStore<[ParamListBase, string, TabNavigationEventMap]> & TabActionHelpers<ParamListBase>, import("@react-navigation/native").RouteProp<ParamListBase, string>>>;
     NavigationContent: ({ children }: {
         children: React.ReactNode;
     }) => React.JSX.Element;

--- a/packages/query-string/package.json
+++ b/packages/query-string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/query-string",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "source": "src/index.ts",
   "types": "./types/index.d.ts",

--- a/packages/react-native-prebuilt/package.json
+++ b/packages/react-native-prebuilt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/react-native-prebuilt",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/resolve/package.json
+++ b/packages/resolve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/resolve",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "source": "src/index.tsx",
   "type": "module",

--- a/packages/rn-proxy/package.json
+++ b/packages/rn-proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vxrn/rn-proxy",
   "sideEffects": false,
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/safe-area/package.json
+++ b/packages/safe-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/safe-area",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "source": "src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",

--- a/packages/test-package/package.json
+++ b/packages/test-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/test-package",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "type": "module",
   "main": "dist/cjs",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vxrn/test",
   "private": true,
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "exports": {
     "./package.json": "./package.json",

--- a/packages/tslib-lite/package.json
+++ b/packages/tslib-lite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vxrn/tslib-lite",
   "sideEffects": false,
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/url-parse/package.json
+++ b/packages/url-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/url-parse",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "type": "module",
   "types": "./src/index.ts",

--- a/packages/use-isomorphic-layout-effect/package.json
+++ b/packages/use-isomorphic-layout-effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/use-isomorphic-layout-effect",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "source": "src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/utils",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "type": "module",
   "types": "./types/index.d.ts",

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vendor",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/vite-flow/package.json
+++ b/packages/vite-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-flow",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/vite-native-client/package.json
+++ b/packages/vite-native-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-native-client",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": [
     "*"
   ],

--- a/packages/vite-native-hmr/package.json
+++ b/packages/vite-native-hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-native-hmr",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/vite-plugin-metro/package.json
+++ b/packages/vite-plugin-metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-plugin-metro",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "type": "module",
   "main": "dist/cjs",

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vxrn",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "sideEffects": false,
   "type": "module",
   "exports": {

--- a/repro/package.json
+++ b/repro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repro",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -18,7 +18,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.2",
-    "one": "1.24.9",
+    "one": "1.25.0",
     "react-native-reanimated": "~4.5.1",
     "react-native-worklets": "~0.10.1",
     "react-native-safe-area-context": "~5.7.0",

--- a/tests/hmr/package.json
+++ b/tests/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-hmr",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/native-features/package.json
+++ b/tests/native-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-native-features",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/tests/sandbox/package.json
+++ b/tests/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-sandbox",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-app-cases/package.json
+++ b/tests/test-app-cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-app-cases",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-build-unified/package.json
+++ b/tests/test-build-unified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-build-unified",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-bundled-dev/package.json
+++ b/tests/test-bundled-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-bundled-dev",
-  "version": "1.24.6",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-cache-headers/package.json
+++ b/tests/test-cache-headers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-cache-headers",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-cloudflare/package.json
+++ b/tests/test-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-cloudflare",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-css-merged/package.json
+++ b/tests/test-css-merged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-css-merged",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-css-preload/package.json
+++ b/tests/test-css-preload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-css-preload",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-deploy-flash/package.json
+++ b/tests/test-deploy-flash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-deploy-flash",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-env/package.json
+++ b/tests/test-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-env",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-headless-web/package.json
+++ b/tests/test-headless-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-headless-web",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-hydration-id/package.json
+++ b/tests/test-hydration-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-hydration-id",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-id-remount/package.json
+++ b/tests/test-id-remount/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-id-remount",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-layout-flicker/package.json
+++ b/tests/test-layout-flicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-layout-flicker",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-layout-render-modes/package.json
+++ b/tests/test-layout-render-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-layout-render-modes",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-loaders/package.json
+++ b/tests/test-loaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-loaders",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-native-tree-shaking/package.json
+++ b/tests/test-native-tree-shaking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-native-tree-shaking",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-not-found/package.json
+++ b/tests/test-not-found/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-not-found",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-params-stability/package.json
+++ b/tests/test-params-stability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-params-stability",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-redirect-flash/package.json
+++ b/tests/test-redirect-flash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-redirect-flash",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-route-file-watching/package.json
+++ b/tests/test-route-file-watching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-route-file-watching",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-routing-flicker/package.json
+++ b/tests/test-routing-flicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-routing-flicker",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-script-loading/package.json
+++ b/tests/test-script-loading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-script-loading",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-skew-protection/package.json
+++ b/tests/test-skew-protection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-skew-protection",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-sootsim-back/package.json
+++ b/tests/test-sootsim-back/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-sootsim-back",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-spa-shell-routing/package.json
+++ b/tests/test-spa-shell-routing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-spa-shell-routing",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-use-dom/package.json
+++ b/tests/test-use-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-use-dom",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -21,5 +21,5 @@
     "typescript": "^5.7.3",
     "vitest": "^4.1.0"
   },
-  "version": "1.24.9"
+  "version": "1.25.0"
 }

--- a/tests/test-warm-routes/package.json
+++ b/tests/test-warm-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-warm-routes",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-weird-deps/package.json
+++ b/tests/test-weird-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-weird-deps",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test/package.json
+++ b/tests/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-test",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Minor release: version bump to 1.25.0, plus the release-workflow fix needed to actually publish it.

## Why this also touches the release workflow

Every `Release` workflow run in this repo's history has failed — 7 for 7. They all die at the same step:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through the merge queue
remote: - Changes must be made through a pull request.
```

The `patch`/`minor`/`major` inputs bump the version inside the workflow and then push that commit straight to `main`, which `main` does not accept. So those inputs have never published anything, and stable releases have been happening by pushing version commits to `main` by hand.

This adds a `republish` input that publishes the version `main` already carries, bumping nothing and pushing nothing to `main`. The version bump lands as an ordinary PR through the merge queue (this one), then `republish` publishes it, tags it, and cuts the GitHub release. It keeps every existing gate: current `main`, green CI on that exact SHA, npm trusted publishing over OIDC.

`patch`/`minor`/`major` are left in place but documented as non-functional, so the failure stays visible instead of looking like a missing feature.

`docs/releasing.md` writes the whole flow down.

## Release contents

Everything from #757:

- rust hook filters across One/vxrn plugins — 234,018 → 25,612 plugin hook calls per build
- `platform-specific-resolve` — 12,624 → 3,436 calls
- react compiler through oxc's rust port — 47.57ms → 1.74ms per file, identical memoization
- vite 8.1.0 → 8.2.2, rolldown 1.1.2 → 1.2.4
- fixes `experimentalBundledDev`, which the 8.2 bump broke, plus `tests/test-bundled-dev` covering it