### PR TITLE
fix(release): authenticate npm publishes with a token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,10 +203,24 @@ jobs:
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $auth"
           git push origin HEAD:main
 
+      # trusted publishing is configured per package on npmjs.com, and only
+      # create-vxrn and @vxrn/use-isomorphic-layout-effect have it. the other 23
+      # packages have no trusted publisher, so npm falls through to interactive
+      # web auth and dies with `E401 ... Failed to generate Web Auth URLs`. that
+      # is what killed 1.25.0 after two packages had already published. the
+      # setup-node step above already wrote an .npmrc pointing at
+      # NODE_AUTH_TOKEN, so a granular token covering the @vxrn scope plus one,
+      # vxrn, create-vxrn and lllink is all npm needs to authenticate the rest.
       - name: Publish prepared version
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
+          [[ -n "${NODE_AUTH_TOKEN:-}" ]] || {
+            echo "NPM_TOKEN secret is not set; npm cannot authenticate" >&2
+            exit 1
+          }
           version=$(node -p "require('./packages/one/package.json').version")
           flags=(--republish --ci --dirty --skip-finish)
           if [[ "$version" =~ -[0-9]{10,}$ ]]; then

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,8 +23,33 @@ Two steps, because `main` is protected by a merge queue.
    ```
 
    It checks that `main` is current and that CI is green on that exact SHA,
-   publishes the version `main` already carries via npm trusted publishing
-   (OIDC, no token), pushes the `vX.Y.Z` tag, and creates the GitHub release.
+   publishes the version `main` already carries, pushes the `vX.Y.Z` tag, and
+   creates the GitHub release.
+
+## npm authentication
+
+Publishing needs an `NPM_TOKEN` repository secret: a granular access token with
+read and write on the `@vxrn` scope plus `one`, `vxrn`, `create-vxrn` and
+`lllink`.
+
+npm trusted publishing (OIDC, no token) would be better, but it is configured
+per package on npmjs.com and only two of this workspace's 25 packages have it.
+The 1.25.0 release published `create-vxrn` and
+`@vxrn/use-isomorphic-layout-effect`, then died on the third package:
+
+```
+npm error code E401
+npm error 401 Unauthorized - PUT https://registry.npmjs.org/@vxrn%2femitter
+  - Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid
+```
+
+With no trusted publisher and no token, npm falls through to interactive web
+auth, which cannot work in CI. Adding trusted publishers for the remaining 23
+packages would also fix it and would let the token go away.
+
+Publishing is idempotent per package: `scripts/release.ts` checks `npm view`
+for each one and skips those already published at the current version, so a
+partially-published version is safe to re-dispatch.
 
 ## Why not `release=minor` directly
 


### PR DESCRIPTION
v1.25.0 published two packages and then died. Same OIDC token, same run:

```
npm error code E401
npm error 401 Unauthorized - PUT https://registry.npmjs.org/@vxrn%2femitter
  - Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid
```

`create-vxrn` and `@vxrn/use-isomorphic-layout-effect` are on npm at 1.25.0. The other 23 packages are still on 1.24.9.

Trusted publishing is configured **per package** on npmjs.com, and only those two have it. For a package with no trusted publisher and no token, npm falls through to interactive web auth, which cannot work on a runner. Two packages succeeding and the third failing in one run is what makes this per-package config rather than anything wrong with the workflow.

This wires `NODE_AUTH_TOKEN` from an `NPM_TOKEN` secret into the publish step. `setup-node` already writes an `.npmrc` pointing at that variable, so nothing else changes. The step fails fast with a clear message if the secret is missing, rather than 25 minutes later inside npm.

**Requires an `NPM_TOKEN` repository secret** — a granular access token with read+write on the `@vxrn` scope plus `one`, `vxrn`, `create-vxrn`, `lllink`.

Adding trusted publishers for the remaining 23 packages would fix this too, and is the better end state. This is the version that unblocks 1.25.1 without 23 trips through the npm web UI.

Re-dispatching is safe: `scripts/release.ts` checks `npm view` per package and skips ones already published at the current version.

## Validation

- `actionlint .github/workflows/release.yml`
- yaml parse check

Not exercised end to end, because that means a real publish.