### PR TITLE
fix(router): abandon a navigation whose navigator went away

### DIFF
--- a/packages/one/src/router/linkToOrphaned.test.ts
+++ b/packages/one/src/router/linkToOrphaned.test.ts
@@ -1,0 +1,96 @@
+import { createNavigationContainerRef } from '@react-navigation/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { One } from '../vite/types'
+import { initialize, replace } from './router'
+
+function createMockContext(files: Record<string, any>): One.RouteContext {
+  const keys = Object.keys(files)
+  const ctx = function (id: string) {
+    return files[id] || {}
+  } as One.RouteContext
+  ctx.keys = () => keys
+  ctx.resolve = (id: string) => id
+  ctx.id = 'link-to-orphaned'
+  return ctx
+}
+
+// the surface linkTo reaches for on a mounted navigator.
+function mountedNavigator() {
+  return {
+    isReady: () => true,
+    getRootState: () => ({
+      key: 'stack-1',
+      type: 'stack',
+      index: 0,
+      routeNames: ['index', 'other'],
+      routes: [{ key: 'index-1', name: 'index' }],
+      stale: false,
+    }),
+    getCurrentRoute: () => ({ key: 'index-1', name: 'index' }),
+    resetRoot: vi.fn(),
+    dispatch: vi.fn(),
+    addListener: () => () => {},
+    removeListener: () => {},
+  }
+}
+
+const NOT_INITIALIZED = "hasn't been initialized yet"
+
+function notInitializedCalls(spy: ReturnType<typeof vi.spyOn>) {
+  return spy.mock.calls.filter((call) =>
+    call.some((arg) => typeof arg === 'string' && arg.includes(NOT_INITIALIZED))
+  )
+}
+
+describe('linkTo against a tree that went away', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let ref: ReturnType<typeof createNavigationContainerRef>
+
+  beforeEach(() => {
+    // the preview shells set this; it keeps the route preload off the network so
+    // the only thing under test is what linkTo does after its await.
+    globalThis['__vxrnHeadless'] = true
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ref = createNavigationContainerRef()
+    ref.current = mountedNavigator() as any
+    initialize(
+      createMockContext({
+        './_layout.tsx': { default: () => null },
+        './index.tsx': { default: () => null },
+        './other.tsx': { default: () => null },
+      }),
+      ref as any,
+      new URL('http://one.test/')
+    )
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    delete globalThis['__vxrnHeadless']
+  })
+
+  // an auth gate that swaps Slot for Redirect, and a Contrast preview cold mount
+  // (React root unmounted, bundle re-evaluated in the same realm), both detach the
+  // container ref while linkTo is parked on its route preload. every method on a
+  // detached ref logs the react-navigation not-initialized error.
+  it('abandons a navigation whose navigator detached during the preload', async () => {
+    const navigation = replace('/other')
+    // linkTo is suspended on `await preloadRoute(...)`, so this lands before it
+    // resumes. no timing involved.
+    ref.current = null
+
+    await navigation
+
+    expect(notInitializedCalls(errorSpy)).toEqual([])
+  })
+
+  // the post-dispatch poll runs on a timer, so it outlives the tree outright.
+  it('stops the post-dispatch route poll once the navigator detaches', async () => {
+    await replace('/other')
+    ref.current = null
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect(notInitializedCalls(errorSpy)).toEqual([])
+  })
+})

--- a/packages/one/src/router/router.ts
+++ b/packages/one/src/router/router.ts
@@ -1333,6 +1333,20 @@ export async function linkTo(
   currentMatches = newMatches
   setClientMatches(newMatches)
 
+  // every await above (route preload, route validation, a module promise thrown
+  // by loadRoute) can outlive the tree that started this navigation. an auth
+  // gate that swaps Slot for Redirect unmounts the subtree mid-flight, and any
+  // host that hot-swaps an app by unmounting the React root and re-evaluating
+  // its bundle in the same realm leaves this closure holding a container ref
+  // that is detached for good. every method on a detached ref logs "The
+  // 'navigation' object hasn't been initialized yet", and there is no tree left
+  // to dispatch into, so abandon the navigation. do not wait for readiness: it
+  // never returns for an orphaned navigation.
+  if (!navigationRef.isReady()) {
+    setLoadingState('loaded')
+    return
+  }
+
   const currentRootState = navigationRef.getRootState()
 
   const hash = href.indexOf('#')
@@ -1423,6 +1437,14 @@ export async function linkTo(
 
   let warningTm
   const interval = setInterval(() => {
+    // this fires after the dispatch, later than 16ms on a busy main thread, and
+    // the tree it belongs to can be gone by then. a detached ref never
+    // re-attaches for this navigation, so stop rather than poll it.
+    if (!navigationRef.isReady()) {
+      clearTimeout(warningTm)
+      clearInterval(interval)
+      return
+    }
     const next = navigationRef.getCurrentRoute()
     if (currentRouteBeforeDispatch !== next) {
       // let the main thread clear at least before running
@@ -1431,7 +1453,10 @@ export async function linkTo(
       })
     }
     clearTimeout(warningTm)
-    clearTimeout(interval)
+    // clearInterval to match the setInterval above and the early return's
+    // teardown. clearTimeout also worked here (browsers and node share one
+    // handle space between the two), so this is consistency, not a fix.
+    clearInterval(interval)
   }, 16)
   if (process.env.NODE_ENV === 'development') {
     warningTm = setTimeout(() => {


### PR DESCRIPTION
`linkTo` awaits route preload and validation, and that work can outlive the tree that started the navigation. An auth gate swapping Slot for Redirect, or any host that hot-swaps an app by unmounting the React root and re-evaluating its bundle in the same realm, leaves the closure holding a container ref that is detached for good. Every method on a detached ref logs `The 'navigation' object hasn't been initialized yet`.

Two guards, both bailing rather than waiting, because the ref never re-attaches for an orphaned navigation:

- after the awaits, before the ref is re-entered: bail and clear the loading state `linkTo` set before the preload, so nothing is left hanging.
- inside the 16ms post-dispatch poll, which fires later than 16ms on a busy main thread and can outlive its tree.

`dismiss()`/`dismissAll()` are deliberately untouched. Those are synchronous user actions where a not-ready ref is genuine misuse and the log is informative.

The `clearTimeout(interval)` -> `clearInterval(interval)` change is consistency with the early return's teardown, not a fix: measured, `clearTimeout` already stopped the interval in both Chromium and node, which share one handle space.

`linkToOrphaned.test.ts` covers both paths deterministically, detaching the ref synchronously after `replace()` so it lands before `linkTo` resumes past its first await. Negative control: removing only the two guards and leaving `clearInterval` in place reproduces the production string in both tests.

Validation: full package suite 67 files / 575 tests, `bun run typecheck`, `bun run lint` 0 warnings 0 errors, all against the exact bytes on the branch.