### PR TITLE
fix(native): keep route Fast Refresh from remounting

### DIFF
--- a/packages/one/src/router/routeHmr.native.test.ts
+++ b/packages/one/src/router/routeHmr.native.test.ts
@@ -25,18 +25,16 @@ describe('routeHmr.native', () => {
     expect(typeof globalThis.__VXRN_ON_MODULE_UPDATED__).toBe('function')
   })
 
-  it('bumps the epoch and notifies subscribers, and stops after unsubscribe', () => {
+  it('does not bump the epoch, so Fast Refresh can keep the mounted route', () => {
     const before = routeHmr.getRouteHmrEpoch()
     const listener = vi.fn()
     const unsubscribe = routeHmr.subscribeRouteHmr(listener)
 
     globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')
-    expect(routeHmr.getRouteHmrEpoch()).toBe(before + 1)
-    expect(listener).toHaveBeenCalledTimes(1)
+    expect(routeHmr.getRouteHmrEpoch()).toBe(before)
+    expect(listener).not.toHaveBeenCalled()
 
     unsubscribe()
-    globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')
-    expect(listener).toHaveBeenCalledTimes(1)
   })
 
   it('evicts the route cache for the updated file when window.__oneRouteCache is present', () => {
@@ -46,7 +44,7 @@ describe('routeHmr.native', () => {
     expect(clearFile).toHaveBeenCalledWith('app/_layout.tsx')
   })
 
-  it('does not bump the epoch for a non-route module when the cache says so', () => {
+  it('does not bump the epoch for a non-route module either', () => {
     const before = routeHmr.getRouteHmrEpoch()
     const listener = vi.fn()
     const unsubscribe = routeHmr.subscribeRouteHmr(listener)
@@ -65,9 +63,10 @@ describe('routeHmr.native', () => {
     expect(() => globalThis.__VXRN_ON_MODULE_UPDATED__!('x.tsx')).not.toThrow()
   })
 
-  it('still notifies subscribers when route-cache eviction throws', () => {
+  it('does not throw or bump the epoch when route-cache eviction throws', () => {
     const listener = vi.fn()
     const unsubscribe = routeHmr.subscribeRouteHmr(listener)
+    const before = routeHmr.getRouteHmrEpoch()
     ;(globalThis as any).window = {
       __oneRouteCache: {
         clearFile() {
@@ -76,10 +75,9 @@ describe('routeHmr.native', () => {
       },
     }
 
-    expect(() => globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')).toThrow(
-      'cache eviction failed'
-    )
-    expect(listener).toHaveBeenCalledOnce()
+    expect(() => globalThis.__VXRN_ON_MODULE_UPDATED__!('app/index.tsx')).not.toThrow()
+    expect(routeHmr.getRouteHmrEpoch()).toBe(before)
+    expect(listener).not.toHaveBeenCalled()
     unsubscribe()
   })
 })

--- a/packages/one/src/router/routeHmr.native.ts
+++ b/packages/one/src/router/routeHmr.native.ts
@@ -1,7 +1,10 @@
 // native Fast Refresh for One routes
 //
 // vxrn calls the global hook after committing an updated module. One evicts that
-// route and bumps this external-store epoch so mounted screens load fresh exports.
+// route from the loader cache so the next loadRoute() sees fresh exports. it
+// does not bump the epoch: ScreenComponent re-running loadRoute() would render a
+// new function identity and remount the route, which is what made
+// `generation:1` jump to `generation:2` when a route file was Fast Refreshed.
 
 declare global {
   // vxrn's native HMR runtime invokes this (when defined) with each committed
@@ -23,21 +26,14 @@ export const getRouteHmrEpoch = () => routeHmrEpoch
 
 if (process.env.NODE_ENV === 'development') {
   globalThis.__VXRN_ON_MODULE_UPDATED__ = (id: string) => {
-    // only refresh mounted screens when the updated module is a route. a leaf
-    // Fast Refresh already patches in place; bumping this epoch re-renders every
-    // ScreenComponent, and used to remount any layout that exported ErrorBoundary.
-    let shouldRefresh = true
     try {
       const routeCache =
         typeof window === 'undefined' ? undefined : (window as any).__oneRouteCache
       if (typeof routeCache?.clearFile === 'function') {
-        shouldRefresh = routeCache.clearFile(id) !== false
+        routeCache.clearFile(id)
       }
-    } finally {
-      if (shouldRefresh) {
-        routeHmrEpoch++
-        routeHmrListeners.forEach((listener) => listener())
-      }
+    } catch (error) {
+      console.error('[one] route cache eviction failed', error)
     }
   }
 }

--- a/packages/one/src/router/useScreens.tsx
+++ b/packages/one/src/router/useScreens.tsx
@@ -412,9 +412,9 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       }, [])
     }
 
-    // native Fast Refresh: subscribe to the route-hot epoch (the routeHmr.native
-    // store bumps it when vxrn reports a route module update) so this component
-    // re-renders and re-runs loadRoute() to pick up the edited module's exports
+    // native Fast Refresh: subscribe to the route-hot epoch. route file patches
+    // are applied in place and do not bump it; a bump re-runs loadRoute() and
+    // remounts the screen.
     if (
       process.env.NODE_ENV === 'development' &&
       process.env.TAMAGUI_TARGET === 'native'

--- a/packages/vxrn/src/plugins/reactNativeDevServer.ts
+++ b/packages/vxrn/src/plugins/reactNativeDevServer.ts
@@ -254,10 +254,10 @@ export function createReactNativeDevServerPlugin(
         })
       }
 
-      // a created file belongs to the dev engine now: the native entry plugin
-      // registers the route directories with addWatchFile, so rolldown's own
-      // watcher reports a route appearing and the engine rebuilds and reloads
-      // for that alone, instead of every file written anywhere in the project.
+      // a created route file: rolldown's addWatchFile on the route directories
+      // is supposed to report it, and the engine rebuilds only then. github's
+      // macos runners do not always surface that, so vite's watcher is the
+      // backup, still scoped to route files inside handleAddedFile.
       //
       // a deletion it cannot survive. rolldown's dev engine panics its worker
       // when it retires a module that left the disk ("index out of bounds" out
@@ -265,6 +265,26 @@ export function createReactNativeDevServerPlugin(
       // once the file comes back. that engine cannot be repaired, so drop it
       // and let the next bundle request build a fresh one.
       let deletionTimer: ReturnType<typeof setTimeout> | undefined
+      let addTimer: ReturnType<typeof setTimeout> | undefined
+      const addedFiles = new Set<string>()
+      server.watcher.on('add', (file) => {
+        if (file.split('/').some((segment) => segment.startsWith('.'))) return
+        addedFiles.add(file)
+        clearTimeout(addTimer)
+        addTimer = setTimeout(() => {
+          const files = [...addedFiles]
+          addedFiles.clear()
+          for (const platform of Object.keys(devEngines)) {
+            const devEngine = devEngines[platform]
+            if (!devEngine) continue
+            for (const added of files) {
+              devEngine.handleAddedFile(added).catch((error) => {
+                console.error(`[vxrn] handling added ${added} for ${platform} failed`, error)
+              })
+            }
+          }
+        }, 50)
+      })
       server.watcher.on('unlink', (file) => {
         // vite's watcher already skips node_modules and .git. keep out the rest
         // of what a dev server writes into a project while it runs: caches and

--- a/packages/vxrn/src/utils/createNativeDevEngine.ts
+++ b/packages/vxrn/src/utils/createNativeDevEngine.ts
@@ -98,6 +98,7 @@ interface NativeDevEngineResult {
   getBundle: () => Promise<NativeDevBundle>
   getAsset: (pathname: string, hash?: string) => NativeDevAsset | undefined
   close: () => Promise<void>
+  handleAddedFile: (file: string) => Promise<void>
 }
 
 // shared resolve extensions for native builds
@@ -643,7 +644,30 @@ try {
   // the finished bundle waits on this too.
   let outputProcessed: Promise<void> = Promise.resolve()
 
-  const engine = await dev(inputOptions, outputOptions, {
+  let engine: Awaited<ReturnType<typeof dev>>
+
+  const rebuildIfNewRoute = async (files: string[]): Promise<boolean> => {
+    const { routeRoot, files: knownRoutes, isRouteFile } = virtualEntry.routes
+    const routeRootPrefix = `${normalizePath(routeRoot)}/`
+    const routeAdded = files.some((file) => {
+      const normalized = normalizePath(file)
+      if (isRouteFile(normalized)) return !knownRoutes.has(normalized)
+      return (
+        normalized.startsWith(routeRootPrefix) &&
+        statSync(file, { throwIfNoEntry: false })?.isDirectory() === true
+      )
+    })
+    if (!routeAdded) return false
+    await queueEngineWork(async () => {
+      engine.triggerFullBuild()
+      await engine.ensureLatestBuildOutput()
+      await outputProcessed
+    })
+    onHmrUpdate?.({ type: 'hmr:reload' })
+    return true
+  }
+
+  engine = await dev(inputOptions, outputOptions, {
     onOutput: async (result) => {
       let finishOutput = () => {}
       outputProcessed = new Promise<void>((resolve) => {
@@ -668,26 +692,7 @@ try {
       // `import.meta.glob` was expanded back when it transformed the entry.
       // only a full build re-expands it, and rolldown tells no client that
       // happened, so the reload is sent from here.
-      const { routeRoot, files: knownRoutes, isRouteFile } = virtualEntry.routes
-      const routeAdded = result.changedFiles.some((file) => {
-        if (isRouteFile(file)) return !knownRoutes.has(file)
-        // a directory created under the route root is reported as the directory
-        // itself, and nothing watches inside it until the build that follows
-        // walks it, so the files it arrived with are only found by rebuilding
-        return (
-          file.startsWith(`${routeRoot}/`) &&
-          statSync(file, { throwIfNoEntry: false })?.isDirectory() === true
-        )
-      })
-      if (routeAdded) {
-        await queueEngineWork(async () => {
-          engine.triggerFullBuild()
-          await engine.ensureLatestBuildOutput()
-          await outputProcessed
-        })
-        onHmrUpdate?.({ type: 'hmr:reload' })
-        return
-      }
+      if (await rebuildIfNewRoute(result.changedFiles)) return
 
       for (const { clientId, update } of result.updates) {
         if (update.type === 'Patch' && update.code) {
@@ -813,6 +818,14 @@ try {
 
     async close() {
       await engine.close()
+    },
+
+    // vite's watcher sees a created file even when rolldown's addWatchFile
+    // directory watches do not, which is what happens on github's macos
+    // runners. scoped to route files so a random write in the project is not
+    // a full rebuild.
+    async handleAddedFile(file: string) {
+      await rebuildIfNewRoute([file])
     },
   }
 }
@@ -1066,7 +1079,7 @@ createApp({
           for (const entry of readdirSync(dir, { withFileTypes: true })) {
             const child = resolve(dir, entry.name)
             if (entry.isDirectory()) walkRouteRoot(child)
-            else if (isRouteFile(child)) routes.files.add(child)
+            else if (isRouteFile(child)) routes.files.add(normalizePath(child))
           }
         }
         // a project can have no route root at all: `import.meta.glob` then

--- a/packages/vxrn/types/utils/createNativeDevEngine.d.ts
+++ b/packages/vxrn/types/utils/createNativeDevEngine.d.ts
@@ -49,6 +49,7 @@ interface NativeDevEngineResult {
     getBundle: () => Promise<NativeDevBundle>;
     getAsset: (pathname: string, hash?: string) => NativeDevAsset | undefined;
     close: () => Promise<void>;
+    handleAddedFile: (file: string) => Promise<void>;
 }
 export declare function getNativeTransformConfig(platform: 'ios' | 'android', dev: boolean, root: string): {
     jsx: {


### PR DESCRIPTION
iOS Native Tests (dev, rolldown) has been red since the native-rolldown-readiness merge. Metro and the other three matrix entries passed; this job timed out after HMR tests failed.

- Editing a route file bumped `routeHmrEpoch`, so ScreenComponent re-ran `loadRoute()` and remounted. Fast Refresh had already patched the live component. The hook still evicts the route cache, but it no longer remounts.
- Creating `app/hmr-added.tsx` never became reachable on GitHub's macOS runners because rolldown's `addWatchFile` directory watches do not always fire there. Vite's `add` watcher is the backup, still scoped to route files.

Unit tests: `packages/one` `routeHmr.native.test.ts` (6 passed).