### PR TITLE
fix(vxrn): only optimize dep subpaths the installed package exports

### DIFF
--- a/packages/one/src/cli/build.ts
+++ b/packages/one/src/cli/build.ts
@@ -286,7 +286,7 @@ export async function build(args: {
 
   const options = await fillOptions(vxrnOutput.options, { mode: 'prod' })
 
-  const { optimizeDeps } = getOptimizeDeps('build')
+  const { optimizeDeps } = getOptimizeDeps('build', options.root)
   const { rolldownOptions: _rolldownOptions, ...optimizeDepsNoRolldown } = optimizeDeps
 
   // unified mode: api + middleware routes share config with the SSR server build —

--- a/packages/vxrn/src/config/getAdditionalViteConfig.ts
+++ b/packages/vxrn/src/config/getAdditionalViteConfig.ts
@@ -7,8 +7,8 @@ import { webExtensions } from '../constants'
 /**
  * These configs are originally in `getViteServerConfig`. Maybe we should organize and move each of them into other more appropriate places.
  */
-export function getAdditionalViteConfig(): Omit<InlineConfig, 'plugins'> {
-  const { optimizeDeps } = getOptimizeDeps('serve')
+export function getAdditionalViteConfig(root?: string): Omit<InlineConfig, 'plugins'> {
+  const { optimizeDeps } = getOptimizeDeps('serve', root)
 
   // TODO: can we move most of this into `one` plugin:
   const { rolldownOptions, ...ssrOptimizeDepsWithoutRolldown } = optimizeDeps

--- a/packages/vxrn/src/config/getOptimizeDeps.test.ts
+++ b/packages/vxrn/src/config/getOptimizeDeps.test.ts
@@ -1,5 +1,16 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { getOptimizeDeps } from './getOptimizeDeps'
+
+function rootWithPackage(name: string, packageJson: Record<string, unknown>) {
+  const root = mkdtempSync(join(tmpdir(), 'vxrn-optimize-deps-'))
+  const dir = join(root, 'node_modules', name)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, ...packageJson }))
+  return root
+}
 
 describe('getOptimizeDeps', () => {
   it('does not force NativeWind JSX runtime subpaths into dev optimization', () => {
@@ -17,5 +28,52 @@ describe('getOptimizeDeps', () => {
     }
 
     expect(optimizeDeps.include).toContain('nativewind')
+  })
+})
+
+describe('getOptimizeDeps subpath guard', () => {
+  it('drops subpaths the installed package no longer exports', () => {
+    const root = rootWithPackage('react-native-css-interop', {
+      exports: { '.': './dist/index.js' },
+    })
+    const { depsToOptimize, needsInterop, optimizeDeps } = getOptimizeDeps('serve', root)
+
+    for (const dep of [
+      'react-native-css-interop/jsx-runtime',
+      'react-native-css-interop/jsx-dev-runtime',
+    ]) {
+      expect(depsToOptimize).not.toContain(dep)
+      expect(needsInterop).not.toContain(dep)
+      expect(optimizeDeps.include).not.toContain(dep)
+      expect(optimizeDeps.needsInterop).not.toContain(dep)
+    }
+
+    expect(optimizeDeps.include).toContain('react-native-css-interop')
+  })
+
+  it('keeps subpaths when the installed package has no exports map', () => {
+    const root = rootWithPackage('react-native-css-interop', { main: 'dist/index' })
+
+    expect(getOptimizeDeps('serve', root).optimizeDeps.include).toContain(
+      'react-native-css-interop/jsx-runtime'
+    )
+  })
+
+  it('keeps subpaths of packages that are not installed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'vxrn-optimize-deps-empty-'))
+
+    expect(getOptimizeDeps('serve', root).optimizeDeps.include).toContain(
+      'react-native-css-interop/jsx-runtime'
+    )
+  })
+
+  it('keeps subpaths declared through a wildcard export', () => {
+    const root = rootWithPackage('react-native-css-interop', {
+      exports: { '.': './dist/index.js', './*': './dist/*.js' },
+    })
+
+    expect(getOptimizeDeps('serve', root).optimizeDeps.include).toContain(
+      'react-native-css-interop/jsx-runtime'
+    )
   })
 })

--- a/packages/vxrn/src/config/getOptimizeDeps.test.ts
+++ b/packages/vxrn/src/config/getOptimizeDeps.test.ts
@@ -6,10 +6,23 @@ import { getOptimizeDeps } from './getOptimizeDeps'
 
 function rootWithPackage(name: string, packageJson: Record<string, unknown>) {
   const root = mkdtempSync(join(tmpdir(), 'vxrn-optimize-deps-'))
-  const dir = join(root, 'node_modules', name)
+  writePackage(root, name, packageJson)
+  return root
+}
+
+/** the monorepo/hoisting case: the package sits above the root vite is started from */
+function rootWithHoistedPackage(name: string, packageJson: Record<string, unknown>) {
+  const workspace = mkdtempSync(join(tmpdir(), 'vxrn-optimize-deps-hoisted-'))
+  writePackage(workspace, name, packageJson)
+  const root = join(workspace, 'app')
+  mkdirSync(root)
+  return root
+}
+
+function writePackage(at: string, name: string, packageJson: Record<string, unknown>) {
+  const dir = join(at, 'node_modules', name)
   mkdirSync(dir, { recursive: true })
   writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, ...packageJson }))
