### PR TITLE
v1.25.1

### DIFF
--- a/apps/one-tray/package.json
+++ b/apps/one-tray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-tray",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "scripts": {
     "build": "[ \"$(uname)\" = \"Darwin\" ] && make debug || true",

--- a/apps/onestack.dev/package.json
+++ b/apps/onestack.dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "site",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
     },
     "apps/one-tray": {
       "name": "one-tray",
-      "version": "1.25.0",
+      "version": "1.25.1",
     },
     "apps/onestack.dev": {
       "name": "site",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@docsearch/react": "^3.9.0",
         "@react-navigation/native": "~7.3.16",
@@ -75,7 +75,7 @@
     },
     "examples/bare": {
       "name": "example-bare",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "expo-constants": "~57.0.9",
         "react": "19.2.3",
@@ -101,7 +101,7 @@
     },
     "examples/expo-blank": {
       "name": "expo-blank-app",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "expo": "~57.0.11",
         "expo-status-bar": "~57.0.1",
@@ -113,7 +113,7 @@
     },
     "examples/expo-blank-with-vite-metro": {
       "name": "expo-blank-with-vite-metro",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "expo": "~57.0.11",
         "one": "workspace:*",
@@ -130,7 +130,7 @@
     },
     "examples/one-basic": {
       "name": "example-basic",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -152,7 +152,7 @@
     },
     "examples/testflight": {
       "name": "example-testflight",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@bottom-tabs/react-navigation": "^0.9.1",
         "@dotenvx/dotenvx": "^1.12.1",
@@ -191,7 +191,7 @@
     },
     "packages/color-scheme": {
       "name": "@vxrn/color-scheme",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@vxrn/use-isomorphic-layout-effect": "workspace:*",
       },
@@ -208,7 +208,7 @@
     },
     "packages/compiler": {
       "name": "@vxrn/compiler",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/plugin-transform-destructuring": "^7.28.5",
@@ -240,7 +240,7 @@
     },
     "packages/create-vxrn": {
       "name": "create-vxrn",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "bin": {
         "create-vxrn": "run.js",
       },
@@ -265,7 +265,7 @@
     },
     "packages/debug": {
       "name": "@vxrn/debug",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "debug": "^4.3.7",
       },
@@ -276,7 +276,7 @@
     },
     "packages/emitter": {
       "name": "@vxrn/emitter",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "devDependencies": {
         "@tamagui/build": "2.6.2",
         "react": "19.2.3",
@@ -287,7 +287,7 @@
     },
     "packages/lllink": {
       "name": "lllink",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "bin": {
         "lllink": "dist/index.mjs",
       },
@@ -298,7 +298,7 @@
     },
     "packages/mdx": {
       "name": "@vxrn/mdx",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "compare-versions": "^4.1.3",
         "esbuild-wasm": "^0.25.11",
@@ -330,7 +330,7 @@
     },
     "packages/mdx-rust": {
       "name": "@vxrn/mdx-rust",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "compare-versions": "^4.1.3",
         "fast-glob": "^3.3.3",
@@ -353,7 +353,7 @@
     },
     "packages/native": {
       "name": "@vxrn/native",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@vxrn/use-isomorphic-layout-effect": "workspace:*",
       },
@@ -368,7 +368,7 @@
       "peerDependencies": {
         "@react-navigation/native": "~7.3.16",
         "@react-navigation/native-stack": "~7.18.8",
-        "one": "1.25.0",
+        "one": "1.25.1",
         "react": "*",
         "react-native": "*",
         "react-native-safe-area-context": ">=5.4.0",
@@ -380,7 +380,7 @@
     },
     "packages/one": {
       "name": "one",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "bin": {
         "one": "run.mjs",
       },
@@ -466,7 +466,7 @@
         "@react-navigation/native": "~7.3.16",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
-        "react-native": "0.86.2",
+        "react-native": "^0.86.0",
         "react-native-bottom-tabs": ">=1.0.0",
         "react-native-gesture-handler": ">=2.0.0",
         "react-native-reanimated": ">=4.0.0",
@@ -488,7 +488,7 @@
     },
     "packages/one-vscode": {
       "name": "one-vscode",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "ws": "^8.21.0",
       },
@@ -501,7 +501,7 @@
     },
     "packages/query-string": {
       "name": "@vxrn/query-string",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "query-string": "^9.1.0",
       },
