### PR TITLE
feat(site): add RSS feed for blog

### DIFF
--- a/apps/onestack.dev/app/(content)/blog/rss.xml+api.ts
+++ b/apps/onestack.dev/app/(content)/blog/rss.xml+api.ts
@@ -1,0 +1,63 @@
+const SITE_URL = 'https://onestack.dev'
+
+export type BlogFrontmatter = {
+  description?: string
+  draft?: boolean
+  publishedAt?: string
+  slug: string
+  title?: string
+}
+
+const blogFrontmattersPromise = import('@vxrn/mdx-rust').then(({ getAllFrontmatter }) =>
+  getAllFrontmatter('data/blog')
+)
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+export function createRssFeed(posts: BlogFrontmatter[]) {
+  const items = posts
+    .filter((post) => !post.draft)
+    .sort(
+      (a, b) =>
+        Number(new Date(b.publishedAt || '')) - Number(new Date(a.publishedAt || ''))
+    )
+    .map((post) => {
+      const permalink = `${SITE_URL}/blog/${post.slug.replace(/^blog\//, '')}`
+
+      return `    <item>
+      <title>${escapeXml(post.title || '')}</title>
+      <link>${escapeXml(permalink)}</link>
+      <guid>${escapeXml(permalink)}</guid>
+      <pubDate>${escapeXml(new Date(post.publishedAt || '').toUTCString())}</pubDate>
+      <description>${escapeXml(post.description || '')}</description>
+    </item>`
+    })
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>One Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Latest news and updates from One</description>
+${items}
+  </channel>
+</rss>`
+}
+
+export async function GET() {
+  const frontmatters = await blogFrontmattersPromise
+
+  return new Response(createRssFeed(frontmatters), {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  })
+}

--- a/apps/onestack.dev/app/_layout.tsx
+++ b/apps/onestack.dev/app/_layout.tsx
@@ -27,6 +27,7 @@ export default function Layout() {
         />
         <link rel="icon" href="/favicon.png" sizes="32x32" />
         <link rel="icon" href="/large-icon.png" sizes="192x192" />
+        <link rel="alternate" type="application/rss+xml" href="/blog/rss.xml" />
       </head>
 
       <body>

--- a/apps/onestack.dev/tests/rss.test.ts
+++ b/apps/onestack.dev/tests/rss.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from 'vitest'
+import { createRssFeed } from '../app/(content)/blog/rss.xml+api'
+
+const serverUrl = process.env.ONE_SERVER_URL || 'http://localhost:8081'
+
+test('serves published blog posts as RSS 2.0', async () => {
+  const response = await fetch(`${serverUrl}/blog/rss.xml`)
+
+  expect(response.status).toBe(200)
+  expect(response.headers.get('content-type')).toBe('application/rss+xml; charset=utf-8')
+
+  const xml = await response.text()
+
+  expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+  expect(xml).toContain('<rss version="2.0">')
+  expect(xml).toContain('<title>One Blog</title>')
+  expect(xml).toContain('<link>https://onestack.dev/blog</link>')
+  expect(xml).toContain('<description>Latest news and updates from One</description>')
+  expect(xml).toContain('<title>One v1 Release Candidate</title>')
+  expect(xml).toContain('<link>https://onestack.dev/blog/version-one</link>')
+  expect(xml).toContain('<guid>https://onestack.dev/blog/version-one</guid>')
+  expect(xml).toContain('<pubDate>Sun, 28 Dec 2025 00:00:00 GMT</pubDate>')
+  expect(xml).toContain(
+    '<description>The React framework for cross-platform apps (with a single Vite plugin).</description>'
+  )
+})
+
+test('excludes draft blog posts', () => {
+  const xml = createRssFeed([
+    {
+      title: 'Published post',
+      slug: 'published-post',
+      publishedAt: '2026-01-02',
+      description: 'Visible to readers',
+    },
+    {
+      title: 'Draft post',
+      slug: 'draft-post',
+      publishedAt: '2026-01-03',
+      description: 'Not ready for readers',
+      draft: true,
+    },
+  ])
+
+  expect(xml).toContain('<title>Published post</title>')
+  expect(xml).not.toContain('Draft post')
+  expect(xml).not.toContain('https://onestack.dev/blog/draft-post')
+})
+
+test('sorts published blog posts newest first', () => {
+  const xml = createRssFeed([
+    {
+      title: 'Older post',
+      slug: 'older-post',
+      publishedAt: '2026-01-02',
+      description: 'Published first',
+    },
+    {
+      title: 'Newer post',
+      slug: 'newer-post',
+      publishedAt: '2026-02-03',
+      description: 'Published later',
+    },
+  ])
+
+  expect(xml.indexOf('<title>Newer post</title>')).toBeLessThan(
+    xml.indexOf('<title>Older post</title>')
+  )
+})
+
+test('escapes XML text in blog feed items', () => {
+  const xml = createRssFeed([
+    {
+      title: `Rock & <Roll> "Now" 'Live'`,
+      slug: 'rock&roll',
+      publishedAt: '2026-03-04',
+      description: `Use & <angles> "quotes" and 'apostrophes'`,
+    },
+  ])
+
+  expect(xml).toContain(
+    '<title>Rock &amp; &lt;Roll&gt; &quot;Now&quot; &apos;Live&apos;</title>'
+  )
+  expect(xml).toContain('<link>https://onestack.dev/blog/rock&amp;roll</link>')
+  expect(xml).toContain('<guid>https://onestack.dev/blog/rock&amp;roll</guid>')
+  expect(xml).toContain(
+    '<description>Use &amp; &lt;angles&gt; &quot;quotes&quot; and &apos;apostrophes&apos;</description>'
+  )
+})
+
+test('advertises the RSS feed in the site head', async () => {
+  const response = await fetch(serverUrl)
+  const html = await response.text()
+
+  expect(html).toMatch(
+    /<link(?=[^>]*rel="alternate")(?=[^>]*type="application\/rss\+xml")(?=[^>]*href="\/blog\/rss\.xml")[^>]*>/
+  )
+})


### PR DESCRIPTION
## Summary

- add an RSS 2.0 feed at `/blog/rss.xml`
- generate feed items from published blog frontmatter
- sort posts newest first and safely escape XML
- advertise the feed from the site head
- add regression coverage for HTTP behavior, filtering, ordering, escaping, and discovery

## Testing

- `TEST_ONLY=prod bun run vitest run tests/rss.test.ts --mode prod`
- `bun run typecheck`
- `../../node_modules/.bin/oxlint app/_layout.tsx 'app/(content)/blog/rss.xml+api.ts' tests/rss.test.ts`
- `../../node_modules/.bin/oxfmt --check app/_layout.tsx 'app/(content)/blog/rss.xml+api.ts' tests/rss.test.ts`
- `bun run build:web`
- generated XML validated with `xmllint --noout -`

Closes #746