-  return root
 }
 
 describe('getOptimizeDeps', () => {
@@ -51,6 +64,60 @@ describe('getOptimizeDeps subpath guard', () => {
     expect(optimizeDeps.include).toContain('react-native-css-interop')
   })
 
+  it('drops subpaths the installed package blocks with a null export', () => {
+    const root = rootWithPackage('react-native-css-interop', {
+      exports: {
+        '.': './dist/index.js',
+        './jsx-runtime': null,
+        './jsx-dev-runtime': './dist/jsx-dev-runtime.js',
+      },
+    })
+    const { depsToOptimize, needsInterop, optimizeDeps } = getOptimizeDeps('serve', root)
+
+    // `"./x": null` is not exported, exactly as if the key were absent: vite throws the same
+    // `is not exported under the conditions` error for both, so presence of the key is not
+    // enough to keep the entry
+    expect(depsToOptimize).not.toContain('react-native-css-interop/jsx-runtime')
+    expect(needsInterop).not.toContain('react-native-css-interop/jsx-runtime')
+    expect(optimizeDeps.include).not.toContain('react-native-css-interop/jsx-runtime')
+    expect(optimizeDeps.needsInterop).not.toContain(
+      'react-native-css-interop/jsx-runtime'
+    )
+
+    expect(optimizeDeps.include).toContain('react-native-css-interop')
+    expect(optimizeDeps.include).toContain('react-native-css-interop/jsx-dev-runtime')
+  })
+
+  it('finds a package hoisted above the root', () => {
+    const root = rootWithHoistedPackage('react-native-css-interop', {
+      exports: { '.': './dist/index.js' },
+    })
+
+    expect(getOptimizeDeps('serve', root).optimizeDeps.include).not.toContain(
+      'react-native-css-interop/jsx-runtime'
+    )
+  })
+
+  it('resolves a relative root before walking node_modules', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'vxrn-optimize-deps-relative-'))
+    writePackage(workspace, 'react-native-css-interop', {
+      exports: { '.': './dist/index.js' },
+    })
+    mkdirSync(join(workspace, 'packages', 'app'), { recursive: true })
+
+    // vite's `config.root` may be relative, and a relative root would stop the walk at the
+    // cwd instead of reaching the hoisted copy two directories up
+    const cwd = process.cwd()
+    try {
+      process.chdir(join(workspace, 'packages'))
+      expect(getOptimizeDeps('serve', 'app').optimizeDeps.include).not.toContain(
+        'react-native-css-interop/jsx-runtime'
+      )
+    } finally {
+      process.chdir(cwd)
+    }
+  })
+
   it('keeps subpaths when the installed package has no exports map', () => {
     const root = rootWithPackage('react-native-css-interop', { main: 'dist/index' })
 
@@ -72,6 +139,18 @@ describe('getOptimizeDeps subpath guard', () => {
       exports: { '.': './dist/index.js', './*': './dist/*.js' },
     })
 
+    expect(getOptimizeDeps('serve', root).optimizeDeps.include).toContain(
+      'react-native-css-interop/jsx-runtime'
+    )
+  })
+
+  it('keeps a subpath a wildcard export matches with an empty expansion', () => {
+    const root = rootWithPackage('react-native-css-interop', {
+      exports: { '.': './dist/index.js', './jsx-runtime*': './dist/jsx-runtime*.js' },
+    })
+
+    // vite resolves `./jsx-runtime` off this key, node does not, and the guard follows vite
+    // because vite is what actually resolves the include list
     expect(getOptimizeDeps('serve', root).optimizeDeps.include).toContain(
       'react-native-css-interop/jsx-runtime'
     )

--- a/packages/vxrn/src/config/getOptimizeDeps.ts
+++ b/packages/vxrn/src/config/getOptimizeDeps.ts
@@ -1,9 +1,14 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import type { UserConfig } from 'vite'
 import { webExtensions } from '../constants'
 
 // TODO we need to traverse to get sub-deps...
 
-export function getOptimizeDeps(mode: 'build' | 'serve') {
+export function getOptimizeDeps(mode: 'build' | 'serve', root = process.cwd()) {
+  const packageJsonCache = new Map<string, PackageManifest | null>()
+  const isIncludable = (dep: string) => subpathIsDeclared(dep, root, packageJsonCache)
+
   const needsInterop = [
     'nativewind',
 
@@ -52,7 +57,7 @@ export function getOptimizeDeps(mode: 'build' | 'serve') {
     '@algolia/autocomplete-plugin-algolia-insights',
     '@algolia/autocomplete-shared',
     'moti',
-  ]
+  ].filter(isIncludable)
 
   const depsToOptimize = [
     ...needsInterop,
@@ -117,7 +122,7 @@ export function getOptimizeDeps(mode: 'build' | 'serve') {
     '@floating-ui/react-dom',
     'tamagui',
     'reforest',
-  ]
+  ].filter(isIncludable)
 
   if (mode === 'build') {
     // breaks in serve mode
@@ -161,4 +166,97 @@ export function getOptimizeDeps(mode: 'build' | 'serve') {
       },
     } satisfies UserConfig['optimizeDeps'],
   }
+}
+
+type PackageManifest = { exports?: unknown }
+
+/**
+ * vite resolves every `optimizeDeps.include` entry eagerly. an entry whose package is
+ * installed but no longer declares that subpath in `exports` is a hard resolve error, not a
+ * warning, so listing one kills dev server startup. nativewind v5 dropping ./jsx-runtime and
+ * ./jsx-dev-runtime is the case that hit us; guard the whole list so the next drop is a no-op.
+ */
+function subpathIsDeclared(
+  dep: string,
+  root: string,
+  cache: Map<string, PackageManifest | null>
+): boolean {
+  const packageName = getPackageName(dep)
+  if (dep === packageName) {
+    // bare package entry, there is no subpath to check
+    return true
+  }
+  const packageJson = readInstalledPackageJson(packageName, root, cache)
+  // not installed at all is only a vite warning, and a package with no `exports` map still
+  // resolves subpaths off the filesystem. neither case is ours to drop.
+  if (!packageJson?.exports) {
+    return true
+  }
+  return exportsDeclaresSubpath(packageJson.exports, `.${dep.slice(packageName.length)}`)
+}
+
+function getPackageName(dep: string): string {
+  const parts = dep.split('/')
+  return dep[0] === '@' ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+function readInstalledPackageJson(
+  packageName: string,
+  root: string,
+  cache: Map<string, PackageManifest | null>
+): PackageManifest | null {
+  const cached = cache.get(packageName)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  let found: PackageManifest | null = null
+  let dir = root
+  while (true) {
+    const file = join(dir, 'node_modules', packageName, 'package.json')
+    if (existsSync(file)) {
+      try {
+        found = JSON.parse(readFileSync(file, 'utf-8'))
+      } catch {
+        // unreadable manifest, treat it as unknown and keep the entry
+      }
+      break
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+
+  cache.set(packageName, found)
+  return found
+}
+
+function exportsDeclaresSubpath(exports: unknown, subpath: string): boolean {
+  if (!exports || typeof exports !== 'object' || Array.isArray(exports)) {
+    // a string or array `exports` declares the root entry only
+    return false
+  }
+  const keys = Object.keys(exports)
+  if (!keys.some((key) => key[0] === '.')) {
+    // conditions-only map, again the root entry only
+    return false
+  }
+  return keys.some((key) => exportKeyMatches(key, subpath))
+}
+
+function exportKeyMatches(key: string, subpath: string): boolean {
+  const star = key.indexOf('*')
+  if (star === -1) {
+    return key === subpath
+  }
+  // only the first `*` is a wildcard per the node exports spec
+  const prefix = key.slice(0, star)
+  const suffix = key.slice(star + 1)
+  return (
+    subpath.length >= prefix.length + suffix.length &&
+    subpath.startsWith(prefix) &&
+    subpath.endsWith(suffix)
+  )
 }

--- a/packages/vxrn/src/config/getOptimizeDeps.ts
+++ b/packages/vxrn/src/config/getOptimizeDeps.ts
@@ -1,13 +1,16 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import type { UserConfig } from 'vite'
 import { webExtensions } from '../constants'
 
 // TODO we need to traverse to get sub-deps...
 
 export function getOptimizeDeps(mode: 'build' | 'serve', root = process.cwd()) {
+  // callers hand us a vite/vxrn root that may be relative, and the node_modules walk needs
+  // an absolute path or it stops at the cwd instead of continuing to the filesystem root
+  const rootDir = resolve(root)
   const packageJsonCache = new Map<string, PackageManifest | null>()
-  const isIncludable = (dep: string) => subpathIsDeclared(dep, root, packageJsonCache)
+  const isIncludable = (dep: string) => subpathIsDeclared(dep, rootDir, packageJsonCache)
 
   const needsInterop = [
     'nativewind',
@@ -238,12 +241,12 @@ function exportsDeclaresSubpath(exports: unknown, subpath: string): boolean {
     // a string or array `exports` declares the root entry only
     return false
   }
-  const keys = Object.keys(exports)
-  if (!keys.some((key) => key[0] === '.')) {
-    // conditions-only map, again the root entry only
-    return false
-  }
-  return keys.some((key) => exportKeyMatches(key, subpath))
+  // a `null` target is an explicit "not exported", so key presence alone proves nothing, and
+  // keys not starting with `.` are a conditions-only map, again the root entry only. this is
+  // the same walk vite does in `expandGlobIds`.
+  return Object.entries(exports as Record<string, unknown>).some(
+    ([key, target]) => target != null && key[0] === '.' && exportKeyMatches(key, subpath)
+  )
 }
 
 function exportKeyMatches(key: string, subpath: string): boolean {

--- a/packages/vxrn/src/config/getViteServerConfig.ts
+++ b/packages/vxrn/src/config/getViteServerConfig.ts
@@ -17,13 +17,13 @@ export async function getViteServerConfig(
   userViteConfig?: UserConfig
 ) {
   const { root, server } = config
-  const { optimizeDeps } = getOptimizeDeps('serve')
+  const { optimizeDeps } = getOptimizeDeps('serve', root)
 
   // TODO: can we move most of this into `one` plugin:
   let serverConfig: UserConfig = mergeConfig(
     await getBaseViteConfigWithPlugins(config),
 
-    mergeConfig(getAdditionalViteConfig(), {
+    mergeConfig(getAdditionalViteConfig(root), {
       plugins: [...getReactNativePlugins(config)],
       server: {
         // vite 8.1 deprecated server.hmr.* in favor of server.ws.*

--- a/packages/vxrn/src/exports/build.ts
+++ b/packages/vxrn/src/exports/build.ts
@@ -111,7 +111,7 @@ export const build = async (optionsIn: VXRNOptions, buildArgs: BuildArgs = {}) =
     )
   }
 
-  const { optimizeDeps } = getOptimizeDeps('build')
+  const { optimizeDeps } = getOptimizeDeps('build', options.root)
   const { rolldownOptions: optimizeDepsRolldownOptions, ...optimizeDepsWithoutRolldown } =
     optimizeDeps
 

--- a/packages/vxrn/src/plugins/defaultDepOptimizePlugin.ts
+++ b/packages/vxrn/src/plugins/defaultDepOptimizePlugin.ts
@@ -24,7 +24,7 @@ export function defaultDepOptimizePlugin(): Plugin {
         )
       }
 
-      const { optimizeDeps } = getOptimizeDeps(env.command)
+      const { optimizeDeps } = getOptimizeDeps(env.command, config.root)
 
       // On dev, CLI mode will use `getViteServerConfig` which calls `mergeUserConfig` to merge
       // user defined configs with vxrn defaults. The `mergeUserConfig` function have a

--- a/packages/vxrn/src/vxrn-vite-plugin.ts
+++ b/packages/vxrn/src/vxrn-vite-plugin.ts
@@ -66,7 +66,7 @@ export function vxrn(options?: VxrnPluginOptions): PluginOption {
           mode,
         })
 
-        const additionalConfig = getAdditionalViteConfig()
+        const additionalConfig = getAdditionalViteConfig(root)
         return mergeConfig(baseConfig, additionalConfig)
       },
     },

--- a/packages/vxrn/types/config/getAdditionalViteConfig.d.ts
+++ b/packages/vxrn/types/config/getAdditionalViteConfig.d.ts
@@ -2,5 +2,5 @@ import type { InlineConfig } from 'vite';
 /**
  * These configs are originally in `getViteServerConfig`. Maybe we should organize and move each of them into other more appropriate places.
  */
-export declare function getAdditionalViteConfig(): Omit<InlineConfig, 'plugins'>;
+export declare function getAdditionalViteConfig(root?: string): Omit<InlineConfig, 'plugins'>;
 //# sourceMappingURL=getAdditionalViteConfig.d.ts.map

--- a/packages/vxrn/types/config/getOptimizeDeps.d.ts
+++ b/packages/vxrn/types/config/getOptimizeDeps.d.ts
@@ -1,4 +1,4 @@
-export declare function getOptimizeDeps(mode: 'build' | 'serve'): {
+export declare function getOptimizeDeps(mode: 'build' | 'serve', root?: string): {
     needsInterop: string[];
     depsToOptimize: string[];
     optimizeDeps: {


### PR DESCRIPTION
## Summary

Issue #729 is half fixed. Commit `2ae5dac306` removed the two NativeWind runtime entries, so the exact symptom in the report is gone:

```
ERROR  "./jsx-dev-runtime" is not exported under the conditions ["vxrn-web", "import"] from package /.../node_modules/nativewind
```

The half that is still open is the one named in the last line of the "Suggested fix" section: there is no resolve guard, and `react-native-css-interop/jsx-runtime` / `react-native-css-interop/jsx-dev-runtime` are still listed unconditionally.

`packages/vxrn/src/config/getOptimizeDeps.ts` on `main` @ `85ee5bcf` (v1.26.0), lines 10-11:

```ts
const needsInterop = [
  'nativewind',

  'react-native-css-interop/jsx-runtime',      // line 10
  'react-native-css-interop/jsx-dev-runtime',  // line 11
  'react-native-css-interop',
  ...
```

Those two happen to resolve today, so nothing is broken right now. `react-native-css-interop@0.2.6` ships no `exports` field at all, so its subpaths resolve straight off the filesystem (`node_modules/react-native-css-interop/jsx-runtime/`). The moment that package adds an `exports` map without those keys, or a project installs a version that already has one, vxrn is back to the exact failure in this issue.

## Root cause

Not the two package names, but the fact that `getOptimizeDeps` hands vite a fixed list of subpaths and never checks the installed packages.

The asymmetry that makes this fatal rather than noisy is in vite's `addManuallyIncludedOptimizeDeps` (`vite@8.2.2`, `dist/node/chunks/node.js`). Every `optimizeDeps.include` entry is resolved eagerly:

- resolver returns nothing (package not installed) -> `unableToOptimize(id, 'Failed to resolve dependency')`, a `logger.warn`, startup continues. That is why the list can safely carry `pg`, `@docsearch/react`, `moti` and friends that most projects do not install.
- package installed but its `exports` map does not declare the subpath -> the resolver throws instead of returning, so it never reaches the warn path and the dev server never comes up.

So the list is only ever dangerous for entries whose package is installed and whose `exports` map lost the key. That is exactly what NativeWind v5 did: `npm view nativewind@5.0.0-preview.4 exports` is `['.', './babel', './metro', './theme', './types']`, no `./jsx-runtime`.

## Fix

Implements suggestion (a) from the issue, since (b) was described as less robust. Before returning the list, drop any entry whose installed package proves the subpath is gone:

1. Split `pkg/sub` into package name and subpath (scoped names handled).
2. Walk `node_modules` upward from `root` for the package's `package.json`.
3. Keep the entry if the package is not installed, or has no `exports` field. Neither of those is the failing case, and dropping them would change behaviour for no gain.
4. Only if there is an `exports` map, keep the entry when the map declares the subpath under a non-`null` target (exact key, or a `*` pattern key).

Point 4 reads the target, not just the key, because `"./jsx-runtime": null` is an explicit "not exported" and would otherwise fail open on exactly the case this PR exists to prevent. Verified on `node v24.13.0`, where `import.meta.resolve('pkg/blocked')` against `exports: { ".": "./index.js", "./blocked": null }` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`, and on `vite@8.2.2`, where `createServer` with that package installed and `optimizeDeps.include: ['pkg/blocked']` throws:

```
"./blocked" is not exported under the conditions ["module", "browser", "development", "import"] from package .../node_modules/nulldep
```

which is byte-for-byte the shape of the failure in #729, and identical to what vite throws when the key is absent entirely. Vite's own `expandGlobIds` skips these with `if (exports[key] == null) continue`.

Filtering is applied to the whole list, not just the two `react-native-css-interop` lines, which is the "robust against future similar drops" part. `root` is a new optional second parameter defaulting to `process.cwd()`, which is already what `getOptionsFilled` uses when no root is given, and it is now passed at all five call sites (see Notes).

On the wildcard length guard: the guard accepts a `*` that expands to the empty string, so `exports: { "./jsx-runtime*": "./dist/jsx-runtime*.js" }` keeps `pkg/jsx-runtime`. That is deliberately vite's behaviour, not node's. Node rejects it (`packageSubpath.length >= key.length`, and `key` includes the `*`); `vite@8.2.2` `createServer` resolves it. Since vite is what actually resolves this list, following node here would be a silent wrong drop.

Rejected alternative: the shorter `try { createRequire(root).resolve(dep) } catch { drop }`. I built it and measured it against this repo's install before discarding it, because it looked like the obvious version:

| approach | kept of 101 |
| --- | --- |
| `exports`-map guard (this PR) | 101 |
| `createRequire(...).resolve` | 80 |

The 21 it drops are wrong drops, in two ways. Most are bare package entries it cannot see from the workspace root at all (`nativewind`, `pg`, `moti`, `secure-json-parse`, `@supabase/postgres-js`, ...), which vite only warns about today. Worse, it also drops `swr/mutation`, `one/zero` and `@floating-ui/react`, live subpaths whose packages are installed workspace-locally rather than hoisted. It also resolves under the `require` condition while vite resolves under `["vxrn-web", "import"]`, so a subpath exported only under `import` would go too. Over-removal is silent and under-removal is a warning, so the guard should only fire when it is certain. Reading the `exports` keys is condition-agnostic and hoisting-agnostic, and can only drop an entry in the case that already breaks vite.

## Test plan

Added to the existing `packages/vxrn/src/config/getOptimizeDeps.test.ts`, next to the guard added by `2ae5dac306`.

- [x] `bun run vitest run src/config/getOptimizeDeps.test.ts` in `packages/vxrn`: 9 tests pass (1 pre-existing, 8 new). Names appear in `--reporter=verbose` output, no skips.
- [x] Fixture coverage per branch: `exports` map without the key (dropped), key present but `null` (dropped), package hoisted one directory above `root` (found, then dropped), relative `root` (resolved, then found and dropped), no `exports` field (kept), package absent (kept), `./*` wildcard key (kept), wildcard matching an empty expansion (kept).
- [x] Mutation-tested, one test kills each mutant and nothing else changes:

  | mutant | test that goes red |
  | --- | --- |
  | drop the `target != null` check | `drops subpaths the installed package blocks with a null export` |
  | delete the upward `node_modules` walk | `finds a package hoisted above the root` |
  | `>=` to `>` in the wildcard length guard | `keeps a subpath a wildcard export matches with an empty expansion` |
  | drop the `resolve(root)` normalization | `resolves a relative root before walking node_modules` |

- [x] Counterfactual: restored `getOptimizeDeps.ts` to the previous commit with the test file kept. Exactly the two tests covering the two behaviour changes go red, both on an assertion rather than a crash (`AssertionError: expected [ 'nativewind', ...(100) ] to not include 'react-native-css-interop/jsx-runtime'`). The other seven pass in both states by design: they assert the guard does not over-remove.
- [x] No over-removal on a real install. Ran `getOptimizeDeps('serve', <repo root>)` against this monorepo's `bun install`: 101 entries in, 101 entries out, 0 dropped, 44 `needsInterop` preserved. `react-native-css-interop@0.2.6` is installed here and all three of its entries survive, as do `swr/mutation`, `one/zero` and `@floating-ui/react`. Whole call measured at 1.2ms.
- [x] `packages/vxrn` full `vitest run --dir src`: 48 passed / 9 failed (57) with this change, 44 passed / 9 failed (53) before it. Same 9 failures, same 7 files, 4 added tests.
- [x] `packages/one` `bun run test:one`: 545 passed / 4 failed / 56 skipped (605), byte-identical before and after, so threading `options.root` into `one/src/cli/build.ts` changes nothing there.
- [x] `oxlint`: 0 warnings, 0 errors on all 8 touched source files. `oxfmt -c .prettierrc` applied.
- [x] `tsc --noEmit` in `packages/vxrn`: 0 errors. `types/config/getOptimizeDeps.d.ts` and `types/config/getAdditionalViteConfig.d.ts` regenerated for the new parameters, and diffed against a fresh `tsc --emitDeclarationOnly` to confirm nothing else in `types/` moved. `packages/one` `tsc --noEmit` reports only the pre-existing `Cannot find module 'create-vxrn/create'` in the untouched `src/cli/main.ts`, which is an unbuilt workspace package.

The other 7 failing files in a full `vitest run --dir src` here fail on `Cannot find module '@vxrn/debug'` / `Failed to resolve entry for package "@vxrn/compiler"` because I did not run a workspace build. They fail identically on unmodified `main`.

## Notes

`root` is now threaded at all five call sites, since leaving it unpassed made the parameter dead and the guard always read `process.cwd()`:

- `getViteServerConfig` passes the `config.root` it already destructures one line above.
- `getAdditionalViteConfig` takes an optional `root` and gets it from both its callers: `getViteServerConfig`, and `vxrn-vite-plugin`, which has already resolved a root (with its own `process.cwd()` fallback and warning) just above the call.
- `defaultDepOptimizePlugin` passes vite's `config.root`, which may be `undefined` and then falls through to the existing default.
- `vxrn/src/exports/build.ts` and `one/src/cli/build.ts` pass `options.root` off the `fillOptions` result.

`getOptimizeDeps` now runs `resolve(root)` first, because vite's `config.root` may be relative and a relative root would end the upward walk at the cwd rather than at the filesystem root.

This only changes behaviour when a hoisted copy at or above the cwd has a different `exports` map from the one the app actually resolves. In that case the old code silently dropped a live entry from both `depsToOptimize` and `needsInterop`, and dropping from `needsInterop` changes CJS interop rather than only pre-bundling. Happy to split this back out if you would rather keep the PR to the filter alone.

One thing I would flag about the requested approach rather than substitute my own: this reads `exports` from the manifest, which is a slightly different question from what vite's resolver answers. A package could declare a subpath whose target file is missing, and the guard would keep it. That is a strictly rarer failure than the one this fixes, and catching it would mean running the full resolver at config time. Mentioning it in case you want the stricter version instead.

Also happy to rework any of this, including dropping the general filter and guarding only the two `react-native-css-interop` lines, if the narrower change is preferred.

