### PR TITLE
fix(router): keep browser diagnostics out of native route failures

### DIFF
--- a/packages/one/src/router/useViteRoutes.test.ts
+++ b/packages/one/src/router/useViteRoutes.test.ts
@@ -2,10 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   hmrImport: vi.fn(),
+  diagnoseRouteLoadFailure: vi.fn(),
 }))
 
 vi.mock('./hmrImport', () => ({
   hmrImport: mocks.hmrImport,
+}))
+
+vi.mock('./diagnoseRouteLoadFailure', () => ({
+  diagnoseRouteLoadFailure: mocks.diagnoseRouteLoadFailure,
 }))
 
 import { globbedRoutesToRouteContext } from './useViteRoutes'
@@ -14,8 +19,94 @@ const realWindow = (globalThis as any).window
 
 afterEach(() => {
   vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
   mocks.hmrImport.mockReset()
+  mocks.diagnoseRouteLoadFailure.mockReset()
   ;(globalThis as any).window = realWindow
+})
+
+describe('route load error diagnostics', () => {
+  it.each(['native', 'server', 'web shim', 'browser'])(
+    '%s preserves the original route error',
+    async (environment) => {
+      vi.stubEnv('NODE_ENV', 'development')
+      vi.stubEnv('TAMAGUI_TARGET', environment === 'native' ? 'native' : 'web')
+      vi.stubGlobal(
+        'window',
+        environment === 'server'
+          ? undefined
+          : environment === 'browser'
+            ? {
+                history: {},
+                location: { href: 'http://localhost/', origin: 'http://localhost' },
+              }
+            : {}
+      )
+      const report = vi.fn()
+      vi.stubGlobal('__oneReportRouteLoadError', report)
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      mocks.diagnoseRouteLoadFailure.mockResolvedValue(null)
+      vi.resetModules()
+      const { globbedRoutesToRouteContext } = await import('./useViteRoutes')
+      const error = new Error('original route failure')
+      const context = globbedRoutesToRouteContext(
+        { '/app/index.tsx': () => Promise.reject(error) },
+        'app'
+      )
+
+      const route = await resolveRoute(context)
+
+      expect(route.default()).toBeNull()
+      expect(report).toHaveBeenCalledExactlyOnceWith({
+        id: './index.tsx',
+        message: error.message,
+        stack: error.stack,
+      })
+      if (environment === 'browser') {
+        expect(mocks.diagnoseRouteLoadFailure).toHaveBeenCalledExactlyOnceWith(
+          './index.tsx',
+          '/app/index.tsx'
+        )
+      } else {
+        expect(mocks.diagnoseRouteLoadFailure).not.toHaveBeenCalled()
+      }
+    }
+  )
+
+  it('keeps the original report when a browser diagnostic rejects', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('TAMAGUI_TARGET', 'web')
+    vi.stubGlobal('window', {
+      history: {},
+      location: { href: 'http://localhost/', origin: 'http://localhost' },
+    })
+    const report = vi.fn()
+    vi.stubGlobal('__oneReportRouteLoadError', report)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.diagnoseRouteLoadFailure.mockRejectedValue(new Error('diagnostic failed'))
+    vi.resetModules()
+    const { globbedRoutesToRouteContext } = await import('./useViteRoutes')
+    const error = new Error('original route failure')
+    const context = globbedRoutesToRouteContext(
+      { '/app/index.tsx': () => Promise.reject(error) },
+      'app'
+    )
+
+    const route = await resolveRoute(context)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(route.default()).toBeNull()
+    expect(report).toHaveBeenCalledExactlyOnceWith({
+      id: './index.tsx',
+      message: error.message,
+      stack: error.stack,
+    })
+    expect(mocks.diagnoseRouteLoadFailure).toHaveBeenCalledExactlyOnceWith(
+      './index.tsx',
+      '/app/index.tsx'
+    )
+  })
 })
 
 async function resolveRoute(context: ReturnType<typeof globbedRoutesToRouteContext>) {

--- a/packages/one/src/router/useViteRoutes.tsx
+++ b/packages/one/src/router/useViteRoutes.tsx
@@ -1,5 +1,6 @@
 import type { GlobbedRouteImports } from '../types'
 import type { One } from '../vite/types'
+import { hasWebHistory } from '../constants'
 import { handleSkewError, isChunkLoadError } from '../utils/dynamicImport'
 import { diagnoseRouteLoadFailure } from './diagnoseRouteLoadFailure'
 import { hmrImport } from './hmrImport'
@@ -316,10 +317,12 @@ export function globbedRoutesToRouteContext(
             // `Importing a module script failed` names neither the module nor
             // the reason. when a browser content blocker refused one of the
             // route's imports, walking the graph finds the exact file.
-            if (process.env.NODE_ENV === 'development' && routePaths[id]) {
-              diagnoseRouteLoadFailure(id, routePaths[id]).then((message) => {
-                if (message) console.error(message)
-              })
+            if (hasWebHistory && routePaths[id]) {
+              diagnoseRouteLoadFailure(id, routePaths[id])
+                .then((message) => {
+                  if (message) console.error(message)
+                })
+                .catch(() => {})
             }
           }
           loadedRoutes[id] = {


### PR DESCRIPTION
Native route import failures launched a browser diagnostic that read `window.location.href`, producing a second error that masked the original failure. Run that diagnostic only when browser history and location are available, and keep a rejected diagnostic from replacing the original route error report.

Validation: six router tests pass, including native, SSR, incomplete window shims, browser diagnostics, and diagnostic rejection. The tests failed before the fix. An independent native route rejection probe now reports the original error with no unhandled diagnostic rejection. All 15 dependency build tasks pass; targeted lint is clean.
