### PR TITLE
fix(vxrn): warn when a dep patch matches nothing

### DIFF
--- a/packages/vxrn/src/utils/patches.test.ts
+++ b/packages/vxrn/src/utils/patches.test.ts
@@ -273,4 +273,67 @@ describe('applyDependencyPatches', () => {
     )
     expect(content).toContain('// marker')
   })
+
+  it('warns when a patch matches nothing, and stays quiet when it applies', async () => {
+    // a patch is a literal string replace against upstream source. when
+    // upstream moves the code, the replace silently stops doing anything and
+    // whatever it was guarding is quietly unprotected. that is how
+    // react-native's RCTTurboModule.mm SIGSEGV patch went dead on RN 0.86.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const stale: DepPatch[] = [
+      {
+        module: 'test-pkg',
+        patchFiles: {
+          'index.js': (contents) => (contents || '').replace('CODE THAT MOVED', 'fixed'),
+        },
+      },
+    ]
+
+    await setupAndPatch({
+      patches: stale,
+      setupFs: async (nm) => {
+        const pkgDir = join(nm, 'test-pkg')
+        await FSExtra.ensureDir(pkgDir)
+        await FSExtra.writeFile(
+          join(pkgDir, 'package.json'),
+          makePkg('test-pkg', '1.0.0')
+        )
+        await FSExtra.writeFile(join(pkgDir, 'index.js'), 'module.exports = {}')
+      },
+    })
+
+    expect(warn.mock.calls.flat().join(' ')).toContain('stale')
+    warn.mockClear()
+
+    // a patch that does apply must not warn, or the warning is noise
+    const applies: DepPatch[] = [
+      {
+        module: 'test-pkg',
+        patchFiles: {
+          'index.js': (contents) =>
+            (contents || '').replace(
+              'module.exports',
+              'globalThis.x = 1; module.exports'
+            ),
+        },
+      },
+    ]
+
+    await setupAndPatch({
+      patches: applies,
+      setupFs: async (nm) => {
+        const pkgDir = join(nm, 'test-pkg')
+        await FSExtra.ensureDir(pkgDir)
+        await FSExtra.writeFile(
+          join(pkgDir, 'package.json'),
+          makePkg('test-pkg', '1.0.0')
+        )
+        await FSExtra.writeFile(join(pkgDir, 'index.js'), 'module.exports = {}')
+      },
+    })
+
+    expect(warn.mock.calls.flat().join(' ')).not.toContain('stale')
+    warn.mockRestore()
+  })
 })

--- a/packages/vxrn/src/utils/patches.ts
+++ b/packages/vxrn/src/utils/patches.ts
@@ -300,6 +300,23 @@ export async function applyDependencyPatches(
                     const out = await patchDef(sourceContent)
                     if (typeof out === 'string' && out !== sourceContent) {
                       patchedContent = out
+                    } else if (typeof out === 'string') {
+                      // the patch ran and changed nothing. these patches are
+                      // literal string replaces against upstream source, so
+                      // that means the code it targets moved or was rewritten
+                      // and the patch is now a no-op. silence here is
+                      // dangerous: react-native's RCTTurboModule.mm patch
+                      // guards an ios SIGSEGV, and it stopped matching on RN
+                      // 0.86 without a word, which only turned up because
+                      // someone read the patch by hand during an upgrade.
+                      //
+                      // a patch that doesn't apply says so by returning
+                      // undefined (`if (contents.includes(x)) return`), so a
+                      // returned string that equals its input is always a stale
+                      // patch, never an intentional skip.
+                      console.warn(
+                        `[vxrn] patch for ${patch.module} matched nothing in ${relativePath} — it is stale and is no longer protecting anything`
+                      )
                     }
                   }
 


### PR DESCRIPTION
## The bug

vxrn's dep patches are literal string replaces against upstream source:

```ts
const out = await patchDef(sourceContent)
if (typeof out === 'string' && out !== sourceContent) {
  patchedContent = out
}
```

When upstream moves the code, the replace matches nothing, returns its input unchanged, and this branch quietly does nothing. Whatever the patch was guarding is now unprotected, with no signal anywhere.

## How it turned up

During the takeout Expo 57 / RN 0.86 upgrade. `react-native`'s `RCTTurboModule.mm` patch guards an iOS SIGSEGV when a void TurboModule method throws an `NSException`. Its version gate (`>=0.81.0`) still matches on RN 0.86, so it looks live — but the string it replaces no longer exists in 0.86, so it had silently become a no-op.

Nothing surfaced that. It was found by reading the patch by hand. A web build never exercises it, so CI is green either way, and the failure it prevents is a native crash.

## Why an unchanged return is always stale

Patches that legitimately don't apply already say so by returning `undefined`:

```ts
if (contents.includes('createComponentForStaticNavigation')) return
```

So a returned *string* equal to its input can only mean the replace found nothing. That makes this warnable without false positives. I checked every patch function in `builtInDepPatches.ts` — none returns its input deliberately.

Kept as a warning rather than a throw: a stale patch shouldn't break someone's build, it should be visible.

## Test

Added a test asserting it warns on a stale patch and stays silent on one that applies. Verified it fails without the fix (removing the warning branch makes it red), so it actually catches the regression rather than just passing.