### PR TITLE
fix: pin toml to 4.2.0 to clear new high advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1479,6 +1479,7 @@
     "shell-quote": "1.10.0",
     "tar": "7.5.11",
     "tmp": "0.2.7",
+    "toml": "4.2.0",
     "undici": "7.29.0",
     "uuid": "11.1.1",
     "vite": "8.2.2",
@@ -5051,7 +5052,7 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
+    "toml": ["toml@4.2.0", "", {}, "sha512-TvAJjbHZlYmI323+srtqHQFyJsoWy6mI09ppkuj9+iRsqsVKG9fvTcOP7FHF2UCb0QSYtjEavffrKzdd0XgClg=="],
 
     "toqr": ["toqr@0.1.1", "", {}, "sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA=="],
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
     "launch-editor": "2.14.1",
     "uuid": "11.1.1",
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.18"
+    "nanoid": "3.3.18",
+    "toml": "4.2.0"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.14",


### PR DESCRIPTION
`bun audit` started failing on main with no code change — GHSA-82x6-q7mm-w9cf and GHSA-v5mp-jgw5-2x6j were published against `toml@3.0.0` today, between the green run on f470b920f and the red one on 024bc6951. The lockfile's toml entry is identical across those two SHAs.

`remark-mdx-frontmatter@5.2.0` (latest) still pins `toml@^3.0.0`, so there is no upstream fix to take. Pinned via `resolutions`, the same mechanism already used for tar, undici, ws, node-forge and others.

Verified: toml@4.2.0 exports the same named `parse`; `@vxrn/mdx` builds; a TOML-frontmatter MDX doc still compiles through remark-mdx-frontmatter; `bun run audit` is clean.