@@ -511,7 +511,7 @@
     },
     "packages/react-native-prebuilt": {
       "name": "@vxrn/react-native-prebuilt",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@vxrn/utils": "workspace:*",
         "@vxrn/vite-flow": "workspace:*",
@@ -535,7 +535,7 @@
     },
     "packages/resolve": {
       "name": "@vxrn/resolve",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "devDependencies": {
         "@tamagui/build": "2.6.2",
         "vitest": "^4.1.0",
@@ -543,11 +543,11 @@
     },
     "packages/rn-proxy": {
       "name": "@vxrn/rn-proxy",
-      "version": "1.25.0",
+      "version": "1.25.1",
     },
     "packages/safe-area": {
       "name": "@vxrn/safe-area",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "devDependencies": {
         "@biomejs/biome": "2.3.3",
         "@tamagui/build": "2.6.2",
@@ -555,7 +555,7 @@
     },
     "packages/test": {
       "name": "@vxrn/test",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "react": "19.2.3",
         "zx": "^8.5.5",
@@ -569,15 +569,15 @@
     },
     "packages/test-package": {
       "name": "@vxrn/test-package",
-      "version": "1.25.0",
+      "version": "1.25.1",
     },
     "packages/tslib-lite": {
       "name": "@vxrn/tslib-lite",
-      "version": "1.25.0",
+      "version": "1.25.1",
     },
     "packages/url-parse": {
       "name": "@vxrn/url-parse",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "url-parse": "^1.5.10",
       },
@@ -587,7 +587,7 @@
     },
     "packages/use-isomorphic-layout-effect": {
       "name": "@vxrn/use-isomorphic-layout-effect",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "devDependencies": {
         "@tamagui/build": "2.6.2",
         "react": "19.2.3",
@@ -598,7 +598,7 @@
     },
     "packages/utils": {
       "name": "@vxrn/utils",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@vxrn/debug": "workspace:*",
         "@vxrn/resolve": "workspace:*",
@@ -611,11 +611,11 @@
     },
     "packages/vendor": {
       "name": "@vxrn/vendor",
-      "version": "1.25.0",
+      "version": "1.25.1",
     },
     "packages/vite-flow": {
       "name": "@vxrn/vite-flow",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -630,7 +630,7 @@
     },
     "packages/vite-native-client": {
       "name": "@vxrn/vite-native-client",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "devDependencies": {
         "@biomejs/biome": "2.3.3",
         "@tamagui/build": "2.6.2",
@@ -642,7 +642,7 @@
     },
     "packages/vite-native-hmr": {
       "name": "@vxrn/vite-native-hmr",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@types/webpack-env": "^1.18.8",
         "pretty-format": "^28.1.0",
@@ -657,7 +657,7 @@
     },
     "packages/vite-plugin-metro": {
       "name": "@vxrn/vite-plugin-metro",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@babel/core": "^7.28.5",
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -694,7 +694,7 @@
     },
     "packages/vxrn": {
       "name": "vxrn",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "bin": {
         "vxrn": "run.mjs",
       },
@@ -748,7 +748,7 @@
     },
     "tests/hmr": {
       "name": "test-hmr",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -768,7 +768,7 @@
     },
     "tests/native-features": {
       "name": "test-native-features",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@vxrn/native": "workspace:*",
@@ -817,7 +817,7 @@
     },
     "tests/sandbox": {
       "name": "test-sandbox",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -843,7 +843,7 @@
     },
     "tests/test": {
       "name": "test-test",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -884,7 +884,7 @@
     },
     "tests/test-app-cases": {
       "name": "test-app-cases",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -907,7 +907,7 @@
     },
     "tests/test-build-unified": {
       "name": "test-build-unified",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "axios": "^1.18.0",
         "date-fns": "^3.6.0",
@@ -925,7 +925,7 @@
     },
     "tests/test-bundled-dev": {
       "name": "test-bundled-dev",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -940,7 +940,7 @@
     },
     "tests/test-cache-headers": {
       "name": "test-cache-headers",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -955,7 +955,7 @@
     },
     "tests/test-cloudflare": {
       "name": "test-cloudflare",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
       },
@@ -970,7 +970,7 @@
     },
     "tests/test-css-merged": {
       "name": "test-css-merged",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -985,7 +985,7 @@
     },
     "tests/test-css-preload": {
       "name": "test-css-preload",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1000,7 +1000,7 @@
     },
     "tests/test-deploy-flash": {
       "name": "test-deploy-flash",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1020,7 +1020,7 @@
     },
     "tests/test-env": {
       "name": "test-env",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1036,7 +1036,7 @@
     },
     "tests/test-headless-web": {
       "name": "test-headless-web",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1051,7 +1051,7 @@
     },
     "tests/test-hydration-id": {
       "name": "test-hydration-id",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1070,7 +1070,7 @@
     },
     "tests/test-id-remount": {
       "name": "test-id-remount",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1087,7 +1087,7 @@
     },
     "tests/test-layout-flicker": {
       "name": "test-layout-flicker",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1107,7 +1107,7 @@
     },
     "tests/test-layout-render-modes": {
       "name": "test-layout-render-modes",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1123,7 +1123,7 @@
     },
     "tests/test-loaders": {
       "name": "test-loaders",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -1150,7 +1150,7 @@
     },
     "tests/test-native-tree-shaking": {
       "name": "test-native-tree-shaking",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@vxrn/mdx": "workspace:*",
@@ -1172,7 +1172,7 @@
     },
     "tests/test-not-found": {
       "name": "test-not-found",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1192,7 +1192,7 @@
     },
     "tests/test-params-stability": {
       "name": "test-params-stability",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1212,7 +1212,7 @@
     },
     "tests/test-redirect-flash": {
       "name": "test-redirect-flash",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1232,7 +1232,7 @@
     },
     "tests/test-route-file-watching": {
       "name": "test-route-file-watching",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1252,7 +1252,7 @@
     },
     "tests/test-routing-flicker": {
       "name": "test-routing-flicker",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "@tamagui/config": "2.6.2",
@@ -1278,7 +1278,7 @@
     },
     "tests/test-script-loading": {
       "name": "test-script-loading",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1293,7 +1293,7 @@
     },
     "tests/test-skew-protection": {
       "name": "test-skew-protection",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "one": "workspace:*",
@@ -1313,7 +1313,7 @@
     },
     "tests/test-sootsim-back": {
       "name": "test-sootsim-back",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1333,7 +1333,7 @@
     },
     "tests/test-spa-shell-routing": {
       "name": "test-spa-shell-routing",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1349,7 +1349,7 @@
     },
     "tests/test-use-dom": {
       "name": "test-use-dom",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@react-navigation/native": "~7.3.16",
         "expo": "~57.0.11",
@@ -1368,7 +1368,7 @@
     },
     "tests/test-vercel": {
       "name": "test-vercel",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1384,7 +1384,7 @@
     },
     "tests/test-warm-routes": {
       "name": "test-warm-routes",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "one": "workspace:*",
         "react": "19.2.3",
@@ -1400,7 +1400,7 @@
     },
     "tests/test-weird-deps": {
       "name": "test-weird-deps",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "devDependencies": {
         "vite": "^8.2.2",
       },

--- a/examples/bare/package.json
+++ b/examples/bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-bare",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/examples/expo-blank-with-vite-metro/package.json
+++ b/examples/expo-blank-with-vite-metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-blank-with-vite-metro",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/examples/expo-blank/package.json
+++ b/examples/expo-blank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-blank-app",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "main": "expo/AppEntry.js",
   "scripts": {

--- a/examples/one-basic/package.json
+++ b/examples/one-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-basic",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/testflight/package.json
+++ b/examples/testflight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-testflight",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/color-scheme/package.json
+++ b/packages/color-scheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/color-scheme",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "exports": {
     "./package.json": "./package.json",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/compiler",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/create-vxrn/package.json
+++ b/packages/create-vxrn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-vxrn",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "bin": {
     "create-vxrn": "run.js"
   },

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/debug",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "source": "src/index.ts",
   "type": "module",

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/emitter",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "source": "src/index.ts",
   "types": "./src/index.ts",

--- a/packages/lllink/package.json
+++ b/packages/lllink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lllink",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "module": "dist",
   "exports": {

--- a/packages/mdx-rust/package.json
+++ b/packages/mdx-rust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/mdx-rust",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "sideEffects": false,
   "module": "dist",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/mdx",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "commonjs",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/native",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "description": "Native navigation features for One - zoom transitions, toolbar, color API, split view",
   "license": "MIT",
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "@react-navigation/native": "~7.3.16",
     "@react-navigation/native-stack": "~7.18.8",
-    "one": "1.25.0",
+    "one": "1.25.1",
     "react": "*",
     "react-native": "*",
     "react-native-screens": ">=4.0.0",

--- a/packages/one-vscode/package.json
+++ b/packages/one-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "one-vscode",
   "displayName": "One Framework",
   "description": "VSCode integration for One framework - live element highlighting",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "publisher": "one",
   "engines": {

--- a/packages/one/package.json
+++ b/packages/one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "license": "BSD-3-Clause",
   "sideEffects": [
     "setup.mjs",
@@ -235,7 +235,7 @@
     "@react-navigation/native": "~7.3.16",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "react-native": "0.86.2",
+    "react-native": "^0.86.0",
     "react-native-bottom-tabs": ">=1.0.0",
     "react-native-gesture-handler": ">=2.0.0",
     "react-native-reanimated": ">=4.0.0",

--- a/packages/query-string/package.json
+++ b/packages/query-string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/query-string",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "source": "src/index.ts",
   "types": "./types/index.d.ts",

--- a/packages/react-native-prebuilt/package.json
+++ b/packages/react-native-prebuilt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/react-native-prebuilt",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/resolve/package.json
+++ b/packages/resolve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/resolve",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "source": "src/index.tsx",
   "type": "module",

--- a/packages/rn-proxy/package.json
+++ b/packages/rn-proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vxrn/rn-proxy",
   "sideEffects": false,
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/safe-area/package.json
+++ b/packages/safe-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/safe-area",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "source": "src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",

--- a/packages/test-package/package.json
+++ b/packages/test-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/test-package",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "type": "module",
   "main": "dist/cjs",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vxrn/test",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "exports": {
     "./package.json": "./package.json",

--- a/packages/tslib-lite/package.json
+++ b/packages/tslib-lite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vxrn/tslib-lite",
   "sideEffects": false,
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/url-parse/package.json
+++ b/packages/url-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/url-parse",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "type": "module",
   "types": "./src/index.ts",

--- a/packages/use-isomorphic-layout-effect/package.json
+++ b/packages/use-isomorphic-layout-effect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/use-isomorphic-layout-effect",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "source": "src/index.ts",
   "types": "./types/index.d.ts",
   "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/utils",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "type": "module",
   "types": "./types/index.d.ts",

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vendor",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/vite-flow/package.json
+++ b/packages/vite-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-flow",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/vite-native-client/package.json
+++ b/packages/vite-native-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-native-client",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": [
     "*"
   ],

--- a/packages/vite-native-hmr/package.json
+++ b/packages/vite-native-hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-native-hmr",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/vite-plugin-metro/package.json
+++ b/packages/vite-plugin-metro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vxrn/vite-plugin-metro",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "type": "module",
   "main": "dist/cjs",

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vxrn",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "sideEffects": false,
   "type": "module",
   "exports": {

--- a/repro/package.json
+++ b/repro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repro",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -18,7 +18,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.2",
-    "one": "1.25.0",
+    "one": "1.25.1",
     "react-native-reanimated": "~4.5.1",
     "react-native-worklets": "~0.10.1",
     "react-native-safe-area-context": "~5.7.0",

--- a/tests/hmr/package.json
+++ b/tests/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-hmr",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/native-features/package.json
+++ b/tests/native-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-native-features",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/tests/sandbox/package.json
+++ b/tests/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-sandbox",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-app-cases/package.json
+++ b/tests/test-app-cases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-app-cases",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-build-unified/package.json
+++ b/tests/test-build-unified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-build-unified",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-bundled-dev/package.json
+++ b/tests/test-bundled-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-bundled-dev",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-cache-headers/package.json
+++ b/tests/test-cache-headers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-cache-headers",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-cloudflare/package.json
+++ b/tests/test-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-cloudflare",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-css-merged/package.json
+++ b/tests/test-css-merged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-css-merged",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-css-preload/package.json
+++ b/tests/test-css-preload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-css-preload",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-deploy-flash/package.json
+++ b/tests/test-deploy-flash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-deploy-flash",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-env/package.json
+++ b/tests/test-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-env",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-headless-web/package.json
+++ b/tests/test-headless-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-headless-web",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-hydration-id/package.json
+++ b/tests/test-hydration-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-hydration-id",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-id-remount/package.json
+++ b/tests/test-id-remount/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-id-remount",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-layout-flicker/package.json
+++ b/tests/test-layout-flicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-layout-flicker",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-layout-render-modes/package.json
+++ b/tests/test-layout-render-modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-layout-render-modes",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-loaders/package.json
+++ b/tests/test-loaders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-loaders",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-native-tree-shaking/package.json
+++ b/tests/test-native-tree-shaking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-native-tree-shaking",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-not-found/package.json
+++ b/tests/test-not-found/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-not-found",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-params-stability/package.json
+++ b/tests/test-params-stability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-params-stability",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-redirect-flash/package.json
+++ b/tests/test-redirect-flash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-redirect-flash",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-route-file-watching/package.json
+++ b/tests/test-route-file-watching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-route-file-watching",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-routing-flicker/package.json
+++ b/tests/test-routing-flicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-routing-flicker",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-script-loading/package.json
+++ b/tests/test-script-loading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-script-loading",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-skew-protection/package.json
+++ b/tests/test-skew-protection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-skew-protection",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-sootsim-back/package.json
+++ b/tests/test-sootsim-back/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-sootsim-back",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-spa-shell-routing/package.json
+++ b/tests/test-spa-shell-routing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-spa-shell-routing",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-use-dom/package.json
+++ b/tests/test-use-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-use-dom",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-vercel/package.json
+++ b/tests/test-vercel/package.json
@@ -21,5 +21,5 @@
     "typescript": "^5.7.3",
     "vitest": "^4.1.0"
   },
-  "version": "1.25.0"
+  "version": "1.25.1"
 }

--- a/tests/test-warm-routes/package.json
+++ b/tests/test-warm-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-warm-routes",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test-weird-deps/package.json
+++ b/tests/test-weird-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-weird-deps",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/test/package.json
+++ b/tests/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-test",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch release carrying the `react-native` peer fix.

## The peer was pinned to an exact patch

```diff
-    "react-native": "0.86.2",
+    "react-native": "^0.86.0",
```

It was the only exact-pinned peer One had — every other peer is already a range. Pinning an exact patch means any app on `0.86.0` or `0.86.5` gets a peer warning for no reason.

No duplicate-install risk from loosening it: `react-native` is an **optional** peer, so One never installs it, and the range only affects whether the package manager warns. (The dependency that *could* duplicate is `vite`, and that's a real dependency already on a caret.)

Verified `^0.86.0` accepts 0.86.0 / 0.86.2 / 0.86.9 and rejects 0.85.4 / 0.87.0, that nothing in the source asserts the exact version, and that `packages/one` typechecks with 573 tests passing.

## Why 1.25.1

v1.25.0's publish partially completed and then died:

```
npm error 401 Unauthorized - PUT https://registry.npmjs.org/@vxrn%2femitter
Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid
```

`@vxrn/use-isomorphic-layout-effect@1.25.0` and `create-vxrn@1.25.0` published; the other 24 packages, `one` and `vxrn` included, did not.

That partial state is not itself a problem — `publishPackagesWithAuthProbe` checks each version with `npm view`, skips what is already published, and builds a temp workspace from only the pending set, so a re-run would have handled it. 1.25.1 exists because the peer fix above needs a version to ship on and `main` already carries the `v1.25.0` commit.

The partial publish is also inert for users: `one@1.24.9` depends on `@vxrn/use-isomorphic-layout-effect` at an exact `1.24.9`, not a range, so nobody resolves the orphaned 1.25.0.

## Still blocked on npm

Trusted publishing (OIDC) is configured **per package on npmjs.com**, and only those two packages have `onejs/one` → `release.yml` registered as a trusted publisher. Nothing in this repo can change that. Once the remaining packages are configured, `release=republish` publishes cleanly.